### PR TITLE
Bugfix/numpy compile

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -91,6 +91,7 @@ jobs:
         verify-metadata: true
 
   upload_pypi:
+    if: ${{ github.event_name == 'release' }}
     needs: [build_wheels, build_sdist, check-main-test-status]
     runs-on: ubuntu-latest
     steps:
@@ -101,7 +102,6 @@ jobs:
 
     - name: Publish distribution 📦 to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
-      if: ${{ github.event_name == 'release' }}
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,7 +50,7 @@ jobs:
         CIBW_TEST_EXTRAS: "complete,dev"
         CIBW_TEST_COMMAND: >
           mv {project}/pycontrails {project}/pycontrails-bak &&
-          python -m pytest {project}/tests &&
+          python -m pytest {project}/tests -vv &&
           mv {project}/pycontrails-bak {project}/pycontrails
 
     - uses: actions/upload-artifact@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -126,4 +126,4 @@ jobs:
         ruff pycontrails tests
         mypy pycontrails
         pydocstyle pycontrails --verbose
-        pytest tests/unit
+        pytest tests/unit -vv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 
 # Changelog
 
+## v0.40.1
+
+#### Fixes
+
+- Use [oldest-supported-numpy](https://pypi.org/project/oldest-supported-numpy/) for building pycontrails wheels. This allows pycontrails to be compatible with environments that use old versions of numpy. The [pycontrails v0.40.0 wheels](https://pypi.org/project/pycontrails/0.40.0/#files) are not compatible with numpy 1.22.
+- Fix a unit test (`test_dtypes.py::test_issr_sac_grid_output`) that occasionally hangs.
+
 ## v0.40.0
 
 Support scipy 1.10, improve interpolation performance, and fix many windows issues.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 # https://setuptools.readthedocs.io/en/latest/
 [build-system]
-requires = ["setuptools", "setuptools_scm", "wheel", "cython", "numpy"]
+requires = ["setuptools", "setuptools_scm", "wheel", "cython", "oldest-supported-numpy"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/tests/unit/test_dtypes.py
+++ b/tests/unit/test_dtypes.py
@@ -74,7 +74,12 @@ def test_unit_conversion():
 @pytest.mark.parametrize("model_class", [ISSR, SAC])
 @pytest.mark.parametrize("method", ["linear", "nearest"])
 def test_issr_sac_grid_output(met_issr: MetDataset, model_class: type, method: str):
-    """Confirm ISSR and SAC gridded output is float32 when met input is float32."""
+    """Confirm ISSR and SAC gridded output is float32 when met input is float32.
+
+    Something in dask threading is causing this test to occasionally hang. As a
+    workaround, we load the met data into memory before passing it to the model.
+    """
+    met_issr.data.load()
 
     assert all(v == "float32" for v in met_issr.data.dtypes.values())
 


### PR DESCRIPTION
#### Fixes

- Use [oldest-supported-numpy](https://pypi.org/project/oldest-supported-numpy/) for building pycontrails wheels. This allows pycontrails to be compatible with environments that use old versions of numpy. The [pycontrails v0.40.0 wheels](https://pypi.org/project/pycontrails/0.40.0/#files) are not compatible with numpy 1.22.
- Fix a unit test (`test_dtypes.py::test_issr_sac_grid_output`) that occasionally hangs.
