### PR TITLE
Feature/scipy1.10

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -18,23 +18,15 @@ on:
 env:
   PYCONTRAILS_CACHE_DIR: '${{ github.workspace }}/.cache/pycontrails'
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
 # Allow one concurrent deployment
 concurrency:
   group: "pages"
   cancel-in-progress: true
 
+
 jobs:
   build:
     runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
     - name: OS Dependencies
@@ -83,6 +75,21 @@ jobs:
       with:
         path: 'docs/_build/html/'
 
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+
+    steps:
     - name: Deploy to GitHub Pages
       id: deployment
-      uses: actions/deploy-pages@v1
+      uses: actions/deploy-pages@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,9 +45,9 @@ jobs:
         CIBW_ARCHS_MACOS: x86_64 arm64
         # Completely isolate tests to prevent cibuildwheel from importing the
         # source instead of the wheel. This happens when tests/__init__.py is read.
-        # CIBW_BEFORE_TEST: cp -r {project}/tests /tmp/tests
+        CIBW_BEFORE_TEST: mkdir /tmp/isolated && cp -r {project}/tests /tmp/isolated && cp {project}/README.md {project}/.gitignore {project}/pyproject.toml /tmp/isolated && ls -la /tmp/isolated
         CIBW_TEST_EXTRAS: "complete,dev"
-        CIBW_TEST_COMMAND: rm -r {project}/pycontrails && python -m pytest {project}/tests/unit
+        CIBW_TEST_COMMAND: cd /tmp/isolated && python -m pytest tests/unit
 
     - uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,9 +40,10 @@ jobs:
       uses: pypa/cibuildwheel@v2.12.1
       env:
         CIBW_BUILD: cp39-* cp310-* cp311-*
-        CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux*"
+        CIBW_SKIP: '*-win32 *-manylinux_i686 *-musllinux*'
         CIBW_BUILD_VERBOSITY: 3
         CIBW_ARCHS_MACOS: x86_64 arm64
+        CIBW_TEST_SKIP: '*-macosx_arm64 *-win'
         # Completely isolate tests to prevent cibuildwheel from importing the
         # source instead of the wheel. This happens when tests/__init__.py is read.
         CIBW_TEST_EXTRAS: "complete,dev"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,8 +27,9 @@ jobs:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-2019, macos-11]
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
     - uses: actions/checkout@v3
@@ -39,7 +40,12 @@ jobs:
       uses: pypa/cibuildwheel@v2.12.1
       env:
         CIBW_BUILD: cp39-* cp310-* cp311-*
-        CIBW_BUILD_VERBOSITY: 3
+        CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux*"
+        CIBW_BUILD_VERBOSITY: 1
+        CIBW_ARCHS_MACOS: x86_64 arm64
+        CIBW_TEST_SKIP: "*-macosx_arm64"
+        CIBW_TEST_REQUIRES: pytest
+        CIBW_TEST_COMMAND: pytest {project}/tests/unit
 
     - uses: actions/upload-artifact@v3
       with:
@@ -53,15 +59,8 @@ jobs:
       with:
         fetch-depth: 0
 
-    - uses: actions/setup-python@v4
-      with:
-        python-version: '3.11'
-
-    - name: Install build
-      run: python -m pip install build
-
     - name: Build sdist
-      run: python -m build --sdist
+      run: pipx run build --sdist
 
     - uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,7 +56,6 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: '3.11'
-        cache: 'pip'
 
     - name: Install build
       run: python -m pip install build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,8 +43,11 @@ jobs:
         CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux*"
         CIBW_BUILD_VERBOSITY: 3
         CIBW_ARCHS_MACOS: x86_64 arm64
+        # Completely isolate tests to prevent cibuildwheel from importing the
+        # source instead of the wheel. This happens when tests/__init__.py is read.
+        CIBW_BEFORE_TEST: cp -r {project}/tests /tmp/tests
         CIBW_TEST_REQUIRES: pytest
-        CIBW_TEST_COMMAND: python -m pytest {project}/tests/unit
+        CIBW_TEST_COMMAND: python -m pytest /tmp/tests/unit
 
     - uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,9 +45,9 @@ jobs:
         CIBW_ARCHS_MACOS: x86_64 arm64
         # Completely isolate tests to prevent cibuildwheel from importing the
         # source instead of the wheel. This happens when tests/__init__.py is read.
-        CIBW_BEFORE_TEST: cp -r {project}/tests /tmp/tests
+        # CIBW_BEFORE_TEST: cp -r {project}/tests /tmp/tests
         CIBW_TEST_EXTRAS: "complete,dev"
-        CIBW_TEST_COMMAND: python -m pytest /tmp/tests/unit
+        CIBW_TEST_COMMAND: rm -r {project}/pycontrails && python -m pytest {project}/tests/unit
 
     - uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,6 +36,7 @@ jobs:
       with:
         fetch-depth: 0
 
+    # https://cibuildwheel.readthedocs.io/en/stable/options/#testing
     - name: Build wheels
       uses: pypa/cibuildwheel@v2.12.1
       env:
@@ -43,7 +44,7 @@ jobs:
         CIBW_SKIP: '*-win32 *-manylinux_i686 *-musllinux*'
         CIBW_BUILD_VERBOSITY: 3
         CIBW_ARCHS_MACOS: x86_64 arm64
-        CIBW_TEST_SKIP: '*-macosx_arm64 *-win'
+        CIBW_TEST_SKIP: '*-macosx_arm64 *-win_amd64'
         # Completely isolate tests to prevent cibuildwheel from importing the
         # source instead of the wheel. This happens when tests/__init__.py is read.
         CIBW_TEST_EXTRAS: "complete,dev"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,11 +41,12 @@ jobs:
       env:
         CIBW_BUILD: cp39-* cp310-* cp311-*
         CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux*"
-        CIBW_BUILD_VERBOSITY: 1
+        CIBW_BUILD_VERBOSITY: 3
         CIBW_ARCHS_MACOS: x86_64 arm64
         CIBW_TEST_SKIP: "*-macosx_arm64"
         CIBW_TEST_REQUIRES: pytest
-        CIBW_TEST_COMMAND: pytest {project}/tests/unit
+        CIBW_TEST_COMMAND: pytest {package}/tests/unit
+        CIBW_BEFORE_TEST: ls -l {project} && ls -l {package}
 
     - uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -92,7 +92,7 @@ jobs:
 
     - name: Publish distribution 📦 to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
