### PR TITLE
Feature/shift longitude reverse

### DIFF
--- a/pycontrails/core/met.py
+++ b/pycontrails/core/met.py
@@ -2245,7 +2245,6 @@ def shift_longitude(data: XArrayType) -> XArrayType:
     data : XArrayType
         :class:`xr.Dataset` or :class:`xr.DataArray` with longitude dimension
 
-
     Returns
     -------
     XArrayType
@@ -2254,6 +2253,26 @@ def shift_longitude(data: XArrayType) -> XArrayType:
     return data.assign_coords(
         longitude=((data["longitude"].values + 180.0) % 360.0) - 180.0
     ).sortby("longitude", ascending=True)
+
+
+def shift_longitude_reverse(data: XArrayType) -> XArrayType:
+    """Shift longitude values from [-180, 180) to [0, 360) domain.
+
+    Sorts data by ascending longitude values.
+
+    Parameters
+    ----------
+    data : XArrayType
+        :class:`xr.Dataset` or :class:`xr.DataArray` with longitude dimension
+
+    Returns
+    -------
+    XArrayType
+        :class:`xr.Dataset` or :class:`xr.DataArray` with longitude values on [0, 360).
+    """
+    return data.assign_coords(longitude=(data["longitude"].values + 360.0) % 360.0).sortby(
+        "longitude", ascending=True
+    )
 
 
 def _wrap_longitude(data: XArrayType) -> XArrayType:

--- a/pycontrails/core/met.py
+++ b/pycontrails/core/met.py
@@ -2235,44 +2235,30 @@ def _is_zarr(ds: xr.Dataset | xr.DataArray) -> bool:
     return dask0.array.array.array.__class__.__name__ == "ZarrArrayWrapper"
 
 
-def shift_longitude(data: XArrayType) -> XArrayType:
-    """Shift longitude values from [0, 360) to [-180, 180) domain.
+def shift_longitude(data: XArrayType, bound: float = -180.0) -> XArrayType:
+    """Shift longitude values from any input domain to [bound, 360 + bound) domain.
 
     Sorts data by ascending longitude values.
+
 
     Parameters
     ----------
     data : XArrayType
         :class:`xr.Dataset` or :class:`xr.DataArray` with longitude dimension
+    bound : float, optional
+        Lower bound of the domain.
+        Output domain will be [bound, 360 + bound).
+        Defaults to -180, which results in longitude domain [-180, 180).
+
 
     Returns
     -------
     XArrayType
-        :class:`xr.Dataset` or :class:`xr.DataArray` with longitude values on [-180, 180).
+        :class:`xr.Dataset` or :class:`xr.DataArray` with longitude values on [a, 360 + a).
     """
     return data.assign_coords(
-        longitude=((data["longitude"].values + 180.0) % 360.0) - 180.0
+        longitude=((data["longitude"].values - bound) % 360.0) + bound
     ).sortby("longitude", ascending=True)
-
-
-def shift_longitude_reverse(data: XArrayType) -> XArrayType:
-    """Shift longitude values from [-180, 180) to [0, 360) domain.
-
-    Sorts data by ascending longitude values.
-
-    Parameters
-    ----------
-    data : XArrayType
-        :class:`xr.Dataset` or :class:`xr.DataArray` with longitude dimension
-
-    Returns
-    -------
-    XArrayType
-        :class:`xr.Dataset` or :class:`xr.DataArray` with longitude values on [0, 360).
-    """
-    return data.assign_coords(longitude=(data["longitude"].values + 360.0) % 360.0).sortby(
-        "longitude", ascending=True
-    )
 
 
 def _wrap_longitude(data: XArrayType) -> XArrayType:


### PR DESCRIPTION
## Changes

This is a tiny old branch for a small utility function. I added some test so we make sure to get this into the library.

#### Breaking changes

#### Features

- Adds `met.shift_longitude_reverse` function to translate longitude coordinates from [180, 180) -> [0, 360) domain

#### Fixes

#### Internals

## Tests

- [x] QC test passes locally (`make test`)
- [ ] CI tests pass

## Reviewer


