### PR TITLE
Correct thrust coefficients in PSGrid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Ensure the `Flight.fuel` attribute is preserved for the `Flight.filter` method.
 - Ensure the `Fleet.fl_attrs` attribute is preserved for the `Fleet.filter` method.
 - Raise `ValueError` when `Flight.sort` or `Fleet.sort` is called. Both of these subclasses assume a custom sorting order that is enforced in their constructors.
+- Always correct intermediate thrust coefficients computed in the `PSGrid` model. This correction is already enabled by default in the `PSFlight` model.
 
 ### Internals
 

--- a/pycontrails/__init__.py
+++ b/pycontrails/__init__.py
@@ -18,6 +18,7 @@ limitations under the License.
 
 from __future__ import annotations
 
+import contextlib
 import logging
 from importlib import metadata
 
@@ -25,10 +26,8 @@ import dask.config
 
 # Work around for https://github.com/pydata/xarray/issues/7259
 # Only occurs for xarray 2022.11 and above
-try:
+with contextlib.suppress(ImportError):
     import netCDF4  # noqa: F401
-except ImportError:
-    pass
 
 from pycontrails.core.cache import DiskCacheStore, GCPCacheStore
 from pycontrails.core.datalib import MetDataSource

--- a/pycontrails/core/met.py
+++ b/pycontrails/core/met.py
@@ -1738,7 +1738,8 @@ class MetDataArray(MetBase):
         # load data into memory (required for value assignment in _edges()
         self.data.load()
 
