### PR TITLE
Add `geo.azimuth` function to calculate the azimuth between coordinates

### DIFF
--- a/docs/_static/pycontrails.bib
+++ b/docs/_static/pycontrails.bib
@@ -694,6 +694,19 @@
   keywords = {Global aviation emissions,Global aviation fuel burn}
 }
 
+@misc{wikipediacontributorsAzimuth2023,
+  title = {Azimuth},
+  author = {{Wikipedia contributors}},
+  year = {2023},
+  journal = {Wikipedia},
+  urldate = {2023-04-05},
+  abstract = {An azimuth ( (listen); from Arabic: اَلسُّمُوت, romanized: as-sum\=ut, lit.\,'the directions') is an angular measurement in a spherical coordinate system. More specifically, it is the horizontal angle from a cardinal direction, most commonly north.  Mathematically, the relative position vector from an observer (origin) to a point of interest is projected perpendicularly onto a reference plane (the horizontal plane); the angle between the projected vector and a reference vector on the reference plane is called the azimuth. When used as a celestial coordinate, the azimuth is the horizontal direction of a star or other astronomical object in the sky. The star is the point of interest, the reference plane is the local area (e.g. a circular area with a 5 km radius at sea level) around an observer on Earth's surface, and the reference vector points to true north. The azimuth is the angle between the north vector and the star's vector on the horizontal plane.Azimuth is usually measured in degrees (\textdegree ). The concept is used in navigation, astronomy, engineering, mapping, mining, and ballistics.},
+  copyright = {Creative Commons Attribution-ShareAlike License},
+  howpublished = {https://en.wikipedia.org/w/index.php?title=Azimuth\&oldid=1131548993},
+  langid = {english},
+  annotation = {Page Version ID: 1131548993}
+}
+
 @misc{wikipediacontributorsBarometricFormula2023,
   title = {Barometric Formula},
   author = {{Wikipedia contributors}},

--- a/docs/tutorials/CoCiP.ipynb
+++ b/docs/tutorials/CoCiP.ipynb
@@ -228,7 +228,7 @@
    "id": "7dc81306-085c-4099-bc26-6b19adbd73ab",
    "metadata": {},
    "source": [
-    "Process the flight into a format expected by `pycontrails`. See [pycontrails.Flight](https://py.contrails.earth/api/pycontrails.Flight.html#pycontrails.Flight) for interface details."
+    "Process the flight into a format expected by `pycontrails`. See [pycontrails.Flight](https://py.contrails.org/api/pycontrails.Flight.html#pycontrails.Flight) for interface details."
    ]
   },
   {

--- a/pycontrails/physics/geo.py
+++ b/pycontrails/physics/geo.py
@@ -133,6 +133,61 @@ def azimuth_to_direction(
     return sin_a, cos_a
 
 
+def azimuth(
+    lons0: np.ndarray,
+    lats0: np.ndarray,
+    lons1: np.ndarray,
+    lats1: np.ndarray,
+) -> np.ndarray:
+    """Calculate angle relative to true north (*azimuth*) between a sequence of of segments.
+
+    Parameters
+    ----------
+    lons0 : np.ndarray
+        Longitude values of initial endpoints.
+    lats0 : np.ndarray
+        Latitude values of initial endpoints.
+    lons1 : np.ndarray
+        Longitude values of terminal endpoints.
+    lats1 : np.ndarray
+        Latitude values of terminal endpoints.
+
+    Returns
+    -------
+    np.ndarray
+        Azimuth values, relative to true north
+
+    References
+    ----------
+    Source: https://en.wikipedia.org/wiki/Azimuth#In_geodesy
+
+    See Also
+    --------
+    :func:`longitudinal_angle`
+    """
+    # add direction of travel
+    lons0 = units.degrees_to_radians(lons0)
+    lons1 = units.degrees_to_radians(lons1)
+    lats0 = units.degrees_to_radians(lats0)
+    lats1 = units.degrees_to_radians(lats1)
+    d_lon = lons1 - lons0
+
+    num = np.sin(d_lon)
+    denom = np.cos(lats0) * np.tan(lats1) - np.sin(lats0) * np.cos(d_lon)
+    tan_a = num / denom
+
+    # returns outputs on [-pi/2, pi/2] range
+    alpha = units.radians_to_degrees(np.arctan(tan_a))
+
+    # reverse angle when final lon is smaller than initial lon
+    alpha[d_lon < 0] = alpha[d_lon < 0] + 180
+
+    # reset to [0, 360)
+    alpha[alpha < 0] = alpha[alpha < 0] + 360
+
+    return alpha
+
+
 def longitudinal_angle(
     lons0: np.ndarray,
     lats0: np.ndarray,


### PR DESCRIPTION
## Changes

> Description of changes in this PR.
> Use `make changelog` for starter.
> Should be copied and commit to `CHANGELOG.md`

#### Breaking changes

#### Features

- Add `geo.azimuth` and `geo.segment_azimuth` functions to calculate the azimuth between coordinates. The azimuth is the angle between coordinates relative to true north on the range [0, 360].

#### Fixes

#### Internals

- Clean up `geo` module docstrings
- Add Wikipedia reference for [Azimuth](https://en.wikipedia.org/wiki/Azimuth)

## Tests

- [x] QC test passes locally (`make test`)
- [ ] CI tests pass

## Reviewer

> @zebengberg 
