### PR TITLE
Bugfix/vector subclass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 
 # Changelog
 
+## 0.49.2
+
+### Internals
+
+- Make `Fuel` and its subclasses `JetA`, `SAFBlend`, and `HydrogenFuel` frozen.
+
 ## v0.49.1
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
 
 # Changelog
 
-## 0.49.2
+## 0.49.2 (unreleased)
+
+### Fixes
+
+- Ensure the `Flight.fuel` attribute is preserved for the `Flight.filter` method.
+- Ensure the `Fleet.fl_attrs` attribute is preserved for the `Fleet.filter` method.
+- Raise `ValueError` when `Flight.sort` or `Fleet.sort` is called. Both of these subclasses assume a custom sorting order that is enforced in their constructors.
 
 ### Internals
 

--- a/pycontrails/core/fleet.py
+++ b/pycontrails/core/fleet.py
@@ -127,7 +127,7 @@ class Fleet(Flight):
         return super().copy(**kwargs)
 
     @overrides
-    def filter(self, mask: npt.NDArray[np.bool_], copy: bool = True, **kwargs: Any) -> Flight:
+    def filter(self, mask: npt.NDArray[np.bool_], copy: bool = True, **kwargs: Any) -> Fleet:
         kwargs.setdefault("fuel", self.fuel)
         kwargs.setdefault("fl_attrs", self.fl_attrs)
         return super().filter(mask, copy=copy, **kwargs)

--- a/pycontrails/core/fleet.py
+++ b/pycontrails/core/fleet.py
@@ -129,7 +129,11 @@ class Fleet(Flight):
     @overrides
     def filter(self, mask: npt.NDArray[np.bool_], copy: bool = True, **kwargs: Any) -> Fleet:
         kwargs.setdefault("fuel", self.fuel)
-        kwargs.setdefault("fl_attrs", self.fl_attrs)
+
+        flight_ids = set(np.unique(self["flight_id"][mask]))
+        fl_attrs = {k: v for k, v in self.fl_attrs.items() if k in flight_ids}
+        kwargs.setdefault("fl_attrs", fl_attrs)
+
         return super().filter(mask, copy=copy, **kwargs)
 
     @overrides

--- a/pycontrails/core/fleet.py
+++ b/pycontrails/core/fleet.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
-from typing import Any
+from typing import Any, NoReturn
 
 import numpy as np
 import numpy.typing as npt
@@ -121,14 +121,24 @@ class Fleet(Flight):
         return final_waypoints, fl_attrs
 
     @overrides
