### PR TITLE
Feature/cocipgrid ap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Make `Fuel` and its subclasses `JetA`, `SAFBlend`, and `HydrogenFuel` frozen.
 - No longer copy `met` when `Models.downselect_met` is called. In some modes of operation, this reduces the memory footprint of the model.
 - Update codebase for more harmony with [PDEP 8](https://jorisvandenbossche.github.io/pandas-website-preview/pdeps/0008-inplace-methods-in-pandas.html) and Copy-on-Write semantics.
+- Add `default` parameter to the `VectorDataset.get_data_or_attr` method.
 
 ## v0.49.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - Ensure the `Fleet.fl_attrs` attribute is preserved for the `Fleet.filter` method.
 - Raise `ValueError` when `Flight.sort` or `Fleet.sort` is called. Both of these subclasses assume a custom sorting order that is enforced in their constructors.
 - Always correct intermediate thrust coefficients computed in the `PSGrid` model. This correction is already enabled by default in the `PSFlight` model.
+- Include `attr` fields in the ValueError message raised in `CocipGrid` when not all aircraft performance variables are present on the `source` parameter.
+- Allow `mach_number` as a replacement for `true_airspeed` in `CocipGrid` aircraft performance determination.
 
 ### Internals
 

--- a/pycontrails/core/models.py
+++ b/pycontrails/core/models.py
@@ -665,6 +665,10 @@ class Model(ABC):
         ------
         KeyError
             Raises KeyError if key is not found in any location and ``default`` is not provided.
+
+        See Also
+        --------
+        - GeoVectorDataset.get_data_or_attr
         """
         marker = self.__marker
 
@@ -686,7 +690,8 @@ class Model(ABC):
         if default is not marker:
             return default
 
-        raise KeyError(f"key {key} not found in source data, attrs, or model params")
+        msg = f"Key '{key}' not found in source data, attrs, or model params"
+        raise KeyError(msg)
 
     def _cleanup_indices(self) -> None:
         """Cleanup indices artifacts if ``params["interpolation_use_indices"]`` is True."""

--- a/pycontrails/models/cocipgrid/cocip_grid.py
+++ b/pycontrails/models/cocipgrid/cocip_grid.py
@@ -1609,17 +1609,17 @@ def calc_emissions(vector: GeoVectorDataset, params: dict[str, Any]) -> None:
         vector.attrs.setdefault("engine_uid", param_engine_uid)
     vector.attrs.setdefault("fuel", params["fuel"])
 
-    ap_vars = (
+    ap_vars = {
         "true_airspeed",
         "engine_efficiency",
         "fuel_flow",
         "aircraft_mass",
         "n_engine",
         "wingspan",
-    )
+    }
 
     # Look across both vector.data and vector.attrs
-    missing = set(ap_vars).difference(vector).difference(vector.attrs)
+    missing = ap_vars.difference(vector).difference(vector.attrs)
 
     if missing == {"true_airspeed"}:
         # If we're only missing true_airspeed but mach_number is present,


### PR DESCRIPTION
#### Fixes

- Include `attr` fields in the ValueError message raised in `CocipGrid` when not all aircraft performance variables are present on the `source` parameter.
- Allow `mach_number` as a replacement for `true_airspeed` in `CocipGrid` aircraft performance determination.

#### Internals

- Add `default` parameter to the `VectorDataset.get_data_or_attr` method.

## Tests

- [x] QC test passes locally (`make test`)
- [ ] CI tests pass