-        return MetDataArray(self.data.groupby("level").map(_edges), cachestore=self.cachestore)
+        data = self.data.groupby("level", squeeze=False).map(_edges)
+        return MetDataArray(data, cachestore=self.cachestore)
 
     def to_polygon_feature(
         self,

--- a/pycontrails/core/models.py
+++ b/pycontrails/core/models.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import functools
 import hashlib
 import json
@@ -699,25 +700,17 @@ class Model(ABC):
             return
 
         source = source or self.source
-        try:
+        with contextlib.suppress(KeyError):
             source.attrs["met_source_provider"] = self.met.provider_attr
-        except KeyError:
-            pass
 
-        try:
+        with contextlib.suppress(KeyError):
             source.attrs["met_source_dataset"] = self.met.dataset_attr
-        except KeyError:
-            pass
 
-        try:
+        with contextlib.suppress(KeyError):
             source.attrs["met_source_product"] = self.met.product_attr
-        except KeyError:
-            pass
 
-        try:
+        with contextlib.suppress(KeyError):
             source.attrs["met_source_forecast_time"] = self.met.attrs["forecast_time"]
-        except KeyError:
-            pass
 
 
 def _interp_grid_to_grid(

--- a/pycontrails/models/humidity_scaling/humidity_scaling.py
+++ b/pycontrails/models/humidity_scaling/humidity_scaling.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import abc
+import contextlib
 import dataclasses
 import functools
 import pathlib
@@ -865,10 +866,8 @@ class HistogramMatchingWithEckel(HumidityScaling):
         ensemble_specific_humidity = self.params["ensemble_specific_humidity"]
         assert len(ensemble_specific_humidity) == self.n_members
         for member, mda in enumerate(ensemble_specific_humidity):
-            try:
+            with contextlib.suppress(KeyError):
                 assert mda.data["number"] == member
-            except KeyError:
-                pass
 
     @overload
     def eval(self, source: GeoVectorDataset, **params: Any) -> GeoVectorDataset: ...

--- a/pycontrails/models/pcc.py
+++ b/pycontrails/models/pcc.py
@@ -147,10 +147,6 @@ class PCC(Model):
         sp = self.surface["surface_air_pressure"].data.loc[dict(level=-1)]  # surface air pressure
 
         def _apply_b_contr_plev(_ds: xr.Dataset) -> xr.Dataset:
-            # cannot instantiate SAC object unless all 4 x, y, z, t dimensions are present
-            # convert "level" coordinate to dimension
-            _ds = _ds.expand_dims(dim="level")
-
             p = _ds["air_pressure"]
 
             G = sac.slope_mixing_line(
@@ -195,7 +191,7 @@ class PCC(Model):
 
         # apply calculation per pressure level
         return (
-            self.source.data.groupby("level")  # type: ignore
+            self.source.data.groupby("level", squeeze=False)  # type: ignore
             .map(_apply_b_contr_plev)
             .transpose(*self.source.dim_order)
         )

--- a/pycontrails/models/ps_model/ps_grid.py
+++ b/pycontrails/models/ps_model/ps_grid.py
@@ -220,6 +220,13 @@ def _nominal_perf(aircraft_mass: ArrayOrFloat, perf: _PerfVariables) -> Aircraft
         mach_number, atyp_param.m_des, atyp_param.c_t_des
     )
 
+    # Always correct thrust coefficients in the gridded case
+    # (In the flight case, this correction is governed by a model parameter)
+    c_t_available = ps_operational_limits.max_available_thrust_coefficient(
+        air_temperature, mach_number, c_t_eta_b, atyp_param
+    )
+    np.clip(c_t, 0.0, c_t_available, out=c_t)
+
     engine_efficiency = ps_model.overall_propulsion_efficiency(
         mach_number, c_t, c_t_eta_b, atyp_param
     )

--- a/tests/unit/test_ps_model.py
+++ b/tests/unit/test_ps_model.py
@@ -438,6 +438,7 @@ def test_ps_grid_vector_source(met_era5_fake: MetDataset) -> None:
     }
 
 
+@pytest.mark.filterwarnings("ignore:RMS of")
 def test_ps_grid_met_source(met_era5_fake: MetDataset) -> None:
     """Test the PSGrid model with source=None."""
 
@@ -452,18 +453,18 @@ def test_ps_grid_met_source(met_era5_fake: MetDataset) -> None:
     # Pin some output values
     abs = 1e-2
     assert ds["fuel_flow"].min() == pytest.approx(0.55, abs=abs)
-    assert ds["fuel_flow"].max() == pytest.approx(0.73, abs=abs)
+    assert ds["fuel_flow"].max() == pytest.approx(0.77, abs=abs)
     assert ds["fuel_flow"].mean() == pytest.approx(0.65, abs=abs)
 
     abs = 1e-3
-    assert ds["engine_efficiency"].min() == pytest.approx(0.268, abs=abs)
+    assert ds["engine_efficiency"].min() == pytest.approx(0.272, abs=abs)
     assert ds["engine_efficiency"].max() == pytest.approx(0.282, abs=abs)
-    assert ds["engine_efficiency"].mean() == pytest.approx(0.278, abs=abs)
+    assert ds["engine_efficiency"].mean() == pytest.approx(0.279, abs=abs)
 
     abs = 1e3
     assert ds["aircraft_mass"].min() == pytest.approx(53000, abs=abs)
     assert ds["aircraft_mass"].max() == pytest.approx(68000, abs=abs)
-    assert ds["aircraft_mass"].mean() == pytest.approx(61000, abs=abs)
+    assert ds["aircraft_mass"].mean() == pytest.approx(62000, abs=abs)
 
 
 def test_ps_grid_raises(met_era5_fake: MetDataset) -> None:


### PR DESCRIPTION
### Fixes

Correct thrust coefficients in the `PSGrid` model.

This has already been added to the `PSFlight` model in [pycontrails v0.49.0](https://py.contrails.org/changelog.html#v0-49-0).

Before

<img width="768" alt="Screenshot 2024-01-18 at 12 05 20 PM" src="https://github.com/contrailcirrus/pycontrails/assets/38074806/ab445b2b-b3a3-4ea6-b14a-3bf00a0f6fa9">

After

<img width="791" alt="Screenshot 2024-01-18 at 12 04 11 PM" src="https://github.com/contrailcirrus/pycontrails/assets/38074806/5eccdfa6-5aad-4765-8ead-3a25ffcbe8ed">
