### PR TITLE
Critical bug fix on `correct_fuel_flow` of PS model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 
 # Changelog
 
+## v0.47.3 (unreleased)
+
+### Fixes
+
+- Strengthen `correct_fuel_flow` in the `PSmodel` to account for descent conditions.
+- Clip the denominator computed in `pycontrails.physics.jet.equivalent_fuel_flow_rate_at_cruise`.
+
+### Internals
+
+- Add `FlightPhase` to the `pycontrails` namespace.
+
 ## v0.47.2
 
 ### Features

--- a/pycontrails/__init__.py
+++ b/pycontrails/__init__.py
@@ -33,7 +33,7 @@ except ModuleNotFoundError:
 from pycontrails.core.cache import DiskCacheStore, GCPCacheStore
 from pycontrails.core.datalib import MetDataSource
 from pycontrails.core.fleet import Fleet
-from pycontrails.core.flight import Flight
+from pycontrails.core.flight import Flight, FlightPhase
 from pycontrails.core.fuel import Fuel, HydrogenFuel, JetA, SAFBlend
 from pycontrails.core.met import MetDataArray, MetDataset
 from pycontrails.core.met_var import MetVariable
@@ -54,6 +54,7 @@ __all__ = [
     "DiskCacheStore",
     "Fleet",
     "Flight",
+    "FlightPhase",
     "Fuel",
     "GCPCacheStore",
     "GeoVectorDataset",

--- a/pycontrails/models/ps_model/ps_model.py
+++ b/pycontrails/models/ps_model/ps_model.py
@@ -286,7 +286,7 @@ class PSFlight(AircraftPerformance):
                 mach_num,
                 atyp_param.ff_idle_sls,
                 atyp_param.ff_max_sls,
-                flight_phase
+                flight_phase,
             )
 
         if dt_sec is not None:
@@ -916,7 +916,7 @@ def correct_fuel_flow(
     mach_number: ArrayOrFloat,
     fuel_flow_idle_sls: float,
     fuel_flow_max_sls: float,
-    flight_phase: npt.NDArray[np.uint8] | flight.FlightPhase
+    flight_phase: npt.NDArray[np.uint8] | flight.FlightPhase,
 ) -> ArrayOrFloat:
     r"""Correct fuel mass flow rate to ensure that they are within operational limits.
 
@@ -952,9 +952,9 @@ def correct_fuel_flow(
         mach_number,
     )
 
-    #: Account for descent conditions
-    #: Assume `max_fuel_flow` at descent is not more than 30% of `fuel_flow_max_sls`
-    #: We need this assumption because PTF files are not available in the PS model.
+    # Account for descent conditions
+    # Assume max_fuel_flow at descent is not more than 30% of fuel_flow_max_sls
+    # We need this assumption because PTF files are not available in the PS model.
     descent = flight_phase == flight.FlightPhase.DESCENT
     max_fuel_flow[descent] = 0.3 * fuel_flow_max_sls
     return np.clip(fuel_flow, min_fuel_flow, max_fuel_flow)

--- a/pycontrails/physics/jet.py
+++ b/pycontrails/physics/jet.py
@@ -272,9 +272,9 @@ def equivalent_fuel_flow_rate_at_cruise(
     ----------
     - :cite:`duboisFuelFlowMethod22006`
     """
-    denom = ((theta_amb**3.8 / delta_amb) * np.exp(0.2 * mach_num**2))
-    denom = np.maximum(denom, 1.0)
-    #: denominator must not be < 1, otherwise `corrected_fuel_flow` > `fuel_flow_max_sls`
+    denom = (theta_amb**3.8 / delta_amb) * np.exp(0.2 * mach_num**2)
+    # denominator must be >= 1, otherwise corrected_fuel_flow > fuel_flow_max_sls
+    denom.clip(min=1.0, out=denom)
     return fuel_flow_sls / denom
 
 

--- a/pycontrails/physics/jet.py
+++ b/pycontrails/physics/jet.py
@@ -272,7 +272,10 @@ def equivalent_fuel_flow_rate_at_cruise(
     ----------
     - :cite:`duboisFuelFlowMethod22006`
     """
-    return fuel_flow_sls / ((theta_amb**3.8 / delta_amb) * np.exp(0.2 * mach_num**2))
+    denom = ((theta_amb**3.8 / delta_amb) * np.exp(0.2 * mach_num**2))
+    denom = np.maximum(denom, 1.0)
+    #: denominator must not be < 1, otherwise `corrected_fuel_flow` > `fuel_flow_max_sls`
+    return fuel_flow_sls / denom
 
 
 def minimum_fuel_flow_rate_at_cruise(

--- a/tests/unit/test_ps_model.py
+++ b/tests/unit/test_ps_model.py
@@ -8,7 +8,7 @@ import pytest
 import xarray as xr
 
 import pycontrails.models.ps_model.ps_model as ps
-from pycontrails.core import Flight, GeoVectorDataset, MetDataset
+from pycontrails import Flight, FlightPhase, GeoVectorDataset, MetDataset
 from pycontrails.models.ps_model import PSGrid, ps_nominal_grid
 from pycontrails.physics import jet, units
 
@@ -130,6 +130,7 @@ def test_ps_model() -> None:
         mach_number,
         atyp_param.ff_idle_sls,
         atyp_param.ff_max_sls,
+        FlightPhase.CRUISE,
     )
     np.testing.assert_array_almost_equal(fuel_flow, [0.574, 0.559], decimal=3)
 
@@ -217,6 +218,7 @@ def test_fuel_clipping() -> None:
         mach_num,
         atyp_param.ff_idle_sls,
         atyp_param.ff_max_sls,
+        FlightPhase.CRUISE,
     )
 
     min_fuel_flow = jet.minimum_fuel_flow_rate_at_cruise(atyp_param.ff_idle_sls, altitude_ft)


### PR DESCRIPTION
Closes #XX

## Changes

Resolved bug in the guard rails of the PS model, where the maximum fuel flow at certain conditions could be greater than the maximum fuel flow that can be supplied by the engine. 

#### Breaking changes

#### Features

#### Fixes
- Fix `equivalent_fuel_flow_rate_at_cruise` function in pycontrails.physics.jet
- Strengthen `correct_fuel_flow` in PS model to account for descent conditions, and compensate for the lack of PTF files for the PS model. 

#### Internals

## Tests

- [ ] QC test passes locally (`make test`)
- [ ] CI tests pass

## Reviewer

> Select @ reviewer