-      if: ${{ github.ref == 'refs/heads/main' && github.event_name == 'release' }
+      if: ${{ github.ref == 'refs/heads/main' && github.event_name == 'release' }}
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,9 +45,11 @@ jobs:
         CIBW_ARCHS_MACOS: x86_64 arm64
         # Completely isolate tests to prevent cibuildwheel from importing the
         # source instead of the wheel. This happens when tests/__init__.py is read.
-        CIBW_BEFORE_TEST: mkdir /tmp/isolated && cp -r {project}/tests /tmp/isolated && cp {project}/README.md {project}/.gitignore {project}/pyproject.toml /tmp/isolated && ls -la /tmp/isolated
         CIBW_TEST_EXTRAS: "complete,dev"
-        CIBW_TEST_COMMAND: cd /tmp/isolated && python -m pytest tests/unit
+        CIBW_TEST_COMMAND: >
+          mv {project}/pycontrails {project}/pycontrails-bak &&
+          python -m pytest {project}/tests &&
+          mv {project}/pycontrails-bak {project}/pycontrails
 
     - uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,7 +44,7 @@ jobs:
         CIBW_SKIP: '*-win32 *-manylinux_i686 *-musllinux*'
         CIBW_BUILD_VERBOSITY: 3
         CIBW_ARCHS_MACOS: x86_64 arm64
-        CIBW_TEST_SKIP: '*-macosx_arm64 *-win_amd64'
+        CIBW_TEST_SKIP: '*-macosx_arm64'
         # Completely isolate tests to prevent cibuildwheel from importing the
         # source instead of the wheel. This happens when tests/__init__.py is read.
         CIBW_TEST_EXTRAS: "complete,dev"
@@ -72,8 +72,8 @@ jobs:
       with:
         path: dist/*.tar.gz
 
-  upload_pypi:
-    needs: [build_wheels, build_sdist, check-main-test-status]
+  upload_pypi_test:
+    needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/download-artifact@v3
@@ -89,6 +89,15 @@ jobs:
         repository-url: https://test.pypi.org/legacy/
         verbose: true
         verify-metadata: true
+
+  upload_pypi:
+    needs: [build_wheels, build_sdist, check-main-test-status]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: artifact
+        path: dist
 
     - name: Publish distribution 📦 to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,10 +43,8 @@ jobs:
         CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux*"
         CIBW_BUILD_VERBOSITY: 3
         CIBW_ARCHS_MACOS: x86_64 arm64
-        CIBW_TEST_SKIP: "*-macosx_arm64"
         CIBW_TEST_REQUIRES: pytest
-        CIBW_TEST_COMMAND: pytest {package}/tests/unit
-        CIBW_BEFORE_TEST: ls -l {project} && ls -l {package}
+        CIBW_TEST_COMMAND: python -m pytest {project}/tests/unit
 
     - uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,4 @@
-# Heavily copied from xarray
-# https://github.com/pydata/xarray/blob/main/.github/workflows/testpypi-release.yaml
+# https://github.com/pypa/cibuildwheel/blob/main/examples/github-deploy.yml
 
 name: Release
 
@@ -20,80 +19,51 @@ jobs:
       run: sudo apt-get install -y curl jq
 
     - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
 
     - name: Check main test status
       run: make main-test-status
 
-  build-dist:
-    needs: check-main-test-status
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-
-    - uses: actions/setup-python@v4
-      with:
-        python-version: '3.11'
-
-    - name: Install dependencies
-      run: |
-        pip install --upgrade pip
-        pip install build twine
-
-    - name: Build a binary wheel and a source tarball
-      run: python -m build
-
-    - name: Check the distribution
-      run: twine check --strict dist/*
-
-    - name: Upload the distribution
-      uses: actions/upload-artifact@v3
-      with:
-        name: dist
-        path: dist
-
-  test-dist:
-    needs: build-dist
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest]
-        pyversion: ['3.9', '3.10', '3.11']
-
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, windows-2019, macos-11]
 
     steps:
-    - uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.pyversion }}
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
-    - name: Download the distribution
-      uses: actions/download-artifact@v3
-      with:
-        name: dist
-        path: dist
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.12.1
 
-    - name: List the contents of the distribution
-      run: ls -lh dist
+      - uses: actions/upload-artifact@v3
+        with:
+          path: ./wheelhouse/*.whl
 
-    - name: Install the wheel
-      run: |
-        pip install --upgrade pip
-        pip install dist/pycontrails*.whl
-        python -c "import pycontrails; print(pycontrails.__version__)"
-
-  publish-dist:
-    needs: test-dist
+  build_sdist:
+    name: Build source distribution
     runs-on: ubuntu-latest
-
     steps:
-    - name: Download the distribution
-      uses: actions/download-artifact@v3
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Build sdist
+        run: python -m build --sdist
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: dist/*.tar.gz
+
+  upload_pypi:
+    needs: [build_wheels, build_sdist, check-main-test-status]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/download-artifact@v3
       with:
-        name: dist
+        name: artifact
         path: dist
 
     - name: Publish distribution 📦 to Test PyPI

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,7 +46,7 @@ jobs:
         # Completely isolate tests to prevent cibuildwheel from importing the
         # source instead of the wheel. This happens when tests/__init__.py is read.
         CIBW_BEFORE_TEST: cp -r {project}/tests /tmp/tests
-        CIBW_TEST_REQUIRES: pytest
+        CIBW_TEST_EXTRAS: "complete,dev"
         CIBW_TEST_COMMAND: python -m pytest /tmp/tests/unit
 
     - uses: actions/upload-artifact@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,34 +28,45 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-11]
+        os: [ubuntu-latest, windows-2019, macos-11]
 
     steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
 
-      - name: Build wheels
-        uses: pypa/cibuildwheel@v2.12.1
+    - name: Build wheels
+      uses: pypa/cibuildwheel@v2.12.1
+      env:
+        CIBW_BUILD: cp39-* cp310-* cp311-*
+        CIBW_BUILD_VERBOSITY: 3
 
-      - uses: actions/upload-artifact@v3
-        with:
-          path: ./wheelhouse/*.whl
+    - uses: actions/upload-artifact@v3
+      with:
+        path: ./wheelhouse/*.whl
 
   build_sdist:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
 
-      - name: Build sdist
-        run: python -m build --sdist
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+        cache: 'pip'
 
-      - uses: actions/upload-artifact@v3
-        with:
-          path: dist/*.tar.gz
+    - name: Install build
+      run: python -m pip install build
+
+    - name: Build sdist
+      run: python -m build --sdist
+
+    - uses: actions/upload-artifact@v3
+      with:
+        path: dist/*.tar.gz
 
   upload_pypi:
     needs: [build_wheels, build_sdist, check-main-test-status]
@@ -73,6 +84,7 @@ jobs:
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}
         repository-url: https://test.pypi.org/legacy/
         verbose: true
+        verify-metadata: true
 
     - name: Publish distribution 📦 to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
@@ -81,3 +93,4 @@ jobs:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}
         verbose: true
+        verify-metadata: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -95,9 +95,7 @@ jobs:
         mkdir -p ~/.ssh/ && ssh-keyscan github.com > ~/.ssh/known_hosts
         gcloud secrets versions access latest --secret="contrails-301217-github-ssh-key" > ~/.ssh/id_rsa
         chmod 600 ~/.ssh/id_rsa
-        if [ "${{ matrix.os }}" == "windows-latest" ]; then
-          echo "GIT_SSH_COMMAND=ssh -v -i ~/.ssh/id_rsa" >> $GITHUB_ENV
-        fi
+        export GIT_SSH_COMMAND="ssh -v -i ~/.ssh/id_rsa"
         pip install "pycontrails-bada @ git+ssh://git@github.com/contrailcirrus/pycontrails-bada.git" --verbose
 
     - name: Show environment

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -89,26 +89,22 @@ jobs:
         pip install -U pip wheel
         pip install -e .[dev,docs,ecmwf,gcp,gfs,jupyter,vis,zarr] --verbose
 
-    - name: Install pycontrails-bada extension - windows
+    - name: Install pycontrails-bada - windows
       if: ${{ matrix.os == 'windows-latest' }}
       run: |
-        $PSDefaultParameterValues['Out-File:Encoding'] = 'utf8'
-        mkdir -p ~/.ssh/
-        ssh-keyscan github.com > ~/.ssh/known_hosts
-        gcloud secrets versions access latest --secret="contrails-301217-github-ssh-key" > ~/.ssh/id_rsa
-        chmod 600 ~/.ssh/id_rsa
-        ls -l ~/.ssh
-        pip install "pycontrails-bada @ git+ssh://git@github.com/contrailcirrus/pycontrails-bada.git" --verbose
+        mkdir -p $HOME/.ssh/
+        gcloud secrets versions access latest --secret="contrails-301217-github-ssh-key" --out-file="$HOME/.ssh/id_rsa"
+        pip install "pycontrails-bada @ git+ssh://git@github.com/contrailcirrus/pycontrails-bada.git"
       env:
-        GIT_SSH_COMMAND: "ssh -v"
+        GIT_SSH_COMMAND: "ssh -v -o StrictHostKeyChecking=no"
 
-    - name: Install pycontrails-bada extension - linux
+    - name: Install pycontrails-bada - linux
       if: ${{ matrix.os == 'ubuntu-latest' }}
       run: |
-        mkdir -p ~/.ssh/
-        ssh-keyscan github.com > ~/.ssh/known_hosts
-        gcloud secrets versions access latest --secret="contrails-301217-github-ssh-key" > ~/.ssh/id_rsa
-        chmod 600 ~/.ssh/id_rsa
+        mkdir -p $HOME/.ssh/
+        ssh-keyscan github.com > $HOME/.ssh/known_hosts
+        gcloud secrets versions access latest --secret="contrails-301217-github-ssh-key" > $HOME/.ssh/id_rsa
+        chmod 600 $HOME/.ssh/id_rsa
         pip install "pycontrails-bada @ git+ssh://git@github.com/contrailcirrus/pycontrails-bada.git"
 
     - name: Show environment

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -82,7 +82,7 @@ jobs:
         mkdir -p ${{ env.BADA_CACHE_DIR }}
         gcloud storage cp -r gs://contrails-301217-bada/bada/bada3 ${{ env.BADA_CACHE_DIR }}
         gcloud storage cp -r gs://contrails-301217-bada/bada/bada4 ${{ env.BADA_CACHE_DIR }}
-        ls -la ${{ env.BADA_CACHE_DIR }}
+        ls -l ${{ env.BADA_CACHE_DIR }}
 
     - name: Install pycontrails (dev)
       run: make dev-install

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -89,11 +89,10 @@ jobs:
         pip install -U pip wheel
         pip install -e .[dev,docs,ecmwf,gcp,gfs,jupyter,vis,zarr] --verbose
 
-    - name: Install pycontrails-bada extension
+    - name: Install pycontrails-bada extension - windows
+      if: ${{ matrix.os == 'windows-latest' }}
       run: |
-        if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
-          $PSDefaultParameterValues['Out-File:Encoding'] = 'utf8'
-        fi
+        $PSDefaultParameterValues['Out-File:Encoding'] = 'utf8'
         mkdir -p ~/.ssh/
         ssh-keyscan github.com > ~/.ssh/known_hosts
         gcloud secrets versions access latest --secret="contrails-301217-github-ssh-key" > ~/.ssh/id_rsa
@@ -102,6 +101,15 @@ jobs:
         pip install "pycontrails-bada @ git+ssh://git@github.com/contrailcirrus/pycontrails-bada.git" --verbose
       env:
         GIT_SSH_COMMAND: "ssh -v"
+
+    - name: Install pycontrails-bada extension - linux
+      if: ${{ matrix.os == 'ubuntu-latest' }}
+      run: |
+        mkdir -p ~/.ssh/
+        ssh-keyscan github.com > ~/.ssh/known_hosts
+        gcloud secrets versions access latest --secret="contrails-301217-github-ssh-key" > ~/.ssh/id_rsa
+        chmod 600 ~/.ssh/id_rsa
+        pip install "pycontrails-bada @ git+ssh://git@github.com/contrailcirrus/pycontrails-bada.git"
 
     - name: Show environment
       run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]  # add 'windows-latest'
         pyversion: ['3.9', '3.10', '3.11']
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -90,13 +90,13 @@ jobs:
         pip install -e .[dev,docs,ecmwf,gcp,gfs,jupyter,vis,zarr] --verbose
 
     - name: Install pycontrails-bada extension
-      # if: ${{ matrix.os == 'ubuntu-latest' }}
       run: |
         mkdir -p ~/.ssh/ && ssh-keyscan github.com > ~/.ssh/known_hosts
         gcloud secrets versions access latest --secret="contrails-301217-github-ssh-key" > ~/.ssh/id_rsa
         chmod 600 ~/.ssh/id_rsa
-        export GIT_SSH_COMMAND="ssh -v -i ~/.ssh/id_rsa"
         pip install "pycontrails-bada @ git+ssh://git@github.com/contrailcirrus/pycontrails-bada.git" --verbose
+      env:
+        GIT_SSH_COMMAND: "ssh -v -i ~/.ssh/id_rsa"
 
     - name: Show environment
       run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -90,17 +90,18 @@ jobs:
         pip install -e .[dev,docs,ecmwf,gcp,gfs,jupyter,vis,zarr] --verbose
 
     - name: Install pycontrails-bada extension
-      if: ${{ matrix.os == 'ubuntu-latest' }}
+      # if: ${{ matrix.os == 'ubuntu-latest' }}
       run: |
         mkdir -p ~/.ssh/ && ssh-keyscan github.com > ~/.ssh/known_hosts
         gcloud secrets versions access latest --secret="contrails-301217-github-ssh-key" > ~/.ssh/id_rsa
         chmod 600 ~/.ssh/id_rsa
-        pip install "pycontrails-bada @ git+ssh://git@github.com/contrailcirrus/pycontrails-bada.git"
+        ssh -T git@github.com
+        pip install "pycontrails-bada @ git+ssh://git@github.com/contrailcirrus/pycontrails-bada.git" --verbose
 
     - name: Show environment
       run: |
         pwd
-        ls -l
+        ls -l .
         python --version
         mypy --version
         python -m pip list

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -95,7 +95,9 @@ jobs:
         mkdir -p ~/.ssh/ && ssh-keyscan github.com > ~/.ssh/known_hosts
         gcloud secrets versions access latest --secret="contrails-301217-github-ssh-key" > ~/.ssh/id_rsa
         chmod 600 ~/.ssh/id_rsa
-        ssh -T git@github.com
+        if [ "${{ matrix.os }}" == "windows-latest" ]; then
+          echo "GIT_SSH_COMMAND=ssh -v -i ~/.ssh/id_rsa" >> $GITHUB_ENV
+        fi
         pip install "pycontrails-bada @ git+ssh://git@github.com/contrailcirrus/pycontrails-bada.git" --verbose
 
     - name: Show environment

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,9 +37,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]  # add 'windows-latest'
+        os: [ubuntu-latest, windows-latest]
         pyversion: ['3.9', '3.10', '3.11']
     runs-on: ${{ matrix.os }}
+
+    defaults:
+      run:
+        shell: bash
 
     # set from https://github.com/google-github-actions/auth
     permissions:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -85,7 +85,9 @@ jobs:
         ls -l ${{ env.BADA_CACHE_DIR }}
 
     - name: Install pycontrails (dev)
-      run: make dev-install
+      run: |
+        pip install -U pip wheel
+        pip install .[dev,docs,ecmwf,gcp,gfs,jupyter,vis,zarr] --verbose
 
     - name: Install pycontrails-bada extension
       run: |
@@ -97,19 +99,16 @@ jobs:
     - name: Show environment
       run: |
         pwd
-        ls -la
-        which python
+        ls -l
         python --version
-        which mypy
         mypy --version
         python -m pip list
         python -m pip check
 
     - name: QC & Test
       run: |
-        make ruff
-        make mypy
-        make black-check
-        make pydocstyle
-        make pytest
-
+        black pycontrails --check
+        ruff pycontrails tests
+        mypy pycontrails
+        pydocstyle pycontrails --verbose
+        pytest tests/unit

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -89,6 +89,9 @@ jobs:
         pip install -U pip wheel
         pip install -e .[dev,docs,ecmwf,gcp,gfs,jupyter,vis,zarr] --verbose
 
+    # In latest-windows, redirecting stdout to a file uses utf-16 encoding
+    # This gives an error when ssh tries to read the key
+    # Instead don't pre-create the known_hosts file
     - name: Install pycontrails-bada - windows
       if: ${{ matrix.os == 'windows-latest' }}
       run: |
@@ -96,7 +99,7 @@ jobs:
         gcloud secrets versions access latest --secret="contrails-301217-github-ssh-key" --out-file="$HOME/.ssh/id_rsa"
         pip install "pycontrails-bada @ git+ssh://git@github.com/contrailcirrus/pycontrails-bada.git"
       env:
-        GIT_SSH_COMMAND: "ssh -v -o StrictHostKeyChecking=no"
+        GIT_SSH_COMMAND: "ssh -o StrictHostKeyChecking=no"
 
     - name: Install pycontrails-bada - linux
       if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -91,24 +91,30 @@ jobs:
 
     - name: Install pycontrails-bada extension
       run: |
-        mkdir -p ~/.ssh/ && ssh-keyscan github.com > ~/.ssh/known_hosts
+        if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
+          $PSDefaultParameterValues['Out-File:Encoding'] = 'utf8'
+        fi
+        mkdir -p ~/.ssh/
+        ssh-keyscan github.com > ~/.ssh/known_hosts
         gcloud secrets versions access latest --secret="contrails-301217-github-ssh-key" > ~/.ssh/id_rsa
         chmod 600 ~/.ssh/id_rsa
+        ls -l ~/.ssh
         pip install "pycontrails-bada @ git+ssh://git@github.com/contrailcirrus/pycontrails-bada.git" --verbose
       env:
-        GIT_SSH_COMMAND: "ssh -v -i ~/.ssh/id_rsa"
+        GIT_SSH_COMMAND: "ssh -v"
 
     - name: Show environment
       run: |
         pwd
         ls -l .
+        ls -l pycontrails
         python --version
         mypy --version
-        python -m pip list
-        python -m pip check
+        pip list
 
     - name: QC & Test
       run: |
+        pip check
         black pycontrails --check
         ruff pycontrails tests
         mypy pycontrails

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]  # add 'windows-latest'
+        os: [ubuntu-latest, windows-latest]
         pyversion: ['3.9', '3.10', '3.11']
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,10 +41,6 @@ jobs:
         pyversion: ['3.9', '3.10', '3.11']
     runs-on: ${{ matrix.os }}
 
-    defaults:
-      run:
-        shell: bash
-
     # set from https://github.com/google-github-actions/auth
     permissions:
       contents: 'read'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -87,9 +87,10 @@ jobs:
     - name: Install pycontrails (dev)
       run: |
         pip install -U pip wheel
-        pip install .[dev,docs,ecmwf,gcp,gfs,jupyter,vis,zarr] --verbose
+        pip install -e .[dev,docs,ecmwf,gcp,gfs,jupyter,vis,zarr] --verbose
 
     - name: Install pycontrails-bada extension
+      if: ${{ matrix.os == 'ubuntu-latest' }}
       run: |
         mkdir -p ~/.ssh/ && ssh-keyscan github.com > ~/.ssh/known_hosts
         gcloud secrets versions access latest --secret="contrails-301217-github-ssh-key" > ~/.ssh/id_rsa

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ venv
 _version.py
 rgi_cython.c
 rgi_cython*.so
+rgi_cython*.pyd
 
 # test
 .mypy_cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,19 @@
 
 # Changelog
 
-## v0.40.0 (unreleased)
+## v0.40.0
 
-Support scipy 1.10 and improve interpolation performance.
+Support scipy 1.10, improve interpolation performance, and fix many windows issues.
 
 #### Features
 
 - Improve interpolation performance by cythonizing linear interpolation. This extends the approach taken in [scipy 1.10](https://github.com/scipy/scipy/pull/17291). The pycontrails [cython routines](pycontrails/core/rgi_cython.pyx) allow for both float64 and float32 grids via cython fused types (the current scipy implementation assumes float64). In addition, interpolation up to dimension 4 is supported (the scipy implementation supports dimension 1 and 2).
 - Officially support [scipy 1.10](https://scipy.github.io/devdocs/release/1.10.0-notes.html).
+- Officially test on windows in the GitHub Actions CI.
+- Build custom wheels for python 3.9, 3.10, and 3.11 for the following platforms:
+  - Linux (x86_64)
+  - macOS (arm64 and x86_64)
+  - Windows (x86_64)
 
 #### Breaking changes
 
@@ -18,12 +23,16 @@ Support scipy 1.10 and improve interpolation performance.
 #### Fixes
 
 - Unit tests no longer raise errors when the `pycontrails-bada` package is not installed. Instead, some tests are skipped.
+- Fix many numpy casting issues encountered on windows.
+- Fix temp file issues encountered on windows.
+- Officially support changes in `xarray` 2023.04 and `pandas` 2.0.
 
 #### Internals
 
 - Make the `interpolation` module more aligned with [scipy 1.10 enhancements](https://docs.scipy.org/doc/scipy/release.1.10.0.html#scipy-interpolate-improvements) to the `RegularGridInterpolator`. In particular, grid coordinates now must be float64.
 - Use [cibuildwheel](https://cibuildwheel.readthedocs.io/en/stable/) to build wheels for Linux, macOS (arm64 and x86_64), and Windows on [release](.github/workflows/release.yaml) in Github Actions. Allow this workflow to be triggered manually to test the release process without actually publishing to PyPI.
 - Simplify interpolation with pre-computed indices (invoked with the model parameter `interpolation_use_indices`) via a `RGIArtifacts` interface.
+- Overhaul much of the interpolation module to improve performance.
 - Slight performance enhancements to the `met` module.
 
 ## v0.39.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,36 @@
 
 # Changelog
 
+## v0.40.0 (unreleased)
+
+Support scipy 1.10 and improve interpolation performance.
+
+#### Features
+
+- Improve interpolation performance by cythonizing linear interpolation. This extends the approach taken in [scipy 1.10](https://github.com/scipy/scipy/pull/17291). The pycontrails [cython routines](pycontrails/core/rgi_cython.pyx) allow for both float64 and float32 grids via cython fused types (the current scipy implementation assumes float64). In addition, interpolation up to dimension 4 is supported (the scipy implementation supports dimension 1 and 2).
+- Officially support [scipy 1.10](https://scipy.github.io/devdocs/release/1.10.0-notes.html).
+
+#### Breaking changes
+
+- Change `MetDataset` and `MetDataArray` conventions: underlying dimension coordinates are automatically promoted to float64.
+- Change how datetime arrays are converted to floating values for interpolation. The new approach introduces small differences compared with the previous implementation. These differences are significant enough to see relative differences in CoCiP predictions on the order of 1e-4.
+
+#### Fixes
+
+- Unit tests no longer raise errors when the `pycontrails-bada` package is not installed. Instead, some tests are skipped.
+
+#### Internals
+
+- Make the `interpolation` module more aligned with [scipy 1.10 enhancements](https://docs.scipy.org/doc/scipy/release.1.10.0.html#scipy-interpolate-improvements) to the `RegularGridInterpolator`. In particular, grid coordinates now must be float64.
+- Use [cibuildwheel](https://cibuildwheel.readthedocs.io/en/stable/) to build wheels for Linux, macOS (arm64 and x86_64), and Windows on [release](.github/workflows/release.yaml) in Github Actions. Allow this workflow to be triggered manually to test the release process without actually publishing to PyPI.
+- Simplify interpolation with pre-computed indices (invoked with the model parameter `interpolation_use_indices`) via a `RGIArtifacts` interface.
+- Slight performance enhancements to the `met` module.
+
 ## v0.39.6
 
 #### Features
 
-- Add `geo.azimuth` and `geo.segment_azimuth` functions to calculate the azimuth
-  between coordinates.
-  Azimuth is the angle between coordinates relative to true north on the range [0, 360].
+- Add `geo.azimuth` and `geo.segment_azimuth` functions to calculate the azimuth between coordinates. Azimuth is the angle between coordinates relative to true north on the interval `[0, 360)`.
 
 #### Fixes
 

--- a/Makefile
+++ b/Makefile
@@ -172,6 +172,7 @@ nb-execute: nb-black-check
 nb-check-links:
 	python -m pytest --check-links \
 		--check-links-ignore "https://doi.org/10.1021/acs.est.9b05608" \
+		--check-links-ignore "https://pubs.acs.org/doi/10.1021/acs.est.2c05781" \
 		--check-links-ignore "https://github.com/contrailcirrus/pycontrails-bada" \
 		docs/examples docs/tutorials
 

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ pytest:
 	pytest tests/unit
 
 pydocstyle:
-	pydocstyle pycontrails --match='[^_deprecated].*.py' --verbose
+	pydocstyle pycontrails --verbose
 
 pytest-cov:
 	pytest \

--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,7 @@ nb-execute: nb-black-check
 nb-check-links:
 	python -m pytest --check-links \
 		--check-links-ignore "https://doi.org/10.1021/acs.est.9b05608" \
-		--check-links-ignore "https://pubs.acs.org/doi/10.1021/acs.est.2c05781" \
+		--check-links-ignore "https://doi.org/10.1021/acs.est.2c05781" \
 		--check-links-ignore "https://github.com/contrailcirrus/pycontrails-bada" \
 		docs/examples docs/tutorials
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -56,6 +56,18 @@ See ``[project.optional-dependencies]`` in `pyproject.toml <https://github.com/c
 for the latest optional dependencies.
 
 
+Pre-built wheels
+-----------------
+
+Wheels for common platforms are available on `PyPI <https://pypi.org/project/pycontrails/>`__. Currently, wheels are available for:
+
+- Linux (x86_64)
+- macOS (x86_64 and arm64)
+- Windows (x86_64)
+
+It's possible to build the wheels from source using `Cython <https://cython.org/>`__ and a C compiler with the usual ``pip install`` process. The source distribution on PyPI includes the C files, so it's not necessary to have Cython installed to build from source.
+
+
 Extensions
 ----------
 

--- a/pycontrails/core/flight.py
+++ b/pycontrails/core/flight.py
@@ -1088,8 +1088,8 @@ class Flight(GeoVectorDataset):
         >>> # Intersect and attach
         >>> fl["air_temperature"] = fl.intersect_met(met['air_temperature'])
         >>> fl["air_temperature"]
-        array([235.94657215, 235.55773934, 235.56765885, ..., 234.59956144,
-               234.60406387, 234.60845904])
+        array([235.94658, 235.55774, 235.56766, ..., 234.59956, 234.60406,
+               234.60846], dtype=float32)
 
         >>> # Length (in meters) of waypoints whose temperature exceeds 236K
         >>> fl.length_met("air_temperature", threshold=236)

--- a/pycontrails/core/interpolation.py
+++ b/pycontrails/core/interpolation.py
@@ -93,7 +93,8 @@ class PycontrailsRegularGridInterpolator(scipy.interpolate.RegularGridInterpolat
             A 1-dimensional Boolean array indicating which points are out of bounds.
             If ``bounds_error`` is ``True``, this will be ``None``, indicating that
             no points are out of bounds. (This is the same convention as
-            :meth:`scipy.interpolate.RegularGridInterpolator._prepare_xi`)
+            :meth:`scipy.interpolate.RegularGridInterpolator._prepare_xi`). If
+            every point is in bounds, this is set to ``None``.
         """
         nans = np.any(np.isnan(xi), axis=1)
         if not np.any(nans):
@@ -109,6 +110,8 @@ class PycontrailsRegularGridInterpolator(scipy.interpolate.RegularGridInterpolat
             return nans, None
 
         out_of_bounds = self._find_out_of_bounds(xi.T)
+        if not np.any(out_of_bounds):
+            out_of_bounds = None
         return nans, out_of_bounds
 
     def __call__(

--- a/pycontrails/core/met.py
+++ b/pycontrails/core/met.py
@@ -1229,7 +1229,7 @@ class MetDataArray(MetBase):
     ...     "longitude": np.arange(-20, 20),
     ...     "latitude": np.arange(-30, 30),
     ...     "level": [220, 240, 260, 280],
-    ...     "time": [np.datetime64("2021-08-01T12"), np.datetime64("2021-08-01T16")]
+    ...     "time": [np.datetime64("2021-08-01T12", "ns"), np.datetime64("2021-08-01T16", "ns")]
     ...     }
     >>> da = xr.DataArray(rng.random((40, 60, 4, 2)), dims=coords.keys(), coords=coords)
 

--- a/pycontrails/core/rgi_cython.pyx
+++ b/pycontrails/core/rgi_cython.pyx
@@ -11,15 +11,15 @@ scipy 1.10 in several ways:
 """
 
 import numpy as np
-cimport numpy as np
-cimport cython
 
+cimport cython
+cimport numpy as np
 
 np.import_array()
 
 
 # See https://cython.readthedocs.io/en/latest/src/userguide/fusedtypes.html
-ctypedef fused floating_values:
+ctypedef fused floating:
     float
     double
 
@@ -29,10 +29,10 @@ ctypedef fused floating_values:
 @cython.initializedcheck(False)
 @cython.nonecheck(False)
 def evaluate_linear_4d(
-    const floating_values[:, :, :, :] values,
+    const floating[:, :, :, :] values,
     const long[:, :] indices,
     const double[:, :] norm_distances,
-    floating_values[:] out,
+    floating[:] out,
 ) -> np.ndarray:
     cdef:
         long n_points = indices.shape[1]
@@ -78,10 +78,10 @@ def evaluate_linear_4d(
 @cython.initializedcheck(False)
 @cython.nonecheck(False)
 def evaluate_linear_3d(
-    const floating_values[:, :, :] values,
+    const floating[:, :, :] values,
     const long[:, :] indices,
     const double[:, :] norm_distances,
-    floating_values[:] out,
+    floating[:] out,
 ) -> np.ndarray:
     cdef:
         long n_points = indices.shape[1]
@@ -116,10 +116,10 @@ def evaluate_linear_3d(
 @cython.initializedcheck(False)
 @cython.nonecheck(False)
 def evaluate_linear_2d(
-    const floating_values[:, :] values,
+    const floating[:, :] values,
     const long[:, :] indices,
     const double[:, :] norm_distances,
-    floating_values[:] out,
+    floating[:] out,
 ) -> np.ndarray:
     cdef:
         long n_points = indices.shape[1]
@@ -149,10 +149,10 @@ def evaluate_linear_2d(
 @cython.initializedcheck(False)
 @cython.nonecheck(False)
 def evaluate_linear_1d(
-    const floating_values[:] values,
+    const floating[:] values,
     const long[:] indices,
     const double[:] norm_distances,
-    floating_values[:] out,
+    floating[:] out,
 ) -> np.ndarray:
     cdef:
         long n_points = indices.shape[0]

--- a/pycontrails/core/rgi_cython.pyx
+++ b/pycontrails/core/rgi_cython.pyx
@@ -10,6 +10,7 @@ scipy 1.10 in several ways:
   implementation is only for double arrays.
 """
 
+from libc.math cimport NAN
 import numpy as np
 
 cimport cython
@@ -44,6 +45,10 @@ def evaluate_linear_4d(
         i1 = indices[1, p]
         i2 = indices[2, p]
         i3 = indices[3, p]
+
+        if i0 < 0 or i1 < 0 or i2 < 0 or i3 < 0:
+            out[p] = NAN
+            continue
 
         y0 = norm_distances[0, p]
         y1 = norm_distances[1, p]
@@ -93,6 +98,10 @@ def evaluate_linear_3d(
         i1 = indices[1, p]
         i2 = indices[2, p]
 
+        if i0 < 0 or i1 < 0 or i2 < 0:
+            out[p] = NAN
+            continue
+
         y0 = norm_distances[0, p]
         y1 = norm_distances[1, p]
         y2 = norm_distances[2, p]
@@ -130,6 +139,10 @@ def evaluate_linear_2d(
         i0 = indices[0, p]
         i1 = indices[1, p]
 
+        if i0 < 0 or i1 < 0:
+            out[p] = NAN
+            continue
+
         y0 = norm_distances[0, p]
         y1 = norm_distances[1, p]
 
@@ -161,6 +174,10 @@ def evaluate_linear_1d(
 
     for p in range(n_points):
         i0 = indices[p]
+        if i0 < 0:
+            out[p] = NAN
+            continue
+
         y0 = norm_distances[p]
         out[p] = values[i0] * (1 - y0) + values[i0+1] * y0
 

--- a/pycontrails/core/vector.py
+++ b/pycontrails/core/vector.py
@@ -1583,8 +1583,8 @@ class GeoVectorDataset(VectorDataset):
         except KeyError:
             return None
 
-        indices = np.stack([indices_x, indices_y, indices_z, indices_t], axis=1)
-        distances = np.stack([distances_x, distances_y, distances_z, distances_t], axis=1)
+        indices = np.asarray([indices_x, indices_y, indices_z, indices_t])
+        distances = np.asarray([distances_x, distances_y, distances_z, distances_t])
 
         out_of_bounds = self.get("_out_of_bounds", None)
         nans = self.get("_nans", None)

--- a/pycontrails/core/vector.py
+++ b/pycontrails/core/vector.py
@@ -1469,9 +1469,8 @@ class GeoVectorDataset(VectorDataset):
                231.65126, 231.93065, 232.03345, 231.65955], dtype=float32)
 
         >>> fl.intersect_met(met['air_temperature'], method='linear')
-        array([225.77794546, 225.1390854 , 226.23122163, 226.31832011,
-               225.56102452, 225.81192332, 226.03193091, 226.220562  ,
-               226.03770453, 225.63226519])
+        array([225.77794, 225.13908, 226.23122, 226.31831, 225.56102, 225.81192,
+               226.03194, 226.22057, 226.0377 , 225.63226], dtype=float32)
 
         >>> # Interpolate and attach to `Flight` instance
         >>> for key in met:
@@ -1479,18 +1478,18 @@ class GeoVectorDataset(VectorDataset):
 
         >>> # Show the final three columns of the dataframe
         >>> fl.dataframe.iloc[:, -3:].head()
-            time  air_temperature  specific_humidity
-        0 2022-03-01 00:00:00       225.777945           0.000132
-        1 2022-03-01 00:13:20       225.139085           0.000132
-        2 2022-03-01 00:26:40       226.231222           0.000107
-        3 2022-03-01 00:40:00       226.318320           0.000171
-        4 2022-03-01 00:53:20       225.561025           0.000109
+                         time  air_temperature  specific_humidity
+        0 2022-03-01 00:00:00       225.777939           0.000132
+        1 2022-03-01 00:13:20       225.139084           0.000132
+        2 2022-03-01 00:26:40       226.231216           0.000107
+        3 2022-03-01 00:40:00       226.318314           0.000171
+        4 2022-03-01 00:53:20       225.561020           0.000109
+
         """
         # Override use_indices in certain situations
         if use_indices:
             # Often the single_level data we use has time shifted
-            # Don't allow it for now.
-            # FIXME: We could do something smarter here!
+            # Don't allow it for now. We could do something smarter here!
             if mda.is_single_level:
                 use_indices = False
 

--- a/pycontrails/core/vector.py
+++ b/pycontrails/core/vector.py
@@ -1541,7 +1541,6 @@ class GeoVectorDataset(VectorDataset):
         indices_x, indices_y, indices_z, indices_t = indices.xi_indices
         distances_x, distances_y, distances_z, distances_t = indices.norm_distances
         out_of_bounds = indices.out_of_bounds
-        nans = indices.nans
 
         self["_indices_x"] = indices_x
         self["_indices_y"] = indices_y
@@ -1554,8 +1553,6 @@ class GeoVectorDataset(VectorDataset):
 
         if out_of_bounds is not None:
             self["_out_of_bounds"] = out_of_bounds
-        if nans is not None:
-            self["_nans"] = nans
 
     def _get_indices(self) -> interpolation.RGIArtifacts | None:
         """Get entries from call to :meth:`_put_indices`.
@@ -1587,9 +1584,8 @@ class GeoVectorDataset(VectorDataset):
         distances = np.asarray([distances_x, distances_y, distances_z, distances_t])
 
         out_of_bounds = self.get("_out_of_bounds", None)
-        nans = self.get("_nans", None)
 
-        return interpolation.RGIArtifacts(indices, distances, out_of_bounds, nans)
+        return interpolation.RGIArtifacts(indices, distances, out_of_bounds)
 
     def _invalidate_indices(self) -> None:
         """Remove any cached indices from :attr:`data."""
@@ -1603,7 +1599,6 @@ class GeoVectorDataset(VectorDataset):
             "_distances_z",
             "_distances_t",
             "_out_of_bounds",
-            "_nans",
         ):
             self.data.pop(key, None)
 

--- a/pycontrails/models/__init__.py
+++ b/pycontrails/models/__init__.py
@@ -1,0 +1,1 @@
+"""Contrail modeling support."""

--- a/pycontrails/models/accf.py
+++ b/pycontrails/models/accf.py
@@ -96,8 +96,7 @@ class ACCFParams(ModelParams):
 
 
 class ACCF(Model):
-    """Compute Algorithmic Climate Change Functions (ACCF)
-    over a :class:`Flight` trajectory or :class:`MetDataset` grid.
+    """Compute Algorithmic Climate Change Functions (ACCF).
 
     This class is a wrapper over the DLR / UMadrid library
     `climaccf <https://github.com/dlr-pa/climaccf>`__,

--- a/pycontrails/models/aircraft_performance.py
+++ b/pycontrails/models/aircraft_performance.py
@@ -30,7 +30,7 @@ class AircraftPerformance(Model):
 
     @abc.abstractmethod
     def eval(self, source: Flight | None = None, **params: Any) -> Flight:
-        ...
+        """Evaluate the aircraft performance model."""
 
 
 class AircraftPerformanceGrid(Model):
@@ -52,7 +52,7 @@ class AircraftPerformanceGrid(Model):
     def eval(
         self, source: GeoVectorDataset | MetDataset | None = None, **params: Any
     ) -> GeoVectorDataset | MetDataset:
-        ...
+        """Evaluate the aircraft performance model."""
 
 
 @dataclasses.dataclass

--- a/pycontrails/models/cocipgrid/cocip_grid.py
+++ b/pycontrails/models/cocipgrid/cocip_grid.py
@@ -1616,8 +1616,7 @@ def calc_emissions(vector: GeoVectorDataset, params: dict[str, Any]) -> None:
 
     if not _is_segment_free_mode(vector):
         head_tail_dt_s = vector["segment_length"] / true_airspeed
-        head_tail_dt_ns = (head_tail_dt_s * 1_000_000_000.0).astype(np.int64)
-        head_tail_dt = head_tail_dt_ns.astype("timedelta64[ns]")
+        head_tail_dt = (head_tail_dt_s * 1_000_000_000.0).astype("timedelta64[ns]")
         vector["head_tail_dt"] = head_tail_dt
 
     params["bada_model"] = vector.attrs["bada_model"]

--- a/pycontrails/models/cocipgrid/cocip_grid.py
+++ b/pycontrails/models/cocipgrid/cocip_grid.py
@@ -1615,8 +1615,10 @@ def calc_emissions(vector: GeoVectorDataset, params: dict[str, Any]) -> None:
     true_airspeed = vector["true_airspeed"]
 
     if not _is_segment_free_mode(vector):
-        head_tail_dt = vector["segment_length"] / true_airspeed
-        vector["head_tail_dt"] = head_tail_dt * np.timedelta64(1, "s").astype("timedelta64[ns]")
+        head_tail_dt_s = vector["segment_length"] / true_airspeed
+        head_tail_dt_ns = (head_tail_dt_s * 1_000_000_000.0).astype(np.int64)
+        head_tail_dt = head_tail_dt_ns.astype("timedelta64[ns]")
+        vector["head_tail_dt"] = head_tail_dt
 
     params["bada_model"] = vector.attrs["bada_model"]
 

--- a/pycontrails/models/cocipgrid/cocip_grid.py
+++ b/pycontrails/models/cocipgrid/cocip_grid.py
@@ -129,6 +129,8 @@ class CocipGrid(models.Model, cocip_time_handling.CocipTimeHandlingMixin):
                 "Parameter 'radiative_heating_effects' is not yet implemented in CocipGrid"
             )
 
+        self._target_dtype = np.result_type(*self.met.data.values())
+
     @overload
     def eval(self, source: GeoVectorDataset, **params: Any) -> GeoVectorDataset:
         ...
@@ -448,6 +450,9 @@ class CocipGrid(models.Model, cocip_time_handling.CocipTimeHandlingMixin):
 
                 # Convert the 4D grid to a vector
                 vector = source_slice.to_vector()
+                vector.update(longitude=vector["longitude"].astype(self._target_dtype, copy=False))
+                vector.update(latitude=vector["latitude"].astype(self._target_dtype, copy=False))
+                vector.update(level=vector["level"].astype(self._target_dtype, copy=False))
                 vector["index"] = source_time.size * np.arange(vector.size) + filt_start_idx + idx
 
                 # Split into chunks

--- a/pycontrails/models/cocipgrid/cocip_grid.py
+++ b/pycontrails/models/cocipgrid/cocip_grid.py
@@ -488,7 +488,7 @@ class CocipGrid(models.Model, cocip_time_handling.CocipTimeHandlingMixin):
         """Mutate `vector` by adding additional keys."""
         # Add time
         vector["formation_time"] = vector["time"]
-        vector["age"] = np.full(vector.size, np.timedelta64(0, "s"))
+        vector["age"] = np.full(vector.size, np.timedelta64(0, "ns"))
 
         # Precompute
         vector["air_pressure"] = vector.air_pressure

--- a/pycontrails/models/cocipgrid/cocip_time_handling.py
+++ b/pycontrails/models/cocipgrid/cocip_time_handling.py
@@ -297,13 +297,14 @@ class CocipTimeHandlingMixin:
         """
 
         # Only support met with hourly timestamps
-        remainder = self.met.variables["time"] - self.met.variables["time"].astype("datetime64[h]")
+        time = self.met.variables["time"].values
+        remainder = time - time.astype("datetime64[h]")
         if np.any(remainder.astype(float)):
             raise NotImplementedError("Only support met data with hourly time coordinates.")
 
         request = start, start + self.params["met_slice_dt"]
         buffer = np.timedelta64(0, "h"), np.timedelta64(0, "h")
-        met_sl = coordinates.slice_domain(self.met.variables["time"].values, request, buffer)
+        met_sl = coordinates.slice_domain(time, request, buffer)
         rad_sl = coordinates.slice_domain(self.rad.variables["time"].values, request, buffer)
 
         logger.debug("Update met slices. Start: %s, Stop: %s", met_sl.start, met_sl.stop)

--- a/pycontrails/models/humidity_scaling.py
+++ b/pycontrails/models/humidity_scaling.py
@@ -389,7 +389,12 @@ class ExponentialBoostLatitudeCorrectionHumidityScaling(HumidityScaling):
         b2 = kwargs["rhi_b2"]
         b3 = kwargs["rhi_b3"]
 
+        # Use the dtype of specific_humidity to determine the precision of the
+        # the calculation. If working with gridded data here, latitude will have
+        # float64 precision.
         latitude = kwargs["latitude"]
+        if latitude.dtype != specific_humidity.dtype:
+            latitude = latitude.astype(specific_humidity.dtype)
         lat_abs = np.abs(latitude)
 
         # Compute uncorrected RHi

--- a/pycontrails/models/sac.py
+++ b/pycontrails/models/sac.py
@@ -201,7 +201,7 @@ def slope_mixing_line(
         Slope of the mixing line in a temperature-humidity diagram, [:math:`Pa \ K^{-1}`]
     """
     c_pm = thermo.c_pm(specific_humidity)  # Often taken as 1004 (= constants.c_pd)
-    return (ei_h2o * c_pm * air_pressure) / (constants.epsilon * q_fuel * (1 - engine_efficiency))
+    return (ei_h2o * c_pm * air_pressure) / (constants.epsilon * q_fuel * (1.0 - engine_efficiency))
 
 
 def T_sat_liquid(G: ArrayLike) -> ArrayLike:

--- a/pycontrails/utils/temp.py
+++ b/pycontrails/utils/temp.py
@@ -18,6 +18,10 @@ def temp_filename() -> str:
     -------
     str
         Temp filename
+
+    See Also
+    --------
+    temp_file : Context manager for temp file creation and cleanup
     """
     return os.path.join(tempfile.gettempdir(), os.urandom(24).hex())
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,6 +153,7 @@ zarr = [
 # https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html
 [tool.setuptools]
 license-files = ["LICENSE", "NOTICE"]
+include-package-data = false
 
 # Note that setuptools-scm changes some of the default behavior of setuptools
 # In particular, everything tracked by git is included in the source distribution (sdist)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -16,13 +16,12 @@ BADA_ROOT = pathlib.Path(os.getenv("BADA_CACHE_DIR", default_bada_root))
 BADA3_PATH = BADA_ROOT / "bada3"
 BADA4_PATH = BADA_ROOT / "bada4"
 
-_all_bada_paths = [BADA3_PATH, BADA4_PATH]
-BADA_AVAILABLE = all(path.exists() for path in _all_bada_paths)
+BADA_AVAILABLE = BADA3_PATH.exists() and BADA4_PATH.exists()
 
 
 try:
     import open3d
-
-    OPEN3D_AVAILABLE = True
 except ModuleNotFoundError:
     OPEN3D_AVAILABLE = False
+else:
+    OPEN3D_AVAILABLE = True

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -373,7 +373,7 @@ def bada_model() -> AircraftPerformance:
     BADAFlight = pytest.importorskip("pycontrails.ext.bada").BADAFlight
 
     if not BADA_AVAILABLE:
-        raise RuntimeError("BADA data files unavailable")
+        pytest.skip("BADA data not available")
 
     params = {
         "bada3_path": BADA3_PATH,

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -368,7 +368,9 @@ def flight_fake() -> Flight:
 
 @pytest.fixture
 def bada_model() -> AircraftPerformance:
-    from pycontrails.ext.bada import BADAFlight
+    """Construct generic BADAFlight model."""
+
+    BADAFlight = pytest.importorskip("pycontrails.ext.bada").BADAFlight
 
     if not BADA_AVAILABLE:
         raise RuntimeError("BADA data files unavailable")

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -57,6 +57,7 @@ class TestDiskCacheStore:
         disk_path = "".join(random.choice(["x", "y"]) for _ in range(20))
         assert not _cache.exists(disk_path)
 
+    @pytest.mark.skipif(not pathlib.Path("README.md").is_file(), reason="No README.md")
     def test_cache_size(self) -> None:
         _cache = DiskCacheStore(cache_dir=f"{DISK_CACHE_DIR}/test", allow_clear=True)
         _cache.clear()
@@ -100,6 +101,7 @@ class TestDiskCacheStore:
         _cache.clear()
         assert not _cache.exists("path.nc")
 
+    @pytest.mark.skipif(not pathlib.Path("README.md").is_file(), reason="No README.md")
     def test_put_get(self) -> None:
         _cache = DiskCacheStore(cache_dir=f"{DISK_CACHE_DIR}/test", allow_clear=True)
         _cache.clear()
@@ -123,6 +125,7 @@ class TestDiskCacheStore:
         # clean up
         _cache.clear()
 
+    @pytest.mark.skipif(not pathlib.Path("README.md").is_file(), reason="No README.md")
     def test_put_multiple(self) -> None:
         _cache = DiskCacheStore(cache_dir=f"{DISK_CACHE_DIR}/test", allow_clear=True)
         _cache.clear()

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -98,6 +98,7 @@ class TestDiskCacheStore:
         _cache.clear()
         assert not _cache.exists("path.nc")
 
+    @pytest.mark.skipif(not pathlib.Path("README.md").is_file(), reason="No README.md file")
     def test_put_get(self) -> None:
         _cache = DiskCacheStore(cache_dir=f"{DISK_CACHE_DIR}/test", allow_clear=True)
         _cache.clear()
@@ -121,6 +122,7 @@ class TestDiskCacheStore:
         # clean up
         _cache.clear()
 
+    @pytest.mark.skipif(not pathlib.Path("README.md").is_file(), reason="No README.md file")
     def test_put_multiple(self) -> None:
         _cache = DiskCacheStore(cache_dir=f"{DISK_CACHE_DIR}/test", allow_clear=True)
         _cache.clear()
@@ -207,6 +209,7 @@ class TestGCPCacheStore:
             and f"{CACHE_DIR}" in _cache._disk_cache.cache_dir
         )
 
+    @pytest.mark.skipif(not pathlib.Path("README.md").is_file(), reason="No README.md file")
     def test_cache_size(self) -> None:
         _cache = GCPCacheStore(
             bucket=BUCKET, cache_dir=f"{CACHE_DIR}/", allow_clear=True, read_only=False

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -16,17 +16,19 @@ from pycontrails.core import cache
 # see if GCP credentials exist
 try:
     storage.Client()
-    gcp_credentials = True
 except Exception:
     gcp_credentials = False
+else:
+    gcp_credentials = True
 
 try:
     import requests
 
-    r = requests.get("https://gitlab.com")
-    offline = False
+    r = requests.get("https://github.com")
 except Exception:
     offline = True
+else:
+    offline = False
 
 ############
 # Disk Cache Store
@@ -98,7 +100,6 @@ class TestDiskCacheStore:
         _cache.clear()
         assert not _cache.exists("path.nc")
 
-    @pytest.mark.skipif(not pathlib.Path("README.md").is_file(), reason="No README.md file")
     def test_put_get(self) -> None:
         _cache = DiskCacheStore(cache_dir=f"{DISK_CACHE_DIR}/test", allow_clear=True)
         _cache.clear()
@@ -122,7 +123,6 @@ class TestDiskCacheStore:
         # clean up
         _cache.clear()
 
-    @pytest.mark.skipif(not pathlib.Path("README.md").is_file(), reason="No README.md file")
     def test_put_multiple(self) -> None:
         _cache = DiskCacheStore(cache_dir=f"{DISK_CACHE_DIR}/test", allow_clear=True)
         _cache.clear()
@@ -209,7 +209,6 @@ class TestGCPCacheStore:
             and f"{CACHE_DIR}" in _cache._disk_cache.cache_dir
         )
 
-    @pytest.mark.skipif(not pathlib.Path("README.md").is_file(), reason="No README.md file")
     def test_cache_size(self) -> None:
         _cache = GCPCacheStore(
             bucket=BUCKET, cache_dir=f"{CACHE_DIR}/", allow_clear=True, read_only=False

--- a/tests/unit/test_cocip_grid.py
+++ b/tests/unit/test_cocip_grid.py
@@ -274,7 +274,9 @@ def test_generate_new_grid_vectors(
             assert len(vectors) == 1
 
     lon_concat = np.concatenate([vector["longitude"] for vector in vectors])
-    assert set(lon_concat) == set(source.data["longitude"].values)
+    lon_concat = np.unique(lon_concat)
+    lon_concat.sort()
+    np.testing.assert_array_almost_equal(lon_concat, source.data["longitude"].values, decimal=5)
 
 
 ##############################################################
@@ -466,8 +468,8 @@ def test_grid_results(grid_results: MetDataset) -> None:
     # Ensure a hand picked pinned value is realized.
     # This test is HARD to maintain. Delete if it gets too annoying.
     point = grid_results.data.isel(longitude=14, latitude=19, level=2, time=2)
-    assert np.round(point["contrail_age"].item(), decimals=5) == 1.5
-    assert np.round(point["ef_per_m"].item(), decimals=2) == 46564396.28
+    assert point["contrail_age"].item() == 1.5
+    assert point["ef_per_m"].item() == pytest.approx(46576688, abs=1)
 
 
 @pytest.fixture
@@ -496,17 +498,17 @@ def test_grid_results_segment_free(
     assert out1.data.data_vars.keys() == out2.data.data_vars.keys()
 
     assert np.count_nonzero(out1["ef_per_m"].values) == 605
-    assert np.count_nonzero(out2["ef_per_m"].values) == 622
+    assert np.count_nonzero(out2["ef_per_m"].values) == 621
 
     # Pin some values
     da1 = out1["ef_per_m"].data
     filt1 = da1 > 0
-    assert da1.where(filt1).mean().item() == pytest.approx(39586616, abs=1)
+    assert da1.where(filt1).mean().item() == pytest.approx(39581584, abs=1)
 
     # In segment-free mode (generally and here), the mean nonzero EF is slightly lower
     da2 = out2["ef_per_m"].data
     filt2 = da2 > 0
-    assert da2.where(filt2).mean().item() == pytest.approx(32882996, abs=1)
+    assert da2.where(filt2).mean().item() == pytest.approx(32914018, abs=1)
 
     # For this example, we can say something about the distribution of EFs
     filt = filt1 & filt2
@@ -579,8 +581,8 @@ def test_geovector_source(syn_fl: SyntheticFlight, instance_params: dict[str, An
     assert np.all(out["ef_per_m"][~persistent] == 0)
 
     # Pin the mean EF
-    assert out["ef_per_m"].mean().item() == pytest.approx(875857, abs=1)
-    assert out["ef_per_m"][persistent].mean().item() == pytest.approx(31725499, abs=1)
+    assert out["ef_per_m"].mean().item() == pytest.approx(875854, abs=1)
+    assert out["ef_per_m"][persistent].mean().item() == pytest.approx(31725403, abs=1)
 
 
 @pytest.mark.filterwarnings("ignore:invalid value encountered in remainder")

--- a/tests/unit/test_cocip_grid.py
+++ b/tests/unit/test_cocip_grid.py
@@ -8,10 +8,14 @@ import numpy as np
 import pytest
 import xarray as xr
 
+try:
+    from pycontrails.models.cocipgrid import CocipGrid
+except ImportError:
+    pytest.skip("CocipGrid not available", allow_module_level=True)
+
 from pycontrails import GeoVectorDataset, MetDataset
 from pycontrails.models.aircraft_performance import AircraftPerformance
 from pycontrails.models.cocip import Cocip
-from pycontrails.models.cocipgrid import CocipGrid
 from pycontrails.models.cocipgrid import cocip_grid as cg_module
 from pycontrails.models.humidity_scaling import ExponentialBoostHumidityScaling
 from pycontrails.utils.synthetic_flight import SyntheticFlight

--- a/tests/unit/test_cocip_grid.py
+++ b/tests/unit/test_cocip_grid.py
@@ -473,7 +473,7 @@ def test_grid_results(grid_results: MetDataset) -> None:
     # This test is HARD to maintain. Delete if it gets too annoying.
     point = grid_results.data.isel(longitude=14, latitude=19, level=2, time=2)
     assert point["contrail_age"].item() == 1.5
-    assert point["ef_per_m"].item() == pytest.approx(46576688, abs=1)
+    assert point["ef_per_m"].item() == pytest.approx(46576688, abs=10)
 
 
 @pytest.fixture
@@ -501,18 +501,18 @@ def test_grid_results_segment_free(
     assert out1.shape == out2.shape
     assert out1.data.data_vars.keys() == out2.data.data_vars.keys()
 
-    assert np.count_nonzero(out1["ef_per_m"].values) == 605
-    assert np.count_nonzero(out2["ef_per_m"].values) == 621
+    assert np.count_nonzero(out1["ef_per_m"].values) == pytest.approx(605, abs=1)
+    assert np.count_nonzero(out2["ef_per_m"].values) == pytest.approx(621, abs=1)
 
     # Pin some values
     da1 = out1["ef_per_m"].data
     filt1 = da1 > 0
-    assert da1.where(filt1).mean().item() == pytest.approx(39581584, abs=1)
+    assert da1.where(filt1).mean().item() == pytest.approx(39581584, abs=10)
 
     # In segment-free mode (generally and here), the mean nonzero EF is slightly lower
     da2 = out2["ef_per_m"].data
     filt2 = da2 > 0
-    assert da2.where(filt2).mean().item() == pytest.approx(32914018, abs=1)
+    assert da2.where(filt2).mean().item() == pytest.approx(32914018, abs=10)
 
     # For this example, we can say something about the distribution of EFs
     filt = filt1 & filt2
@@ -585,8 +585,8 @@ def test_geovector_source(syn_fl: SyntheticFlight, instance_params: dict[str, An
     assert np.all(out["ef_per_m"][~persistent] == 0)
 
     # Pin the mean EF
-    assert out["ef_per_m"].mean().item() == pytest.approx(875854, abs=1)
-    assert out["ef_per_m"][persistent].mean().item() == pytest.approx(31725403, abs=1)
+    assert out["ef_per_m"].mean().item() == pytest.approx(875854, abs=10)
+    assert out["ef_per_m"][persistent].mean().item() == pytest.approx(31725403, abs=10)
 
 
 @pytest.mark.filterwarnings("ignore:invalid value encountered in remainder")

--- a/tests/unit/test_cocip_grid.py
+++ b/tests/unit/test_cocip_grid.py
@@ -473,7 +473,7 @@ def test_grid_results(grid_results: MetDataset) -> None:
     # This test is HARD to maintain. Delete if it gets too annoying.
     point = grid_results.data.isel(longitude=14, latitude=19, level=2, time=2)
     assert point["contrail_age"].item() == 1.5
-    assert point["ef_per_m"].item() == pytest.approx(46576688, abs=10)
+    assert point["ef_per_m"].item() == pytest.approx(46576688, abs=1000)
 
 
 @pytest.fixture
@@ -507,12 +507,12 @@ def test_grid_results_segment_free(
     # Pin some values
     da1 = out1["ef_per_m"].data
     filt1 = da1 > 0
-    assert da1.where(filt1).mean().item() == pytest.approx(39581584, abs=10)
+    assert da1.where(filt1).mean().item() == pytest.approx(39581584, rel=1e-3)
 
     # In segment-free mode (generally and here), the mean nonzero EF is slightly lower
     da2 = out2["ef_per_m"].data
     filt2 = da2 > 0
-    assert da2.where(filt2).mean().item() == pytest.approx(32914018, abs=10)
+    assert da2.where(filt2).mean().item() == pytest.approx(32914018, rel=1e-3)
 
     # For this example, we can say something about the distribution of EFs
     filt = filt1 & filt2

--- a/tests/unit/test_cocip_grid.py
+++ b/tests/unit/test_cocip_grid.py
@@ -473,7 +473,7 @@ def test_grid_results(grid_results: MetDataset) -> None:
     # This test is HARD to maintain. Delete if it gets too annoying.
     point = grid_results.data.isel(longitude=14, latitude=19, level=2, time=2)
     assert point["contrail_age"].item() == 1.5
-    assert point["ef_per_m"].item() == pytest.approx(46576688, abs=1000)
+    assert point["ef_per_m"].item() == pytest.approx(46576688, rel=1e-3)
 
 
 @pytest.fixture

--- a/tests/unit/test_cocip_grid_parity.py
+++ b/tests/unit/test_cocip_grid_parity.py
@@ -5,9 +5,13 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
+try:
+    from pycontrails.models.cocipgrid import CocipGrid
+except ImportError:
+    pytest.skip("CocipGrid not available", allow_module_level=True)
+
 from pycontrails import Flight, MetDataset
 from pycontrails.models.cocip import Cocip
-from pycontrails.models.cocipgrid import CocipGrid
 from pycontrails.models.humidity_scaling import ExponentialBoostHumidityScaling
 from pycontrails.utils.synthetic_flight import SyntheticFlight
 from tests import BADA4_PATH

--- a/tests/unit/test_dtypes.py
+++ b/tests/unit/test_dtypes.py
@@ -10,7 +10,6 @@ from pycontrails import Flight, GeoVectorDataset, MetDataset
 from pycontrails.core.met import MetDataArray
 from pycontrails.models.aircraft_performance import AircraftPerformance
 from pycontrails.models.cocip import Cocip
-from pycontrails.models.cocipgrid import CocipGrid
 from pycontrails.models.humidity_scaling import ConstantHumidityScaling
 from pycontrails.models.issr import ISSR
 from pycontrails.models.sac import SAC
@@ -194,6 +193,8 @@ def test_cocip(
 @pytest.mark.parametrize("bada_priority", [3, 4])
 def test_cocip_grid(met_cocip1: MetDataset, rad_cocip1: MetDataset, bada_priority: int):
     """Confirm `CocipGrid` maintains float32 precision."""
+    CocipGrid = pytest.importorskip("pycontrails.models.cocipgrid").CocipGrid
+
     # Keep max_age small to avoid blowing out of bounds
     # And keep dt_integration small to make the evolution interesting
     params = {

--- a/tests/unit/test_dtypes.py
+++ b/tests/unit/test_dtypes.py
@@ -18,83 +18,46 @@ from pycontrails.physics import units
 from tests import BADA3_PATH, BADA4_PATH, BADA_AVAILABLE
 
 
-def ds_to_float32(ds: xr.Dataset):
-    """Convert spatial dimensions to float32."""
-    ds["longitude"] = ds["longitude"].astype("float32")
-    ds["latitude"] = ds["latitude"].astype("float32")
-    ds["level"] = ds["level"].astype("float32")
-    return ds.reset_coords(drop=True)
-
-
-def confirm_float32(met: MetDataset):
-    """Confirm all data arrays are float32."""
-    assert met.data["longitude"].dtype == "float32"
-    assert met.data["latitude"].dtype == "float32"
-    assert met.data["level"].dtype == "float32"
-    if met.data["level"].size > 1:
-        assert met.data["air_pressure"].dtype == "float32"
-        assert met.data["altitude"].dtype == "float32"
-    assert met.data["time"].dtype == "datetime64[ns]"
-    for v in met:
-        assert met[v].data.dtype == "float32"
-
-
 @pytest.fixture
-def met32(met_ecmwf_pl_path: str):
-    """Create a MetDataset with float32 precision spatial coordinates."""
+def met(met_ecmwf_pl_path: str) -> MetDataset:
+    """Create a MetDataset for testing."""
     ds1 = xr.open_dataset(met_ecmwf_pl_path)
-    ds1 = ds_to_float32(ds1)
 
     # shift time and concatenate to create a new dataset
     ds2 = ds1.copy()
     ds2["time"] = ds2["time"] + np.timedelta64(1, "h")
     ds = xr.concat([ds1, ds2], dim="time")
+    for v in ds.data_vars:
+        assert ds[v].dtype == "float32"
 
     met = MetDataset(ds)
-    confirm_float32(met)
     assert met.shape == (15, 8, 3, 4)
     return met
 
 
-@pytest.mark.parametrize("method", ["linear", "nearest"])
-def test_interpolation_float32_out(method: str, met32: MetDataset):
-    """Ensure interpolation output is float32 if all inputs have float32 precision."""
-    mda = met32["t"]
+@pytest.fixture(params=["float32", "float64"])
+def mda(met: MetDataset, request) -> MetDataArray:
+    """Create a MetDataArray for testing."""
+    mda = met["t"]
+    mda.data = mda.data.astype(request.param)
+    return mda
 
-    t0 = met32.data.time.values[0] + np.timedelta64(30, "m")
+
+@pytest.mark.parametrize("vector_dtype", ["float32", "float64", "int32", "int64"])
+@pytest.mark.parametrize("method", ["linear", "nearest"])
+def test_interpolation_out_dtype(mda: MetDataArray, method: str, vector_dtype: str):
+    """Ensure interpolation output dtype is consistent with grid dtype."""
+
+    t0 = mda.data.time.values[0] + np.timedelta64(30, "m")
     vector = GeoVectorDataset(
-        longitude=np.array([1, 2, 3], dtype="float32"),
-        latitude=np.array([1, 2, 3], dtype="float32"),
-        level=np.array([251, 252, 253], dtype="float32"),
+        longitude=np.array([1, 2, 3], dtype=vector_dtype),
+        latitude=np.array([1, 2, 3], dtype=vector_dtype),
+        level=np.array([251, 252, 253], dtype=vector_dtype),
         time=[t0, t0, t0],
     )
     out = vector.intersect_met(mda, bounds_error=True, method=method)
     assert out.size == 3
-    assert out.dtype == "float32"
-
-    # Linear interpolation is somewhat special in that it issues explicit distances
-    # between coordinates. Nearest interpolation does not.
-    mda.data["longitude"] = mda.data["longitude"].astype("float64")
-    out = vector.intersect_met(mda, bounds_error=True, method=method)
-    if method == "linear":
-        # If any met coordinate is float64 and method=linear, the output will be float64
-        assert out.dtype == "float64"
-    else:
-        assert out.dtype == "float32"
-    mda.data["longitude"] = mda.data["longitude"].astype("float32")
-
-    vector.update(longitude=vector["longitude"].astype("float64"))
-    out = vector.intersect_met(mda, bounds_error=True, method=method)
-    if method == "linear":
-        # If any vector coordinate is float64 and method=linear, output will be float64
-        assert out.dtype == "float64"
-    else:
-        assert out.dtype == "float32"
-
-    # In either case, if the met variable has float64 coordinates, the output will be float64
-    mda.data = mda.data.astype("float64")
-    out = vector.intersect_met(mda, bounds_error=True, method=method)
-    assert out.dtype == "float64"
+    assert out.dtype == mda.data.dtype
 
 
 def test_unit_conversion():
@@ -109,36 +72,27 @@ def test_unit_conversion():
     assert level_ft.dtype == "float32"
 
 
-@pytest.fixture(scope="module")
-def issr_sac_met32(met_issr: MetDataset):
-    """Create a MetDataset with float32 precision for ISSR."""
-    ds = met_issr.data.copy()
-    ds = ds_to_float32(ds)
-
-    # Check it
-    met = MetDataset(ds)
-    confirm_float32(met)
-    return met
-
-
 @pytest.mark.parametrize("model_class", [ISSR, SAC])
 @pytest.mark.parametrize("method", ["linear", "nearest"])
-def test_issr_sac_grid_output(issr_sac_met32: MetDataset, model_class: type, method: str):
+def test_issr_sac_grid_output(met_issr: MetDataset, model_class: type, method: str):
     """Confirm ISSR and SAC gridded output is float32 when met input is float32."""
+
+    assert all(v == "float32" for v in met_issr.data.dtypes.values())
+
     model = model_class(
-        issr_sac_met32,
+        met_issr,
         interpolation_method=method,
         humidity_scaling=ConstantHumidityScaling(),
     )
     out = model.eval()
     assert isinstance(out, MetDataArray)
     assert out.data.dtype == "float32"
-    assert out.shape == issr_sac_met32.shape
+    assert out.shape == met_issr.shape
 
 
 @pytest.fixture(scope="module")
-def random_vector(issr_sac_met32: MetDataset):
-    """Create a random vector with coordinates mostly matching `issr_sac_met32`."""
+def random_vector(met_issr: MetDataset):
+    """Create a random vector with coordinates mostly matching `met_issr`."""
     # Build random vector
     # Purposely going out of bounds from met
     rng = np.random.default_rng(22777)
@@ -146,7 +100,7 @@ def random_vector(issr_sac_met32: MetDataset):
     latitude = rng.uniform(-90, 90, 1000).astype("float32")
     level = rng.uniform(200, 300, 1000).astype("float32")
 
-    t0 = issr_sac_met32.data.time.values[0]
+    t0 = met_issr.data.time.values[0]
     time = t0 + rng.integers(0, 60, 1000) * np.timedelta64(1, "m")
 
     return GeoVectorDataset(
@@ -161,7 +115,7 @@ def random_vector(issr_sac_met32: MetDataset):
 @pytest.mark.parametrize("model_class", [ISSR, SAC])
 @pytest.mark.parametrize("method", ["linear", "nearest"])
 def test_issr_sac_vector_output(
-    issr_sac_met32: MetDataset,
+    met_issr: MetDataset,
     model_class: type,
     method: str,
     random_vector: GeoVectorDataset,
@@ -169,7 +123,7 @@ def test_issr_sac_vector_output(
     """Confirm ISSR and SAC vector output is float32 when source and met input is float32."""
     # Run the model
     model = model_class(
-        issr_sac_met32,
+        met_issr,
         interpolation_method=method,
         humidity_scaling=ConstantHumidityScaling(),
     )
@@ -181,34 +135,17 @@ def test_issr_sac_vector_output(
     assert out["specific_humidity"].dtype == "float32"
 
     # Confirm interpolation behaves as expected
-    in_bounds = random_vector.coords_intersect_met(issr_sac_met32)
+    in_bounds = random_vector.coords_intersect_met(met_issr)
     interp_non_nan = np.isfinite(out["air_temperature"])
     np.testing.assert_array_equal(in_bounds, interp_non_nan)
-
-
-@pytest.fixture
-def cocip_met_rad(met_cocip1: MetDataset, rad_cocip1: MetDataset) -> tuple[MetDataset, MetDataset]:
-    """Convert cocip met and rad input to float32."""
-    ds_met = met_cocip1.data
-    ds_met = ds_to_float32(ds_met)
-
-    ds_rad = rad_cocip1.data
-    ds_rad = ds_to_float32(ds_rad)
-
-    met = MetDataset(ds_met)
-    rad = MetDataset(ds_rad)
-
-    confirm_float32(met)
-    confirm_float32(rad)
-
-    return met, rad
 
 
 @pytest.mark.skipif(not BADA4_PATH.is_dir(), reason="BADA4 not available")
 @pytest.mark.parametrize("drop_aircraft_performance", [False, True])
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")
 def test_cocip(
-    cocip_met_rad,
+    met_cocip1: MetDataset,
+    rad_cocip1: MetDataset,
     flight_cocip1: Flight,
     drop_aircraft_performance: bool,
     bada_model: AircraftPerformance,
@@ -227,7 +164,8 @@ def test_cocip(
 
     # Run the model
     cocip = Cocip(
-        *cocip_met_rad,
+        met=met_cocip1,
+        rad=rad_cocip1,
         process_emissions=drop_aircraft_performance,
         humidity_scaling=ConstantHumidityScaling(),
         aircraft_performance=bada_model,
@@ -245,15 +183,16 @@ def test_cocip(
     ]
     for vector in vectors:
         for k in vector:
-            if k not in exclude:
-                arr = vector[k]
-                assert np.can_cast(arr.dtype, "float32"), k
+            if k in exclude:
+                continue
+            arr = vector[k]
+            assert np.can_cast(arr.dtype, "float32"), k
 
 
 @pytest.mark.skipif(not BADA_AVAILABLE, reason="BADA not available")
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")
 @pytest.mark.parametrize("bada_priority", [3, 4])
-def test_cocip_grid(cocip_met_rad: tuple[MetDataset, MetDataset], bada_priority: int):
+def test_cocip_grid(met_cocip1: MetDataset, rad_cocip1: MetDataset, bada_priority: int):
     """Confirm `CocipGrid` maintains float32 precision."""
     # Keep max_age small to avoid blowing out of bounds
     # And keep dt_integration small to make the evolution interesting
@@ -267,7 +206,7 @@ def test_cocip_grid(cocip_met_rad: tuple[MetDataset, MetDataset], bada_priority:
         params["bada3_path"] = BADA3_PATH
     elif bada_priority == 4:
         params["bada4_path"] = BADA4_PATH
-    cg = CocipGrid(*cocip_met_rad, params=params)
+    cg = CocipGrid(met=met_cocip1, rad=rad_cocip1, params=params)
 
     # Create float32 source
     source = cg.create_source(
@@ -276,10 +215,6 @@ def test_cocip_grid(cocip_met_rad: tuple[MetDataset, MetDataset], bada_priority:
         longitude=cg.met.data.longitude.values,
         latitude=cg.met.data.latitude.values,
     )
-    ds = source.data
-    ds = ds_to_float32(ds)
-    source = MetDataset(ds)
-    confirm_float32(source)
     assert source.shape == (16, 8, 1, 1)
 
     out = cg.eval(source)
@@ -288,11 +223,8 @@ def test_cocip_grid(cocip_met_rad: tuple[MetDataset, MetDataset], bada_priority:
     assert out.attrs["max_age"] == "2 hours"
     assert out.attrs["dt_integration"] == "10 minutes"
     assert out.attrs["pycontrails_version"].startswith("0.")
-    assert out.data["longitude"].dtype == "float32"
-    assert out.data["latitude"].dtype == "float32"
-    assert out.data["level"].dtype == "float32"
 
     # Not much persistence, but we can pin them
     # And importantly, they are the same with BADA3 or BADA4
-    (nonzero,) = out["ef_per_m"].data.values.ravel().nonzero()
+    nonzero = np.flatnonzero(out["ef_per_m"].data.values.ravel())
     np.testing.assert_array_equal(nonzero, [38, 46, 52, 53, 54, 61, 62, 70])

--- a/tests/unit/test_fleet.py
+++ b/tests/unit/test_fleet.py
@@ -5,7 +5,11 @@ import pytest
 
 from pycontrails import Flight
 from pycontrails.core.fleet import Fleet
-from pycontrails.utils.synthetic_flight import SyntheticFlight
+
+try:
+    from pycontrails.utils.synthetic_flight import SyntheticFlight
+except ImportError:
+    pytest.skip("SyntheticFlight not available", allow_module_level=True)
 
 
 @pytest.fixture(scope="module")

--- a/tests/unit/test_grid_to_netcdf.py
+++ b/tests/unit/test_grid_to_netcdf.py
@@ -7,8 +7,12 @@ import numpy as np
 import pytest
 import xarray as xr
 
+try:
+    from pycontrails.models.cocipgrid import CocipGrid
+except ImportError:
+    pytest.skip("CocipGrid not available", allow_module_level=True)
+
 from pycontrails import MetDataset
-from pycontrails.models.cocipgrid import CocipGrid
 from pycontrails.models.humidity_scaling import ConstantHumidityScaling
 from pycontrails.models.issr import ISSR
 from pycontrails.models.pcr import PCR

--- a/tests/unit/test_grid_to_netcdf.py
+++ b/tests/unit/test_grid_to_netcdf.py
@@ -1,7 +1,6 @@
 """Ensure gridded output can be written to disk."""
 
 import pathlib
-import tempfile
 
 import numpy as np
 import pytest

--- a/tests/unit/test_met.py
+++ b/tests/unit/test_met.py
@@ -234,7 +234,7 @@ def test_shift_longitude(zero_like_da: xr.DataArray) -> None:
 @pytest.fixture
 def zero_like_da() -> xr.DataArray:
     return xr.DataArray(
-        data=0,
+        data=0.0,
         dims=["longitude", "latitude", "level", "time"],
         coords={
             "longitude": np.arange(-180, 180, 1.0),
@@ -277,7 +277,7 @@ def island_binary(zero_like_da: xr.DataArray) -> MetDataArray:
 
     da = zero_like_da
     island = (np.abs(da["latitude"]) < 5) & (np.abs(da["longitude"]) < 5)
-    da = xr.where(island, 1, da)
+    da = xr.where(island, 1.0, da)
     return MetDataArray(da)
 
 

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -219,7 +219,7 @@ def test_model_grid_required_met_variables(met_era5_fake: MetDataset) -> None:
 def test_model_grid_hash(met_era5_fake: MetDataset) -> None:
     """Model hash."""
     grid_model = ModelTestGrid(met=met_era5_fake)
-    assert grid_model.hash == "084e078e361ced42468cf64d13c461b2b7d15369"
+    assert grid_model.hash == "b0c7e9502e5702950a8f8653e28cc812edf3f302"
 
 
 def test_model_met_not_copied(met_era5_fake: MetDataset) -> None:
@@ -326,7 +326,7 @@ def test_model_flight_required_met_variables(met_era5_fake: MetDataset) -> None:
 def test_model_flight_hash(met_era5_fake: MetDataset) -> None:
     """Ensure pinned hash matches as check for model degradation."""
     flight_model = ModelTestFlight(met_era5_fake)
-    assert flight_model.hash == "4cb1faff8e8633f934a12ec7bbc68578732d3908"
+    assert flight_model.hash == "6c777586ca794efb80a3a4b832f5b04f2371bc67"
 
 
 def test_model_flight_met_not_copied(met_era5_fake: MetDataset) -> None:

--- a/tests/unit/test_sac_issr.py
+++ b/tests/unit/test_sac_issr.py
@@ -552,7 +552,7 @@ def test_issr_source_grid_different_resolution(met_issr: MetDataset, in_bounds: 
     if in_bounds:
         out = model.eval(source, interpolation_bounds_error=True)
         assert np.all(np.isfinite(out.data))
+        return
 
-    else:
-        with pytest.raises(ValueError, match="A value in x_new is below the interpolation range"):
-            model.eval(source, interpolation_bounds_error=True)
+    with pytest.raises(ValueError, match="221"):
+        model.eval(source, interpolation_bounds_error=True)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -10,11 +10,19 @@ import pandas as pd
 import pytest
 import xarray as xr
 
+try:
+    from pycontrails.utils.synthetic_flight import SAMPLE_AIRCRAFT_TYPES, SyntheticFlight
+except ImportError:
+    synthetic_flight_unavailable = True
+    SAMPLE_AIRCRAFT_TYPES = []
+else:
+    synthetic_flight_unavailable = False
+
+
 from pycontrails import Flight, MetDataset
 from pycontrails.utils import types
 from pycontrails.utils.iteration import chunk_list
 from pycontrails.utils.json import NumpyEncoder
-from pycontrails.utils.synthetic_flight import SAMPLE_AIRCRAFT_TYPES, SyntheticFlight
 from pycontrails.utils.temp import remove_tempfile, temp_file, temp_filename
 from pycontrails.utils.types import type_guard
 from tests import BADA3_PATH, BADA4_PATH, BADA_AVAILABLE
@@ -91,6 +99,7 @@ def test_numpy_encoder() -> None:
     assert loaded_dict["date_range"] == date_range.to_numpy().tolist()
 
 
+@pytest.mark.skipif(synthetic_flight_unavailable, reason="synthetic_flight unavailable")
 def test_synthetic_flight(met_cocip1: MetDataset) -> None:
     """Test SyntheticFlight class."""
     # synthetic flights
@@ -127,6 +136,7 @@ def test_synthetic_flight(met_cocip1: MetDataset) -> None:
     assert isinstance(fl, Flight)
 
 
+@pytest.mark.skipif(synthetic_flight_unavailable, reason="synthetic_flight unavailable")
 @pytest.mark.skipif(not BADA_AVAILABLE, reason="No BADA or EDB Files")
 @pytest.mark.parametrize("aircraft_type", SAMPLE_AIRCRAFT_TYPES)
 def test_synthetic_flight_bada(aircraft_type: str) -> None:


### PR DESCRIPTION
#### Features

- Improve interpolation performance by cythonizing linear interpolation. This extends the approach taken in [scipy 1.10](https://github.com/scipy/scipy/pull/17291). The pycontrails [cython routines](pycontrails/core/rgi_cython.pyx) allow for both float64 and float32 grids via cython fused types (the current scipy implementation assumes float64). In addition, interpolation up to dimension 4 is supported (the scipy implementation supports dimension 1 and 2).
- Officially support [scipy 1.10](https://docs.scipy.org/doc/scipy/index.html).

#### Breaking changes

- Change `MetDataset` and `MetDataArray` conventions: underlying dimension coordinates are automatically promoted to float64.
- Change how datetime arrays are converted to floating values for interpolation. The new approach introduces small differences compared with the previous implementation. These differences are significant enough to see relative differences in CoCiP predictions on the order of 1e-4.

#### Fixes

- Unit tests no longer raise errors when the `pycontrails-bada` package is not installed. Instead, some tests are skipped.

#### Internals

- Make the `interpolation` module more aligned with [scipy 1.10 enhancements](https://docs.scipy.org/doc/scipy/release.1.10.0.html#scipy-interpolate-improvements) to the `RegularGridInterpolator`. In particular, grid coordinates now must be float64.
- Use [cibuildwheel](https://cibuildwheel.readthedocs.io/en/stable/) to build wheels for Linux, macOS (arm64 and x86_64), and Windows on [release](.github/workflows/release.yaml) in Github Actions. Allow this workflow to be triggered manually to test the release process without actually publishing to PyPI.
- Simplify interpolation with pre-computed indices (invoked with the model parameter `interpolation_use_indices`) via a `RGIArtifacts` interface.
- Slight performance enhancements to the `met` module.

## Tests

- [x] QC test passes locally (`make test`)
- [x] CI tests pass

## Reviewer

@mlshapiro I still have work to do on the distribution side of this. I may want to hold off merging until I can test better on windows.

## Interpolation performance

I've pasted plots of interpolation times on the head main and the head of this branch.

Both axes are log-scaled.

<img width="850" alt="Screenshot 2023-04-07 at 12 22 55 PM" src="https://user-images.githubusercontent.com/38074806/230658626-b6336a6e-3ca7-4324-8f03-9efa1fca23bb.png">

Both axes are linear scaled.

<img width="827" alt="Screenshot 2023-04-07 at 12 23 31 PM" src="https://user-images.githubusercontent.com/38074806/230658702-30c7367e-668c-49ef-8660-162a043d41c4.png">

The same information in table form. A larger ratio is better.

|   vector_size |   ratio |
|--------------:|--------:|
|            10 |    2.33 |
|            12 |    3.22 |
|            15 |    2.26 |
|            20 |    2.28 |
|            25 |    2.35 |
|            32 |    2.27 |
|            40 |    2.28 |
|            51 |    2.3  |
|            65 |    2.3  |
|            82 |    2.3  |
|           104 |    2.34 |
|           132 |    3.19 |
|           167 |    3.04 |
|           212 |    3.12 |
|           268 |    3.15 |
|           339 |    3.09 |
|           429 |    3.06 |
|           542 |    2.95 |
|           686 |    2.54 |
|           868 |    2.6  |
|          1098 |    2.54 |
|          1389 |    2.33 |
|          1757 |    2.16 |
|          2222 |    2.08 |
|          2811 |    1.97 |
|          3556 |    1.93 |
|          4498 |    1.89 |
|          5689 |    1.87 |
|          7196 |    1.87 |
|          9102 |    1.86 |
|         11513 |    1.79 |
|         14563 |    1.82 |
|         18420 |    1.78 |
|         23299 |    1.84 |
|         29470 |    1.86 |
|         37275 |    2.03 |
|         47148 |    2    |
|         59636 |    2.02 |
|         75431 |    2.04 |
|         95409 |    2.03 |
|        120679 |    2.06 |
|        152641 |    2.04 |
|        193069 |    2.11 |
|        244205 |    2.14 |
|        308884 |    2.24 |
|        390693 |    2.28 |
|        494171 |    2.16 |
|        625055 |    2.19 |
|        790604 |    2.15 |
|       1000000 |    2.28 |


