### PR TITLE
Bugfix/v0.44

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,13 @@
 - Support `MetDataset` source in the `HistogramMatching` humidity scaling model. Previously only `GeoVectorDataset` sources were explicitly supported.
 - Replace `np.gradient` with `dask.array.gradient` in the `tau_cirrus` module. This ensures that the computation is done lazily for dask-backed arrays.
 - Round to 6 digits in the `polygon.determine_buffer` function. This avoid unnecessary warnings for rounding errors.
+- Fix type hint for `opencv-python` 4.8.0.74.
 
 ### Internals
 
 - Take more care with `float` and `int` types in the `contrail_properties` module. Prefer `np.clip` to `np.where` or `np.maximum` for clipping values.
 - Support `air_temperature` in `CocipGrid` verbose formation outputs.
+- Remove `pytest-timeout` dev dependency.
 
 ## v0.44.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Support `MetDataset` source in the `HistogramMatching` humidity scaling model. Previously only `GeoVectorDataset` sources were explicitly supported.
 - Replace `np.gradient` with `dask.array.gradient` in the `tau_cirrus` module. This ensures that the computation is done lazily for dask-backed arrays.
+- Round to 6 digits in the `polygon.determine_buffer` function. This avoid unnecessary warnings for rounding errors.
 
 ### Internals
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixes
 
 - Support `MetDataset` source in the `HistogramMatching` humidity scaling model. Previously only `GeoVectorDataset` sources were explicitly supported.
+- Replace `np.gradient` with `dask.array.gradient` in the `tau_cirrus` module. This ensures that the computation is done lazily for dask-backed arrays.
 
 ## v0.44.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 
 # Changelog
 
