### PR TITLE
Feature/build system numpy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 
 # Changelog
 
-## v0.49.1 (unreleased)
+## v0.49.1
 
 ### Fixes
 
 - Fix memory bottleneck in `CocipGrid` simulation by avoiding expensive call to `pd.concat`.
+- Require `oldest-supported-numpy` for python 3.12. Remove logic for `numpy` 1.26.0rc1 in the `pyproject.toml` build system.
 
 ## v0.49.0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,7 @@ requires = [
     "setuptools_scm",
     "wheel",
     "cython",
-    "oldest-supported-numpy; python_version<'3.12'",
-    "numpy>=1.26.0rc1; python_version>='3.12'",
+    "oldest-supported-numpy",
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
#### Fixes

- Require `oldest-supported-numpy` for python 3.12. Remove logic for `numpy` 1.26.0rc1 in the `pyproject.toml` build system.

## Tests

- [x] QC test passes locally (`make test`)
- [x] CI tests pass

## Reviewer

@nickmasson 