-    def copy(self) -> Fleet:
-        return type(self)(
-            data=self.data,
-            attrs=self.attrs,
-            fuel=self.fuel,
-            copy=True,
-            fl_attrs=self.fl_attrs,
+    def copy(self, **kwargs: Any) -> Fleet:
+        kwargs.setdefault("fuel", self.fuel)
+        kwargs.setdefault("fl_attrs", self.fl_attrs)
+        return super().copy(**kwargs)
+
+    @overrides
+    def filter(self, mask: npt.NDArray[np.bool_], copy: bool = True, **kwargs: Any) -> Flight:
+        kwargs.setdefault("fuel", self.fuel)
+        kwargs.setdefault("fl_attrs", self.fl_attrs)
+        return super().filter(mask, copy=copy, **kwargs)
+
+    @overrides
+    def sort(self, by: str | list[str]) -> NoReturn:
+        msg = (
+            "Fleet.sort is not implemented. A Fleet instance must be sorted "
+            "by 'flight_id' and 'time'."
         )
+        raise ValueError(msg)
 
     @classmethod
     def from_seq(

--- a/pycontrails/core/fleet.py
+++ b/pycontrails/core/fleet.py
@@ -98,7 +98,7 @@ class Fleet(Flight):
         if not np.array_equal(expected_size, actual_size):
             msg = (
                 "Fleet must have contiguous waypoint blocks with constant flight_id. "
-                "If instantiating from a DataFrame, call df.sort(['flight_id', 'time']) "
+                "If instantiating from a DataFrame, call df.sort_values(by=['flight_id', 'time']) "
                 "before passing to Fleet."
             )
             raise ValueError(msg)
@@ -140,7 +140,9 @@ class Fleet(Flight):
     def sort(self, by: str | list[str]) -> NoReturn:
         msg = (
             "Fleet.sort is not implemented. A Fleet instance must be sorted "
-            "by 'flight_id' and 'time'."
+            "by ['flight_id', 'time'] (this is enforced in Fleet._validate). "
+            "To force sorting, create a GeoVectorDataset instance "
+            "and call the 'sort' method."
         )
         raise ValueError(msg)
 

--- a/pycontrails/core/flight.py
+++ b/pycontrails/core/flight.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import enum
 import logging
 import warnings
-from typing import TYPE_CHECKING, Any, NoReturn
+from typing import TYPE_CHECKING, Any, NoReturn, TypeVar
 
 import numpy as np
 import numpy.typing as npt
@@ -19,6 +19,8 @@ from pycontrails.physics import constants, geo, units
 from pycontrails.utils import dependencies
 
 logger = logging.getLogger(__name__)
+
+FlightType = TypeVar("FlightType", bound="Flight")
 
 # optional imports
 if TYPE_CHECKING:
@@ -279,12 +281,14 @@ class Flight(GeoVectorDataset):
                 )
 
     @overrides
-    def copy(self, **kwargs: Any) -> Flight:
+    def copy(self: FlightType, **kwargs: Any) -> FlightType:
         kwargs.setdefault("fuel", self.fuel)
         return super().copy(**kwargs)
 
     @overrides
-    def filter(self, mask: npt.NDArray[np.bool_], copy: bool = True, **kwargs: Any) -> Flight:
+    def filter(
+        self: FlightType, mask: npt.NDArray[np.bool_], copy: bool = True, **kwargs: Any
+    ) -> FlightType:
         kwargs.setdefault("fuel", self.fuel)
         return super().filter(mask, copy=copy, **kwargs)
 

--- a/pycontrails/core/flight.py
+++ b/pycontrails/core/flight.py
@@ -294,7 +294,11 @@ class Flight(GeoVectorDataset):
 
     @overrides
     def sort(self, by: str | list[str]) -> NoReturn:
-        msg = "Flight.sort is not implemented. A Flight instance must be sorted by 'time'."
+        msg = (
+            "Flight.sort is not implemented. A Flight instance is automatically sorted "
+            "by 'time' on creation. To force sorting, create a GeoVectorDataset instance "
+            "and call the 'sort' method."
+        )
         raise ValueError(msg)
 
     @property

--- a/pycontrails/core/fuel.py
+++ b/pycontrails/core/fuel.py
@@ -7,7 +7,7 @@ import dataclasses
 import numpy as np
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class Fuel:
     """Base class for the physical parameters of the fuel."""
 
@@ -36,7 +36,7 @@ class Fuel:
     ei_oc: float
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class JetA(Fuel):
     """Jet A-1 Fuel.
 
@@ -97,20 +97,31 @@ class SAFBlend(Fuel):
 
         self.pct_blend = pct_blend
 
-        self.fuel_name = "Jet A-1 / Sustainable Aviation Fuel Blend"
+        fuel_name = "Jet A-1 / Sustainable Aviation Fuel Blend"
 
         # We take the default values for Jet-A and modify them for a custom blend
         base_fuel = JetA()
-        self.q_fuel = base_fuel.q_fuel + (10700.0 * self.pct_blend)
-        self.hydrogen_content = base_fuel.hydrogen_content + 0.015 * self.pct_blend
-        self.ei_co2 = base_fuel.ei_co2
-        self.ei_h2o = base_fuel.ei_h2o * (self.hydrogen_content / base_fuel.hydrogen_content)
-        self.ei_so2 = base_fuel.ei_so2 * (1.0 - self.pct_blend / 100.0)
-        self.ei_sulphates = self.ei_so2 / 0.98 * 0.02
-        self.ei_oc = base_fuel.ei_oc
+        q_fuel = base_fuel.q_fuel + (10700.0 * self.pct_blend)
+        hydrogen_content = base_fuel.hydrogen_content + 0.015 * self.pct_blend
+        ei_co2 = base_fuel.ei_co2
+        ei_h2o = base_fuel.ei_h2o * (hydrogen_content / base_fuel.hydrogen_content)
+        ei_so2 = base_fuel.ei_so2 * (1.0 - self.pct_blend / 100.0)
+        ei_sulphates = ei_so2 / 0.98 * 0.02
+        ei_oc = base_fuel.ei_oc
+
+        super().__init__(
+            fuel_name=fuel_name,
+            q_fuel=q_fuel,
+            hydrogen_content=hydrogen_content,
+            ei_co2=ei_co2,
+            ei_h2o=ei_h2o,
+            ei_so2=ei_so2,
+            ei_sulphates=ei_sulphates,
+            ei_oc=ei_oc,
+        )
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class HydrogenFuel(Fuel):
     """Hydrogen Fuel.
 

--- a/pycontrails/core/vector.py
+++ b/pycontrails/core/vector.py
@@ -763,15 +763,20 @@ class VectorDataset:
     # Utilities
     # ------------
 
-    def copy(self: VectorDatasetType) -> VectorDatasetType:
+    def copy(self: VectorDatasetType, **kwargs: Any) -> VectorDatasetType:
         """Return a copy of this VectorDatasetType class.
+
+        Parameters
+        ----------
+        **kwargs : Any
+            Additional keyword arguments passed into the constructor of the returned class.
 
         Returns
         -------
         VectorDatasetType
             Copy of class
         """
-        return type(self)(data=self.data, attrs=self.attrs, copy=True)
+        return type(self)(data=self.data, attrs=self.attrs, copy=True, **kwargs)
 
     def select(self: VectorDataset, keys: Iterable[str], copy: bool = True) -> VectorDataset:
         """Return new class instance only containing specified keys.
@@ -795,7 +800,7 @@ class VectorDataset:
         return VectorDataset(data=data, attrs=self.attrs, copy=copy)
 
     def filter(
-        self: VectorDatasetType, mask: npt.NDArray[np.bool_], copy: bool = True
+        self: VectorDatasetType, mask: npt.NDArray[np.bool_], copy: bool = True, **kwargs: Any
     ) -> VectorDatasetType:
         """Filter :attr:`data` according to a boolean array ``mask``.
 
@@ -809,6 +814,8 @@ class VectorDataset:
             Copy data on filter. Defaults to True. See
             `numpy best practices <https://numpy.org/doc/stable/user/basics.indexing.html#slicing-and-striding>`_
             for insight into whether copy is appropriate.
+        **kwargs : Any
+            Additional keyword arguments passed into the constructor of the returned class.
 
         Returns
         -------
@@ -825,12 +832,13 @@ class VectorDataset:
             raise TypeError("Parameter `mask` must be a boolean array.")
 
         data = {key: value[mask] for key, value in self.data.items()}
-        return type(self)(data=data, attrs=self.attrs, copy=copy)
+        return type(self)(data=data, attrs=self.attrs, copy=copy, **kwargs)
 
     def sort(self: VectorDatasetType, by: str | list[str]) -> VectorDatasetType:
         """Sort data by key(s).
 
-        This method always creates a copy of the data.
+        This method always creates a copy of the data by calling
+        :meth:`pandas.DataFrame.sort_values`.
 
         Parameters
         ----------
@@ -842,7 +850,7 @@ class VectorDataset:
         VectorDatasetType
             Instance with sorted data.
         """
-        return type(self)(data=self.dataframe.sort_values(by=by), attrs=self.attrs)
+        return type(self)(data=self.dataframe.sort_values(by=by), attrs=self.attrs, copy=False)
 
     def ensure_vars(self, vars: str | Iterable[str], raise_error: bool = True) -> bool:
         """Ensure variables exist in column of :attr:`data` or :attr:`attrs`.

--- a/pycontrails/datalib/ecmwf/hres.py
+++ b/pycontrails/datalib/ecmwf/hres.py
@@ -342,9 +342,9 @@ class HRES(ECMWFAPI):
         list[tuple[pd.Timestamp, pd.Timestamp]]
             List of tuple time bounds that can be used as inputs to :class:`HRES(time=...)`
         """
-        time_ranges = np.unique([
-            pd.Timestamp(t.year, t.month, t.day, 12 * (t.hour // 12)) for t in timesteps
-        ])
+        time_ranges = np.unique(
+            [pd.Timestamp(t.year, t.month, t.day, 12 * (t.hour // 12)) for t in timesteps]
+        )
 
         if len(time_ranges) == 1:
             time_ranges = [(timesteps[0], timesteps[-1])]

--- a/pycontrails/datalib/ecmwf/ifs.py
+++ b/pycontrails/datalib/ecmwf/ifs.py
@@ -167,9 +167,9 @@ class IFS(datalib.MetDataSource):
             ds["z"] = self._calc_geopotential(ds)
 
         # take the mean of the air pressure to create quasi-gridded level coordinate
-        ds = ds.assign_coords({
-            "level": ("lev", (ds["air_pressure"].mean(dim=["time", "lat", "lon"]) / 100).values)
-        })
+        ds = ds.assign_coords(
+            {"level": ("lev", (ds["air_pressure"].mean(dim=["time", "lat", "lon"]) / 100).values)}
+        )
         ds = ds.swap_dims({"lev": "level"})
         ds = ds.drop_vars(names=["lev"])
 

--- a/pycontrails/datalib/spire/spire.py
+++ b/pycontrails/datalib/spire/spire.py
@@ -198,19 +198,17 @@ def identify_flights(messages: pd.DataFrame) -> pd.Series:
         index=messages.index,
     )
 
-    for idx, gp in messages[
-        [
-            "icao_address",
-            "tail_number",
-            "aircraft_type_icao",
-            "callsign",
-            "timestamp",
-            "longitude",
-            "latitude",
-            "altitude_baro",
-            "on_ground",
-        ]
-    ].groupby(["icao_address", "tail_number", "aircraft_type_icao", "callsign"], sort=False):
+    for idx, gp in messages[[
+        "icao_address",
+        "tail_number",
+        "aircraft_type_icao",
+        "callsign",
+        "timestamp",
+        "longitude",
+        "latitude",
+        "altitude_baro",
+        "on_ground",
+    ]].groupby(["icao_address", "tail_number", "aircraft_type_icao", "callsign"], sort=False):
         # minimum # of messages > TRAJECTORY_MINIMUM_MESSAGES
         if len(gp) < TRAJECTORY_MINIMUM_MESSAGES:
             logger.debug(f"Message {idx} group too small to create flight ids")
@@ -544,16 +542,14 @@ def validate_flights(messages: pd.DataFrame) -> pd.Series:
         index=messages.index,
     )
 
-    for _, gp in messages[
-        [
-            "flight_id",
-            "aircraft_type_icao",
-            "timestamp",
-            "altitude_baro",
-            "on_ground",
-            "speed",
-        ]
-    ].groupby("flight_id", sort=False):
+    for _, gp in messages[[
+        "flight_id",
+        "aircraft_type_icao",
+        "timestamp",
+        "altitude_baro",
+        "on_ground",
+        "speed",
+    ]].groupby("flight_id", sort=False):
         # save flight ids
         valid.loc[gp.index] = is_valid_trajectory(gp)
 

--- a/pycontrails/models/cocip/output_formats.py
+++ b/pycontrails/models/cocip/output_formats.py
@@ -294,18 +294,16 @@ def longitude_latitude_grid(
     """
     # Ensure the required columns are included in `flight_waypoints`, `contrails` and `met`
     flight_waypoints.ensure_vars(("segment_length", "ef"))
-    contrails.ensure_vars(
-        (
-            "formation_time",
-            "segment_length",
-            "width",
-            "tau_contrail",
-            "rf_sw",
-            "rf_lw",
-            "rf_net",
-            "ef",
-        )
-    )
+    contrails.ensure_vars((
+        "formation_time",
+        "segment_length",
+        "width",
+        "tau_contrail",
+        "rf_sw",
+        "rf_lw",
+        "rf_net",
+        "ef",
+    ))
     met.ensure_vars(
         ("air_temperature", "specific_humidity", "specific_cloud_ice_water_content", "geopotential")
     )
@@ -862,39 +860,35 @@ def time_slice_statistics(
     - ``mean_albedo_at_contrail_wypts``, [dimensionless]
     """
     # Ensure the required columns are included in `flight_waypoints`, `contrails`, `met` and `rad`
-    flight_waypoints.ensure_vars(
-        (
-            "flight_id",
-            "segment_length",
-            "true_airspeed",
-            "fuel_flow",
-            "engine_efficiency",
-            "nvpm_ei_n",
-            "sac",
-            "persistent_1",
-        )
-    )
-    contrails.ensure_vars(
-        (
-            "flight_id",
-            "segment_length",
-            "air_temperature",
-            "iwc",
-            "r_ice_vol",
-            "n_ice_per_m",
-            "tau_contrail",
-            "tau_cirrus",
-            "width",
-            "area_eff",
-            "sdr",
-            "rsr",
-            "olr",
-            "rf_sw",
-            "rf_lw",
-            "rf_net",
-            "ef",
-        )
-    )
+    flight_waypoints.ensure_vars((
+        "flight_id",
+        "segment_length",
+        "true_airspeed",
+        "fuel_flow",
+        "engine_efficiency",
+        "nvpm_ei_n",
+        "sac",
+        "persistent_1",
+    ))
+    contrails.ensure_vars((
+        "flight_id",
+        "segment_length",
+        "air_temperature",
+        "iwc",
+        "r_ice_vol",
+        "n_ice_per_m",
+        "tau_contrail",
+        "tau_cirrus",
+        "width",
+        "area_eff",
+        "sdr",
+        "rsr",
+        "olr",
+        "rf_sw",
+        "rf_lw",
+        "rf_net",
+        "ef",
+    ))
 
     # Ensure that the waypoints are within `t_start` and `t_end`
     is_in_time = flight_waypoints.dataframe["time"].between(t_start, t_end, inclusive="right")
@@ -929,14 +923,12 @@ def time_slice_statistics(
 
     # Meteorology domain statistics
     if met is not None:
-        met.ensure_vars(
-            (
-                "air_temperature",
-                "specific_humidity",
-                "specific_cloud_ice_water_content",
-                "geopotential",
-            )
-        )
+        met.ensure_vars((
+            "air_temperature",
+            "specific_humidity",
+            "specific_cloud_ice_water_content",
+            "geopotential",
+        ))
         met = met.downselect(spatial_bbox)
         met_stats = meteorological_time_slice_statistics(t_end, contrails, met, humidity_scaling)
 
@@ -1936,15 +1928,13 @@ def natural_cirrus_properties_to_hi_res_grid(
         relatively narrow contrails.
     """
     # Ensure the required columns are included in `met`
-    met.ensure_vars(
-        (
-            "air_temperature",
-            "specific_humidity",
-            "specific_cloud_ice_water_content",
-            "geopotential",
-            "fraction_of_cloud_cover",
-        )
-    )
+    met.ensure_vars((
+        "air_temperature",
+        "specific_humidity",
+        "specific_cloud_ice_water_content",
+        "geopotential",
+        "fraction_of_cloud_cover",
+    ))
 
     # Ensure `met` only contains one time step, constraint can be relaxed in the future.
     if len(met["time"].data) > 1:

--- a/pycontrails/models/cocip/radiative_forcing.py
+++ b/pycontrails/models/cocip/radiative_forcing.py
@@ -72,9 +72,9 @@ class RFConstants:
 
     #: Approximate the effective emmissivity factor
     #: :math:`\delta_{\tau} in :cite:`schumannParametricRadiativeForcing2012`
-    delta_t = np.array([
-        0.940846, 0.808397, 0.736222, 0.675591, 0.748757, 0.708515, 0.927592, 0.795527
-    ])
+    delta_t = np.array(
+        [0.940846, 0.808397, 0.736222, 0.675591, 0.748757, 0.708515, 0.927592, 0.795527]
+    )
 
     #: Effective radius scaling factor for optical properties (extinction relative to scattering)
     #: :math:`\delta_{lr} in Eq. (3) in :cite:`schumannParametricRadiativeForcing2012`
@@ -83,9 +83,9 @@ class RFConstants:
     #: Optical depth scaling factor for reduction of the OLR at the contrail level due
     #: to existing cirrus above the contrail
     #: :math:`\delta_{lc} in Eq. (4) in :cite:`schumannParametricRadiativeForcing2012`
-    delta_lc = np.array([
-        0.159942, 0.0958129, 0.0924850, 0.0462023, 0.132925, 0.0870067, 0.0626339, 0.0665289
-    ])
+    delta_lc = np.array(
+        [0.159942, 0.0958129, 0.0924850, 0.0462023, 0.132925, 0.0870067, 0.0626339, 0.0665289]
+    )
 
     # -----
     # Variables/coefficients used to calculate the local contrail shortwave radiative forcing.
@@ -97,21 +97,21 @@ class RFConstants:
 
     # Approximates the albedo of the contrail
     #: :math:`A_{\mu}` in Eq. (6) in :cite:`schumannParametricRadiativeForcing2012`
-    A_mu = np.array([
-        0.361226, 0.294072, 0.343894, 0.317866, 0.337227, 0.310978, 0.342593, 0.269179
-    ])
+    A_mu = np.array(
+        [0.361226, 0.294072, 0.343894, 0.317866, 0.337227, 0.310978, 0.342593, 0.269179]
+    )
 
     # Approximates the albedo of the contrail
     #: :math:`C_{\mu}` in Eq. (6) in :cite:`schumannParametricRadiativeForcing2012`
-    C_mu = np.array([
-        0.709300, 0.678016, 0.687546, 0.675315, 0.712041, 0.713317, 0.660267, 0.545716
-    ])
+    C_mu = np.array(
+        [0.709300, 0.678016, 0.687546, 0.675315, 0.712041, 0.713317, 0.660267, 0.545716]
+    )
 
     #: Approximates the effective contrail optical depth
     #: :math:`delta_sr` in Eq. (7) and (8) in :cite:`schumannParametricRadiativeForcing2012`
-    delta_sr = np.array([
-        0.149851, 0.0254270, 0.0238836, 0.0463724, 0.0478892, 0.0700234, 0.0517942, 0
-    ])
+    delta_sr = np.array(
+        [0.149851, 0.0254270, 0.0238836, 0.0463724, 0.0478892, 0.0700234, 0.0517942, 0]
+    )
 
     #: Approximates the effective contrail optical depth
     #: :math:`F_r` in Eq. (7) and (8) in :cite:`schumannParametricRadiativeForcing2012`
@@ -119,15 +119,15 @@ class RFConstants:
 
     #: Approximates the contrail reflectances
     #: :math:`\gamma` in Eq. (9) in :cite:`schumannParametricRadiativeForcing2012`
-    gamma_lower = np.array([
-        0.323166, 0.392598, 0.356189, 0.345040, 0.407515, 0.523604, 0.310853, 0.274741
-    ])
+    gamma_lower = np.array(
+        [0.323166, 0.392598, 0.356189, 0.345040, 0.407515, 0.523604, 0.310853, 0.274741]
+    )
 
     #: Approximates the contrail reflectances
     #: :math:`\Gamma` in Eq. (9) in :cite:`schumannParametricRadiativeForcing2012`
-    gamma_upper = np.array([
-        0.241507, 0.347023, 0.288452, 0.296813, 0.327857, 0.437560, 0.274710, 0.208154
-    ])
+    gamma_upper = np.array(
+        [0.241507, 0.347023, 0.288452, 0.296813, 0.327857, 0.437560, 0.274710, 0.208154]
+    )
 
     #: Approximate the SZA-dependent contrail sideward scattering
     #: :math:`B_{\mu}` in Eq. (10) in :cite:`schumannParametricRadiativeForcing2012`
@@ -135,15 +135,15 @@ class RFConstants:
 
     #: Account for the optical depth of natural cirrus above the contrail
     #: :math:`\delta_{sc}` in Eq. (11) in :cite:`schumannParametricRadiativeForcing2012`
-    delta_sc = np.array([
-        0.157017, 0.143274, 0.167995, 0.148547, 0.173036, 0.162442, 0.171855, 0.213488
-    ])
+    delta_sc = np.array(
+        [0.157017, 0.143274, 0.167995, 0.148547, 0.173036, 0.162442, 0.171855, 0.213488]
+    )
 
     #: Account for the optical depth of natural cirrus above the contrail
     # :math:`\delta'_{sc}` in Eq. (11) in :cite:`schumannParametricRadiativeForcing2012`
-    delta_sc_aps = np.array([
-        0.229574, 0.197611, 0.245036, 0.204875, 0.248328, 0.254029, 0.244051, 0.302246
-    ])
+    delta_sc_aps = np.array(
+        [0.229574, 0.197611, 0.245036, 0.204875, 0.248328, 0.254029, 0.244051, 0.302246]
+    )
 
 
 # create a new constants class to use within module

--- a/pycontrails/models/emissions/emissions.py
+++ b/pycontrails/models/emissions/emissions.py
@@ -917,9 +917,9 @@ def get_thrust_setting(
 
 
 def _row_to_edb_gaseous(tup: Any) -> tuple[str, EDBGaseous]:
-    return tup.engine_uid, EDBGaseous(**{
-        k.name: getattr(tup, k.name) for k in dataclasses.fields(EDBGaseous)
-    })
+    return tup.engine_uid, EDBGaseous(
+        **{k.name: getattr(tup, k.name) for k in dataclasses.fields(EDBGaseous)}
+    )
 
 
 @dataclasses.dataclass(frozen=True)
@@ -1082,9 +1082,9 @@ class EDBGaseous:
 
 
 def _row_to_edb_nvpm(tup: Any) -> tuple[str, EDBnvpm]:
-    return tup.engine_uid, EDBnvpm(**{
-        k.name: getattr(tup, k.name) for k in dataclasses.fields(EDBnvpm)
-    })
+    return tup.engine_uid, EDBnvpm(
+        **{k.name: getattr(tup, k.name) for k in dataclasses.fields(EDBnvpm)}
+    )
 
 
 @dataclasses.dataclass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ complete = ["pycontrails[ecmwf,gcp,gfs,goes,jupyter,pwlf,pyproj,vis,zarr]"]
 
 # Development dependencies
 dev = [
-    "black[jupyter]>=23.11",
+    "black[jupyter]>=23.12",
     "dep_license",
     "fastparquet>=0.8",
     "ipdb>=0.13",

--- a/tests/unit/test_datalib.py
+++ b/tests/unit/test_datalib.py
@@ -32,9 +32,9 @@ def test_parse_timesteps() -> None:
 
     # throw ValueError for length > 2
     with pytest.raises(ValueError, match="Input time bounds must have length"):
-        datalib.parse_timesteps([
-            datetime(2019, 5, 31, 0), datetime(2019, 5, 31, 0), datetime(2019, 5, 31, 0)
-        ])
+        datalib.parse_timesteps(
+            [datetime(2019, 5, 31, 0), datetime(2019, 5, 31, 0), datetime(2019, 5, 31, 0)]
+        )
 
     # accept (start, end)
     ts = datalib.parse_timesteps((datetime(2019, 5, 31, 0), datetime(2019, 5, 31, 3)))

--- a/tests/unit/test_fleet.py
+++ b/tests/unit/test_fleet.py
@@ -270,4 +270,21 @@ def test_method_preserves_fuel_fl_attrs(syn: SyntheticFlight, method: str) -> No
     assert out.fuel is fleet.fuel
 
     assert hasattr(out, "fl_attrs")
-    assert out.fl_attrs is fleet.fl_attrs
+    assert out.fl_attrs == fleet.fl_attrs
+
+
+def test_fleet_filter_removes_flight(syn: SyntheticFlight) -> None:
+    """Ensure fl attributes are removed when Fleet.filter removes a entire flight."""
+
+    fls = [syn() for _ in range(5)]
+    fleet = Fleet.from_seq(fls)
+    assert fleet.n_flights == 5
+
+    id0 = fls[0].attrs["flight_id"]
+    mask = fleet["flight_id"] != id0
+    out = fleet.filter(mask)
+    assert isinstance(out, Fleet)
+
+    assert out.n_flights == 4
+    assert id0 not in out.fl_attrs
+    assert list(out.fl_attrs) == [fl.attrs["flight_id"] for fl in fls[1:]]

--- a/tests/unit/test_met.py
+++ b/tests/unit/test_met.py
@@ -67,9 +67,9 @@ def test_sl_path_to_met(met_ecmwf_sl_path: str) -> None:
 def test_pl_path_to_met(met_ecmwf_pl_path: str) -> None:
     """Confirm `MetDataset` constructor converts `Dataset` with correct conventions."""
     ds = xr.open_dataset(met_ecmwf_pl_path)
-    assert set(ds.variables).issubset({
-        "longitude", "latitude", "level", "time", "t", "r", "q", "ciwc"
-    })
+    assert set(ds.variables).issubset(
+        {"longitude", "latitude", "level", "time", "t", "r", "q", "ciwc"}
+    )
     assert list(ds.data_vars) == ["t", "r", "q", "ciwc"]
 
     mds = MetDataset(ds)

--- a/tests/unit/test_ps_model.py
+++ b/tests/unit/test_ps_model.py
@@ -446,7 +446,7 @@ def test_ps_grid_met_source(met_era5_fake: MetDataset) -> None:
     assert isinstance(out, MetDataset)
 
     ds = out.data
-    assert ds.dims == met_era5_fake.data.dims
+    assert list(ds.dims) == list(met_era5_fake.data.dims)
     assert list(ds) == ["aircraft_mass", "engine_efficiency", "fuel_flow"]
 
     # Pin some output values


### PR DESCRIPTION
This PR fixes a few small bugs.

### Fixes

- Ensure the `Flight.fuel` attribute is preserved for the `Flight.filter` method.
- Ensure the `Fleet.fl_attrs` attribute is preserved for the `Fleet.filter` method.
- Raise `ValueError` when `Flight.sort` or `Fleet.sort` is called. Both of these subclasses assume a custom sorting order that is enforced in their constructors.

### Internals

- Make `Fuel` and its subclasses `JetA`, `SAFBlend`, and `HydrogenFuel` frozen.

## Tests

- [x] QC test passes locally (`make test`)
- [x] CI tests pass

@nickmasson -- FYI, I think this is independent of our API work.
