### PR TITLE
Feature/token permissions

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -14,8 +14,9 @@ on:
 env:
   PYCONTRAILS_CACHE_DIR: '${{ github.workspace }}/.cache/pycontrails'
 
+# disable all permissions at the top level
 # https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
-permissions: read-all
+permissions: {}
 
 # This allows a subsequently queued workflow run to interrupt previous runs
 concurrency:
@@ -28,6 +29,7 @@ jobs:
 
     # set from https://github.com/google-github-actions/auth
     permissions:
+      contents: read
       id-token: write
 
     steps:

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -27,11 +27,6 @@ jobs:
   benchmark-test:
     runs-on: ubuntu-latest
 
-    # set from https://github.com/google-github-actions/auth
-    permissions:
-      contents: read
-      id-token: write
-
     steps:
     # https://github.com/easimon/maximize-build-space
     - name: Maximize build space

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -14,6 +14,9 @@ on:
 env:
   PYCONTRAILS_CACHE_DIR: '${{ github.workspace }}/.cache/pycontrails'
 
+# https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
+permissions: read-all
+
 # This allows a subsequently queued workflow run to interrupt previous runs
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
@@ -25,8 +28,7 @@ jobs:
 
     # set from https://github.com/google-github-actions/auth
     permissions:
-      contents: 'read'
-      id-token: 'write'
+      id-token: write
 
     steps:
     # https://github.com/easimon/maximize-build-space

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -18,14 +18,14 @@ on:
 env:
   PYCONTRAILS_CACHE_DIR: '${{ github.workspace }}/.cache/pycontrails'
 
+# disable all permissions at the top level
 # https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
-permissions: read-all
+permissions: {}
 
 # Allow one concurrent deployment
 concurrency:
   group: "pages"
   cancel-in-progress: true
-
 
 jobs:
   build:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -18,6 +18,9 @@ on:
 env:
   PYCONTRAILS_CACHE_DIR: '${{ github.workspace }}/.cache/pycontrails'
 
+# https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
+permissions: read-all
+
 # Allow one concurrent deployment
 concurrency:
   group: "pages"
@@ -85,7 +88,6 @@ jobs:
 
     # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
     permissions:
-      contents: read
       pages: write
       id-token: write
 

--- a/.github/workflows/doctest.yaml
+++ b/.github/workflows/doctest.yaml
@@ -21,10 +21,8 @@ on:
 env:
   PYCONTRAILS_CACHE_DIR: '${{ github.workspace }}/.cache/pycontrails'
 
-# set from https://github.com/google-github-actions/auth
-permissions:
-  contents: read
-  pages: write
+# https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
+permissions: read-all
 
 # This allows a subsequently queued workflow run to interrupt previous runs
 concurrency:
@@ -34,6 +32,10 @@ concurrency:
 jobs:
   doc-test:
     runs-on: ubuntu-latest
+
+    # set from https://github.com/google-github-actions/auth
+    permissions:
+      id-token: write
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/doctest.yaml
+++ b/.github/workflows/doctest.yaml
@@ -34,11 +34,6 @@ jobs:
   doc-test:
     runs-on: ubuntu-latest
 
-    # set from https://github.com/google-github-actions/auth
-    permissions:
-      contents: read
-      id-token: write
-
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/doctest.yaml
+++ b/.github/workflows/doctest.yaml
@@ -21,8 +21,9 @@ on:
 env:
   PYCONTRAILS_CACHE_DIR: '${{ github.workspace }}/.cache/pycontrails'
 
+# disable all permissions at the top level
 # https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
-permissions: read-all
+permissions: {}
 
 # This allows a subsequently queued workflow run to interrupt previous runs
 concurrency:
@@ -35,6 +36,7 @@ jobs:
 
     # set from https://github.com/google-github-actions/auth
     permissions:
+      contents: read
       id-token: write
 
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,8 +9,9 @@ on:
 
   workflow_dispatch:
 
+# disable all permissions at the top level
 # https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
-permissions: read-all
+permissions: {}
 
 jobs:
   check-main-test-status:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,6 +9,9 @@ on:
 
   workflow_dispatch:
 
+# https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
+permissions: read-all
+
 jobs:
   check-main-test-status:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,12 +25,13 @@ env:
   PYCONTRAILS_CACHE_DIR: '${{ github.workspace }}/.cache/pycontrails'
   BADA_CACHE_DIR: '${{ github.workspace }}/.cache/bada/'
 
+# https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
+permissions: read-all
 
 # This allows a subsequently queued workflow run to interrupt previous runs
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
   cancel-in-progress: true
-
 
 jobs:
   unit-test:
@@ -43,8 +44,7 @@ jobs:
 
     # set from https://github.com/google-github-actions/auth
     permissions:
-      contents: 'read'
-      id-token: 'write'
+      id-token: write
 
     steps:
     - uses: actions/checkout@v4
@@ -75,7 +75,7 @@ jobs:
 
     - name: 'Set up Cloud SDK'
       uses: 'google-github-actions/setup-gcloud@v1'
-    
+
     # download BADA files for testing
     - name: BADA files
       run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -43,11 +43,6 @@ jobs:
         pyversion: ['3.9', '3.10', '3.11']
     runs-on: ${{ matrix.os }}
 
-    # set from https://github.com/google-github-actions/auth
-    permissions:
-      contents: read
-      id-token: write
-
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,8 +25,9 @@ env:
   PYCONTRAILS_CACHE_DIR: '${{ github.workspace }}/.cache/pycontrails'
   BADA_CACHE_DIR: '${{ github.workspace }}/.cache/bada/'
 
+# disable all permissions at the top level
 # https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
-permissions: read-all
+permissions: {}
 
 # This allows a subsequently queued workflow run to interrupt previous runs
 concurrency:
@@ -44,6 +45,7 @@ jobs:
 
     # set from https://github.com/google-github-actions/auth
     permissions:
+      contents: read
       id-token: write
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 - Strengthen `correct_fuel_flow` in the `PSmodel` to account for descent conditions.
 - Clip the denominator computed in `pycontrails.physics.jet.equivalent_fuel_flow_rate_at_cruise`.
+- Ensure the token used within GitHub workflows has the fewest privileges required. Set top-level permissions to `none` in each workflow file. Remove unnecessary permissions previously used in the `google-github-actions/auth` action.
 
 ### Internals
 


### PR DESCRIPTION
Ensure the token used within GitHub workflows has the fewest privileges required. Set top-level permissions to `none` in each workflow file. Remove unnecessary permissions previously used in the `google-github-actions/auth` action.