+## v0.44.1
+
+### Breaking changes
+
+- By default, call `xr.open_mfdataset` with `lock=False` in the `MetDataSource.open_dataset` method. This helps alleviate a `dask` threading issue similar to [this GitHub issue](https://github.com/pydata/xarray/issues/4406).
+
+### Fixes
+
+- Support `MetDataset` source in the `HistogramMatching` humidity scaling model. Previously only `GeoVectorDataset` sources were explicitly supported.
+
 ## v0.44.0
 
 Support for the [Poll-Schumann aircraft performance model](https://doi.org/10.1017/aer.2020.62).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Internals
 
 - Take more care with `float` and `int` types in the `contrail_properties` module. Prefer `np.clip` to `np.where` or `np.maximum` for clipping values.
+- Support `air_temperature` in `CocipGrid` verbose formation outputs.
 
 ## v0.44.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 - Support `MetDataset` source in the `HistogramMatching` humidity scaling model. Previously only `GeoVectorDataset` sources were explicitly supported.
 - Replace `np.gradient` with `dask.array.gradient` in the `tau_cirrus` module. This ensures that the computation is done lazily for dask-backed arrays.
 
+### Internals
+
+- Take more care with `float` and `int` types in the `contrail_properties` module. Prefer `np.clip` to `np.where` or `np.maximum` for clipping values.
+
 ## v0.44.0
 
 Support for the [Poll-Schumann aircraft performance model](https://doi.org/10.1017/aer.2020.62).

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,3 +33,4 @@ pycontrails
    Github <https://github.com/contrailcirrus/pycontrails>
    Contrails Map <https://map.contrails.org>
    Contrails API <https://api.contrails.org>
+   Contrails Navigator <https://forecast.contrails.org>

--- a/docs/tutorials/interpolating-specific-humidity.ipynb
+++ b/docs/tutorials/interpolating-specific-humidity.ipynb
@@ -19,7 +19,7 @@
    "source": [
     "## ERA5 data\n",
     "\n",
-    "In this notebook, we start with publicly available [ARCO ERA5](https://github.com/google-research/arco-era5) \"model-level\" data. For convenience, we download a single time step of data and process it with [Metview](https://metview.readthedocs.io/en/latest/) to create a GRIB file with the specific humidity on pressure levels. If extending this to a larger dataset, note that the [`metview.mvl_ml2hPa`](https://metview.readthedocs.io/en/latest/api/functions/mvl_ml2hPa.html#mvl_ml2hPa) function only accepts a single time value."
+    "In this notebook, we start with publicly available [ARCO ERA5](https://github.com/google-research/arco-era5) \"model-level\" data. For convenience, we download a single time step of data and process it with [Metview](https://metview.readthedocs.io/en/latest/) to create a GRIB file with the specific humidity on pressure levels. If extending this to a larger dataset, note that the [metview.mvl_ml2hPa](https://metview.readthedocs.io/en/latest/api/functions/mvl_ml2hPa.html#mvl_ml2hPa) function only accepts a single time value."
    ]
   },
   {

--- a/pycontrails/core/datalib.py
+++ b/pycontrails/core/datalib.py
@@ -35,6 +35,9 @@ DEFAULT_CHUNKS: dict[str, int] = {"time": 1}
 #: Whether to open multi-file datasets in parallel
 OPEN_IN_PARALLEL: bool = False
 
+#: Whether to use file locking when opening multi-file datasets
+OPEN_WITH_LOCK: bool = False
+
 
 def parse_timesteps(time: TimeInput | None, freq: str | None = "1H") -> list[datetime]:
     """Parse time input into set of time steps.
@@ -649,6 +652,7 @@ class MetDataSource(abc.ABC):
                 - chunks: {"time": 1}
                 - engine: "netcdf4"
                 - parallel: False
+                - lock: False
 
         Returns
         -------
@@ -658,4 +662,5 @@ class MetDataSource(abc.ABC):
         xr_kwargs.setdefault("engine", NETCDF_ENGINE)
         xr_kwargs.setdefault("chunks", DEFAULT_CHUNKS)
         xr_kwargs.setdefault("parallel", OPEN_IN_PARALLEL)
+        xr_kwargs.setdefault("lock", OPEN_WITH_LOCK)
         return xr.open_mfdataset(disk_paths, **xr_kwargs)

--- a/pycontrails/core/polygon.py
+++ b/pycontrails/core/polygon.py
@@ -236,9 +236,12 @@ def _contours_to_polygons(
 
 def determine_buffer(longitude: npt.NDArray[np.float_], latitude: npt.NDArray[np.float_]) -> float:
     """Determine the proper buffer size to use when converting to polygons."""
+
+    ndigits = 6
+
     try:
-        d_lon = longitude[1] - longitude[0]
-        d_lat = latitude[1] - latitude[0]
+        d_lon = round(longitude[1] - longitude[0], ndigits)
+        d_lat = round(latitude[1] - latitude[0], ndigits)
     except IndexError as e:
         raise ValueError("Longitude and latitude must each have at least 2 elements.") from e
 
@@ -246,12 +249,12 @@ def determine_buffer(longitude: npt.NDArray[np.float_], latitude: npt.NDArray[np
         warnings.warn(
             "Longitude and latitude are not evenly spaced. Buffer size may be inaccurate."
         )
-    if not np.all(np.diff(longitude) == d_lon):
+    if not np.all(np.diff(longitude).round(ndigits) == d_lon):
         warnings.warn("Longitude is not evenly spaced. Buffer size may be inaccurate.")
-    if not np.all(np.diff(latitude) == d_lat):
+    if not np.all(np.diff(latitude).round(ndigits) == d_lat):
         warnings.warn("Latitude is not evenly spaced. Buffer size may be inaccurate.")
 
-    return min(d_lon, d_lat) / 2
+    return min(d_lon, d_lat) / 2.0
 
 
 def find_multipolygon(
@@ -393,7 +396,7 @@ def _buffer_simplify_iterate(polygon: shapely.Polygon, epsilon: float) -> shapel
     # Values here are somewhat ad hoc: These seem to allow the algorithm to
     # terminate and are not too computationally expensive
     for i in range(1, 11):
-        distance = epsilon * i / 10
+        distance = epsilon * i / 10.0
 
         # Taking the buffer can change the orientation of the contour
         out = polygon.buffer(distance, quad_segs=1)

--- a/pycontrails/core/polygon.py
+++ b/pycontrails/core/polygon.py
@@ -9,7 +9,7 @@ See Also
 from __future__ import annotations
 
 import warnings
-from typing import Any
+from typing import Any, Sequence
 
 import numpy as np
 import numpy.typing as npt
@@ -138,7 +138,7 @@ def _round_polygon(polygon: shapely.Polygon, precision: int) -> shapely.Polygon:
 
 
 def _contours_to_polygons(
-    contours: tuple[npt.NDArray[np.float_], ...],
+    contours: Sequence[npt.NDArray[np.float_]],
     hierarchy: npt.NDArray[np.int_],
     min_area: float,
     convex_hull: bool,
@@ -153,7 +153,7 @@ def _contours_to_polygons(
 
     Parameters
     ----------
-    contours : tuple[npt.NDArray[np.float_], ...]
+    contours : Sequence[npt.NDArray[np.float_]
         The contours output from :func:`cv2.findContours`.
     hierarchy : npt.NDArray[np.int_]
         The hierarchy output from :func:`cv2.findContours`.

--- a/pycontrails/models/humidity_scaling/humidity_scaling.py
+++ b/pycontrails/models/humidity_scaling/humidity_scaling.py
@@ -24,7 +24,11 @@ from pycontrails.utils.types import ArrayLike
 
 def _rhi_over_q(air_temperature: ArrayLike, air_pressure: ArrayLike) -> ArrayLike:
     """Compute the quotient ``RHi / q``."""
-    return air_pressure * (constants.R_v / constants.R_d) / thermo.e_sat_ice(air_temperature)
+
+    # Keep the air_temperature term before the air_pressure term
+    # If these are xr.DataArray, we want the return value to have the same coords
+    # as the temperature. If air_pressure comes first, the coords will be transposed.
+    return (constants.R_v / constants.R_d) / thermo.e_sat_ice(air_temperature) * air_pressure
 
 
 class HumidityScaling(models.Model):

--- a/pycontrails/models/tau_cirrus.py
+++ b/pycontrails/models/tau_cirrus.py
@@ -1,6 +1,6 @@
 """Calculate tau cirrus on Met data."""
 
-import numpy as np
+import dask.array
 import xarray as xr
 
 from pycontrails.core.met import MetDataset
@@ -63,7 +63,7 @@ def tau_cirrus(met: MetDataset) -> xr.DataArray:
         met.data["air_pressure"],
     )
 
-    dz = -np.gradient(geopotential_height, axis=geopotential_height.get_axis_num("level"))
+    dz = -dask.array.gradient(geopotential_height, axis=geopotential_height.get_axis_num("level"))
     dz = xr.DataArray(dz, dims=geopotential_height.dims)
 
     da = beta_e * dz

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,6 @@ dev = [
     "pyarrow>=5.0",
     "pytest>=6.1",
     "pytest-cov>=2.11",
-    "pytest-timeout>=2.1",
     "requests>=2.25",
     "ruff>=0.0.259",
 ]

--- a/tests/unit/test_cocip_grid.py
+++ b/tests/unit/test_cocip_grid.py
@@ -704,12 +704,13 @@ def test_verbose_outputs_formation(instance_params: dict[str, Any], source: MetD
         "true_airspeed",
         "fuel_flow",
         "specific_humidity",
+        "air_temperature",
         "rhi",
         "iwc",
     }
     assert model.params["verbose_outputs_formation"] == expected
 
-    assert len(out) == 10 + 2  # 10 verbose + 2 core (ef, age)
+    assert len(out) == len(expected) + 2  # verbose formation + 2 core (ef, age)
     for var in model.params["verbose_outputs_formation"]:
         assert var in out
 

--- a/tests/unit/test_ecmwf.py
+++ b/tests/unit/test_ecmwf.py
@@ -13,10 +13,6 @@ from pycontrails.core.met_var import AirTemperature, SurfacePressure
 from pycontrails.datalib.ecmwf import ECMWF_VARIABLES, ERA5, HRES
 from pycontrails.datalib.ecmwf.hres import get_forecast_filename
 
-# There is at least one test in this module that occasionally hangs indefinitely.
-# The root cause is a dask threading issue that is not yet resolved.
-pytestmark = pytest.mark.timeout(3)
-
 
 def test_environ_keys() -> None:
     """Test CDS Keys."""

--- a/tests/unit/test_tau_cirrus.py
+++ b/tests/unit/test_tau_cirrus.py
@@ -58,7 +58,7 @@ def test_implementations_close(met_cocip1: MetDataset) -> None:
     assert (da1 <= 2 * da2).all()
 
     # Pin the mean values of each
-    assert da1.mean().item() == 0.01444357167929411
+    assert da1.mean() == 0.01444357167929411
     assert da2.mean().item() == 0.008129739202558994
 
 


### PR DESCRIPTION
### Breaking changes

- By default, call `xr.open_mfdataset` with `lock=False` in the `MetDataSource.open_dataset` method. This helps alleviate a `dask` threading issue similar to [this GitHub issue](https://github.com/pydata/xarray/issues/4406).

### Fixes

- Support `MetDataset` source in the `HistogramMatching` humidity scaling model. Previously only `GeoVectorDataset` sources were explicitly supported.

## Tests

- [x] QC test passes locally (`make test`)
- [x] CI tests pass
