### PR TITLE
Feature/113

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 
 ## v0.49.3 (unreleased)
 
+### Fixes
+
+- Remove opaque warning issued when all tau_contrail values are nan in `Cocip` evolution.
+- Emit warning in `Cocip.eval` if the advected contrail is blown outside of the domain of the met data.
+
 ### Internals
 
 - Update time frequency aliases for `pandas` 2.2 compatibility.

--- a/pycontrails/core/cache.py
+++ b/pycontrails/core/cache.py
@@ -878,9 +878,11 @@ def _download_with_progress(
     url = blob._get_download_url(gcp_cache._client)
     description = f"Download {gcp_path}"
 
-    with open(disk_path, "wb") as local_file:
-        with tqdm.wrapattr(local_file, "write", total=blob.size, desc=description) as file_obj:
-            download = ChunkedDownload(url, chunk_size, file_obj)
-            transport = gcp_cache.client._http
-            while not download.finished:
-                download.consume_next_chunk(transport, timeout=gcp_cache.timeout)
+    with (
+        open(disk_path, "wb") as local_file,
+        tqdm.wrapattr(local_file, "write", total=blob.size, desc=description) as file_obj,
+    ):
+        download = ChunkedDownload(url, chunk_size, file_obj)
+        transport = gcp_cache.client._http
+        while not download.finished:
+            download.consume_next_chunk(transport, timeout=gcp_cache.timeout)

--- a/pycontrails/core/coordinates.py
+++ b/pycontrails/core/coordinates.py
@@ -157,12 +157,22 @@ def intersect_domain(
     ------
     ValueError
         Raises a ValueError when ``domain`` has all ``nan`` values.
+
+    Examples
+    --------
+    >>> domain = np.array([3.0, 4.0, 2.0])
+    >>> request = np.arange(1.0, 6.0)
+    >>> intersect_domain(domain, request)
+    array([False,  True,  True,  True, False])
+
+    >>> domain = np.array([3.0, np.nan, np.nan])
+    >>> request = np.arange(1.0, 6.0)
+    >>> intersect_domain(domain, request)
+    array([False, False,  True, False, False])
     """
-    # if the whole domain or request is nan, then there is nothing to slice
-    if np.isnan(domain).all():
+    isnan = np.isnan(domain)
+    if isnan.all():
         raise ValueError("Domain is all nan on request")
 
-    # if not np.all(np.diff(domain) >= 0):
-    #     raise ValueError("Domain must be sorted in ascending order")
-
-    return (request >= np.nanmin(domain)) & (request <= np.nanmax(domain))
+    domain = domain[~isnan]
+    return (request >= np.min(domain)) & (request <= np.max(domain))

--- a/pycontrails/core/coordinates.py
+++ b/pycontrails/core/coordinates.py
@@ -103,11 +103,7 @@ def slice_domain(
 
     # ensure domain is sorted
     zero: float | np.timedelta64
-    if pd.api.types.is_datetime64_dtype(domain.dtype):
-        zero = np.timedelta64(0)
-    else:
-        zero = 0.0
-
+    zero = np.timedelta64(0) if pd.api.types.is_datetime64_dtype(domain.dtype) else 0.0
     if not np.all(np.diff(domain) >= zero):
         raise ValueError("Domain must be sorted in ascending order")
 

--- a/pycontrails/core/flightplan.py
+++ b/pycontrails/core/flightplan.py
@@ -123,10 +123,7 @@ def parse_atc_plan(atc_plan: str) -> dict[str, str]:
     if len(basic) > 3:
         aircraft = basic[3].split("/")
         matches = re.match(r"(\d{1})(\S{3,4})", aircraft[0])
-        if matches:
-            groups = matches.groups()
-        else:
-            groups = ()
+        groups = matches.groups() if matches else ()
 
         if matches and len(groups) > 2:
             flightplan["number_aircraft"] = groups[1]
@@ -147,12 +144,9 @@ def parse_atc_plan(atc_plan: str) -> dict[str, str]:
     # Dep. airport info
     if len(basic) > 5:
         matches = re.match(r"(\D*)(\d*)", basic[5])
-        if matches:
-            groups = matches.groups()
-        else:
-            groups = ()
+        groups = matches.groups() if matches else ()
 
-        if len(groups) > 0:
+        if groups:
             flightplan["departure_icao"] = groups[0]
         if len(groups) > 1:
             flightplan["time"] = groups[1]
@@ -160,13 +154,10 @@ def parse_atc_plan(atc_plan: str) -> dict[str, str]:
     # Speed and route info
     if len(basic) > 6:
         matches = re.match(r"(\D*)(\d*)(\D*)(\d*)", basic[6])
-        if matches:
-            groups = matches.groups()
-        else:
-            groups = ()
+        groups = matches.groups() if matches else ()
 
         # match speed and level
-        if len(groups) > 0:
+        if groups:
             flightplan["speed_type"] = groups[0]
             if len(groups) > 1:
                 flightplan["speed"] = groups[1]
@@ -182,30 +173,21 @@ def parse_atc_plan(atc_plan: str) -> dict[str, str]:
     # Dest. airport info
     if len(basic) > 7:
         matches = re.match(r"(\D{4})(\d{4})", basic[7])
-        if matches:
-            groups = matches.groups()
-        else:
-            groups = ()
+        groups = matches.groups() if matches else ()
 
-        if len(groups) > 0:
+        if groups:
             flightplan["destination_icao"] = groups[0]
         if len(groups) > 1:
             flightplan["duration"] = groups[1]
 
         matches = re.match(r"(\D{4})(\d{4})(\s{1})(\D{4})", basic[7])
-        if matches:
-            groups = matches.groups()
-        else:
-            groups = ()
+        groups = matches.groups() if matches else ()
 
         if len(groups) > 3:
             flightplan["alt_icao"] = groups[3]
 
         matches = re.match(r"(\D{4})(\d{4})(\s{1})(\D{4})(\s{1})(\D{4})", basic[7])
-        if matches:
-            groups = matches.groups()
-        else:
-            groups = ()
+        groups = matches.groups() if matches else ()
 
         if len(groups) > 5:
             flightplan["second_alt_icao"] = groups[5]
@@ -217,7 +199,7 @@ def parse_atc_plan(atc_plan: str) -> dict[str, str]:
     # Supl. Info
     if len(basic) > 9:
         sup_match = re.findall(r"(\D{1}[\/]{1})", basic[9])
-        if len(sup_match) > 0:
+        if sup_match:
             suplInfo = {}
             for i in range(len(sup_match) - 1):
                 this_key = sup_match[i]

--- a/pycontrails/core/interpolation.py
+++ b/pycontrails/core/interpolation.py
@@ -506,11 +506,7 @@ def _buildxi(
 
     time_float = _floatize_time(time, offset)
 
-    if single_level:
-        ndim = 3
-    else:
-        ndim = 4
-
+    ndim = 3 if single_level else 4
     shape = longitude.size, ndim
     xi = np.empty(shape, dtype=np.float64)
 

--- a/pycontrails/core/interpolation.py
+++ b/pycontrails/core/interpolation.py
@@ -443,16 +443,17 @@ def interp(
         da = _localize(da, coords)
 
     # Using da.coords.variables is slightly more performant than da["longitude"].values
-    x = da.coords.variables["longitude"].values
-    y = da.coords.variables["latitude"].values
-    z = da.coords.variables["level"].values
+    variables = da.coords.variables
+    x = variables["longitude"].values
+    y = variables["latitude"].values
+    z = variables["level"].values
     if any(v.dtype != np.float64 for v in (x, y, z)):
         raise ValueError(
             "da must have float64 dtype for longitude, latitude, and level coordinates"
         )
 
     # Convert t and time to float64
-    t = da.coords.variables["time"].values
+    t = variables["time"].values
     offset = t[0]
     t = _floatize_time(t, offset)
 

--- a/pycontrails/core/vector.py
+++ b/pycontrails/core/vector.py
@@ -1610,21 +1610,22 @@ class GeoVectorDataset(VectorDataset):
         npt.NDArray[np.bool_]
             True if point is inside the bounding box defined by ``met``.
         """
+        variables = met.variables
 
         lat_intersect = coordinates.intersect_domain(
-            met.variables["latitude"].values,
+            variables["latitude"].values,
             self["latitude"],
         )
         lon_intersect = coordinates.intersect_domain(
-            met.variables["longitude"].values,
+            variables["longitude"].values,
             self["longitude"],
         )
         level_intersect = coordinates.intersect_domain(
-            met.variables["level"].values,
+            variables["level"].values,
             self.level,
         )
         time_intersect = coordinates.intersect_domain(
-            met.variables["time"].values,
+            variables["time"].values,
             self["time"],
         )
 

--- a/pycontrails/core/vector.py
+++ b/pycontrails/core/vector.py
@@ -1568,10 +1568,7 @@ class GeoVectorDataset(VectorDataset):
         transformer = pyproj.Transformer.from_crs(self.attrs["crs"], crs, always_xy=True)
         lon, lat = transformer.transform(self["longitude"], self["latitude"])
 
-        if copy:
-            ret = self.copy()
-        else:
-            ret = self
+        ret = self.copy() if copy else self
 
         ret.update(longitude=lon, latitude=lat)
         ret.attrs.update(crs=crs)

--- a/pycontrails/models/cocip/cocip.py
+++ b/pycontrails/models/cocip/cocip.py
@@ -2185,6 +2185,12 @@ def calc_timestep_contrail_evolution(
         },
         copy=False,
     )
+    intersection = contrail_2.coords_intersect_met(met)
+    if not np.any(intersection):
+        warnings.warn(
+            f"At time {time_2}, the contrail has no intersection with the met data. "
+            "This is likely due to the contrail being advected outside the met domain."
+        )
 
     # Update cumulative radiative heating energy absorbed by the contrail
     # This will always be zero if radiative_heating_effects is not activated in cocip_params

--- a/pycontrails/models/cocip/contrail_properties.py
+++ b/pycontrails/models/cocip/contrail_properties.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import warnings
 from typing import Any, TypeVar
 
 import numpy as np
@@ -437,19 +436,6 @@ def contrail_persistent(
         np.sum(status_5),
         np.sum(status_6),
     )
-    tau_contrail_nan = np.isnan(tau_contrail)
-    logger.debug(
-        "Fraction of nan in tau_contrail: %s / %s",
-        tau_contrail_nan.sum(),
-        tau_contrail_nan.size,
-    )
-    if np.all(tau_contrail_nan):
-        warnings.warn(
-            "All tau_contrail values are nan. This may be due to waypoints "
-            "all lying outside of the met interpolation grid. It could "
-            "indicate an issue with interpolation, or an insufficient "
-            "met domain."
-        )
     return status_1 & status_2 & status_3 & status_4 & status_5 & status_6
 
 

--- a/pycontrails/models/cocipgrid/cocip_grid.py
+++ b/pycontrails/models/cocipgrid/cocip_grid.py
@@ -179,15 +179,16 @@ class CocipGrid(models.Model, cocip_time_handling.CocipTimeHandlingMixin):
             # Perhaps we could use the isel(time=0) slice to construct the source
             # from the met and rad data.
             raise NotImplementedError("CocipGrid.eval() with 'source=None' is not implemented.")
-        if isinstance(source, Flight):
-            if not source.ensure_vars(("true_airspeed", "azimuth"), False):
-                warnings.warn(
-                    "Flight source no longer supported by CocipGrid. "
-                    "Any Flight source will be viewed as a GeoVectorDataset. "
-                    "In particular, flight segment variable such as azimuth and true_airspeed "
-                    "are not used by CocipGrid (nominal values are used instead). Attach "
-                    "these to the Flight source before calling 'eval' to use them in CocipGrid."
-                )
+        if isinstance(source, Flight) and not source.ensure_vars(
+            ("true_airspeed", "azimuth"), False
+        ):
+            warnings.warn(
+                "Flight source no longer supported by CocipGrid. "
+                "Any Flight source will be viewed as a GeoVectorDataset. "
+                "In particular, flight segment variable such as azimuth and true_airspeed "
+                "are not used by CocipGrid (nominal values are used instead). Attach "
+                "these to the Flight source before calling 'eval' to use them in CocipGrid."
+            )
         self.set_source(source)
 
         self.met, self.rad = _downselect_met(self.source, self.met, self.rad, self.params)
@@ -997,10 +998,8 @@ def _run_downwash(
     vector, sac_ = find_initial_contrail_regions(vector, params)
     if (key := "sac") in verbose_outputs_formation:
         verbose_dict[key] = sac_
-    if (key := "T_crit_sac") in verbose_outputs_formation:
-        # This key isn't always present, e.g. find_initial_contrail_regions can exit early
-        if (val := vector.get(key)) is not None:
-            verbose_dict[key] = pd.Series(data=val, index=vector["index"])
+    if (key := "T_crit_sac") in verbose_outputs_formation and (val := vector.get(key)) is not None:
+        verbose_dict[key] = pd.Series(data=val, index=vector["index"])
 
     # Early exit if nothing in vector passes the SAC
     if not vector:
@@ -1022,9 +1021,8 @@ def _run_downwash(
 
     if (key := "persistent") in verbose_outputs_formation:
         verbose_dict[key] = persistent
-    if (key := "iwc") in verbose_outputs_formation:
-        if (data := contrail.get(key)) is not None:
-            verbose_dict[key] = pd.Series(data=data, index=contrail["index"])
+    if (key := "iwc") in verbose_outputs_formation and (data := contrail.get(key)) is not None:
+        verbose_dict[key] = pd.Series(data=data, index=contrail["index"])
 
     return contrail, verbose_dict
 

--- a/pycontrails/physics/thermo.py
+++ b/pycontrails/physics/thermo.py
@@ -197,7 +197,7 @@ def _e_sat_piecewise(T: np.ndarray) -> np.ndarray:
     np.ndarray
         Piecewise array of e_sat_liquid and e_sat_ice values.
     """
-    condlist = [T >= -constants.absolute_zero, T < constants.absolute_zero]
+    condlist = [T >= -constants.absolute_zero, T < constants.absolute_zero]  # noqa: SIM300
     funclist = [e_sat_liquid, e_sat_ice, np.nan]  # nan passed through
     return np.piecewise(T, condlist, funclist)
 

--- a/pycontrails/utils/json.py
+++ b/pycontrails/utils/json.py
@@ -168,7 +168,7 @@ def dataframe_to_geojson_points(
         # converting to int to allow JSON serialization
         properties = {"time": int(row.time.timestamp())}
         used_keys = ["time", "latitude", "longitude", "altitude"]
-        unused_keys = [k for k in row.keys() if k not in used_keys]
+        unused_keys = [k for k in row.keys() if k not in used_keys]  # noqa: SIM118
         properties.update({
             k: (
                 row[k]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -237,7 +237,7 @@ ignore-path = [
 # https://beta.ruff.rs/docs/settings/#select
 # https://www.pydocstyle.org/en/6.3.0/error_codes.html
 [tool.ruff]
-select = ["D", "E", "F", "I", "NPY", "PL", "PT", "UP"]
+select = ["D", "E", "F", "I", "NPY", "PL", "PT", "SIM", "UP"]
 line-length = 100
 ignore = [
     "E402",

--- a/tests/unit/test_cocip.py
+++ b/tests/unit/test_cocip.py
@@ -101,7 +101,7 @@ def cocip_persistent(fl: Flight, met: MetDataset, rad: MetDataset) -> Cocip:
     # Eventually the advected waypoints will blow out of bounds
     # Specifically, there is a contrail at 4:30 with latitude larger than 59
     # We acknowledge this here
-    with pytest.warns(UserWarning, match="outside of the met interpolation grid"):
+    with pytest.warns(UserWarning, match="At time .* contrail has no intersection with the met"):
         cocip.eval(source=fl)
 
     return cocip
@@ -363,8 +363,10 @@ def test_flight_overrides(fl: Flight, met: MetDataset, rad: MetDataset) -> None:
     # Eventually the advected waypoints will blow out of bounds
     # Specifically, there is a contrail at 4:30 with latitude larger than 59
     # We acknowledge this here
-    with pytest.warns(UserWarning, match="outside of the met interpolation grid"):
+    match = "At time 2019-01-01T04:30:00.000000, the contrail has no intersection with the met"
+    with pytest.warns(UserWarning, match=match):
         out1 = cocip.eval(fl)
+    with pytest.warns(UserWarning, match=match):
         out2 = cocip.eval(fl2)
 
     # Because Cocip copies fl, the original isn't modified
@@ -770,7 +772,7 @@ def fleet(met: MetDataset) -> Fleet:
     return Fleet.from_seq(fls, copy=False, broadcast_numeric=False)
 
 
-@pytest.mark.filterwarnings("ignore:All tau_contrail values are nan")
+@pytest.mark.filterwarnings("ignore:.*the contrail has no intersection with the met")
 @pytest.mark.parametrize("contrail_contrail_overlapping", [True, False])
 def test_cocip_contrail_contrail_overlapping(
     met: MetDataset,
@@ -1214,7 +1216,7 @@ def test_cocip_no_persistence_ef_fill_value(fl: Flight, met: MetDataset, rad: Me
     assert "_met_intersection" not in out
 
 
-@pytest.mark.filterwarnings("ignore:All tau_contrail values are nan")
+@pytest.mark.filterwarnings("ignore:.*the contrail has no intersection with the met")
 @pytest.mark.parametrize("q_method", [None, "cubic-spline"])
 def test_exponential_boost_coefficients(
     fl: Flight, met: MetDataset, rad: MetDataset, q_method: str | None

--- a/tests/unit/test_met.py
+++ b/tests/unit/test_met.py
@@ -772,10 +772,7 @@ def test_polygon_iso_value(island_slice: MetDataArray, iso_value: float) -> None
 def test_polyhedra_save(median_binary: MetDataArray, return_type: str) -> None:
     assert len(median_binary.data["time"]) == 1
     path: str | pathlib.Path
-    if return_type == "geojson":
-        path = "test_mesh.json"
-    else:
-        path = "test_mesh.ply"
+    path = "test_mesh.json" if return_type == "geojson" else "test_mesh.ply"
     median_binary.to_polyhedra(return_type=return_type, path=path)
 
     path = pathlib.Path(path)

--- a/tests/unit/test_sac_issr.py
+++ b/tests/unit/test_sac_issr.py
@@ -218,9 +218,11 @@ def test_ISSR_flight_high_altitude(met_era5_fake: MetDataset, flight_fake: Fligh
     fl = flight_fake.copy()
     fl["altitude"] *= 2.5
 
-    with pytest.warns(UserWarning, match="Flight altitude is high"):
-        with pytest.raises(ValueError, match="One of the requested xi is out of bounds"):
-            ISSR(met=met_era5_fake, interpolation_bounds_error=True).eval(source=fl)
+    with (
+        pytest.warns(UserWarning, match="Flight altitude is high"),
+        pytest.raises(ValueError, match="One of the requested xi is out of bounds"),
+    ):
+        ISSR(met=met_era5_fake, interpolation_bounds_error=True).eval(source=fl)
 
     with pytest.warns(UserWarning, match="Flight altitude is high"):
         fl = ISSR(met=met_era5_fake).eval(source=fl)

--- a/tests/unit/test_thermo_sac.py
+++ b/tests/unit/test_thermo_sac.py
@@ -32,7 +32,7 @@ def test_slope_mixing_line(data: VectorDataset, engine_efficiency: float):
     # Consequently, we want G to be bounded above this constant
     # We use a small buffer to quantify this
     buffer = 0.2
-    assert np.all(G > 0.053 + buffer)
+    assert np.all(G > 0.053 + buffer)  # noqa: SIM300
 
 
 @pytest.mark.parametrize("e_sat", [thermo.e_sat_ice, thermo.e_sat_liquid])

--- a/tests/unit/test_vector.py
+++ b/tests/unit/test_vector.py
@@ -731,21 +731,27 @@ def test_time_parsing(random_geo_path: VectorDataset) -> None:
 
     # time can't be coerced to datetime64
     data.update(time=[1, 2, 3, 4])
-    with pytest.warns(UserWarning, match="time"):
-        with pytest.raises(ValueError, match="Could not coerce time data"):
-            GeoVectorDataset(data)
+    with (
+        pytest.warns(UserWarning, match="time"),
+        pytest.raises(ValueError, match="Could not coerce time data"),
+    ):
+        GeoVectorDataset(data)
 
     # fails even if 1 time can't be coerced to datetime64
     data.update(time=[1000000000, 1000000060, 1000000120, 10])
-    with pytest.warns(UserWarning, match="time"):
-        with pytest.raises(ValueError, match="Could not coerce time data"):
-            GeoVectorDataset(data)
+    with (
+        pytest.warns(UserWarning, match="time"),
+        pytest.raises(ValueError, match="Could not coerce time data"),
+    ):
+        GeoVectorDataset(data)
 
     # float times aren't supported
     data.update(time=[1e9, 1e9 + 60, 1e9 + 120, 1e9 + 180])
-    with pytest.warns(UserWarning, match="time"):
-        with pytest.raises(ValueError, match="Could not coerce time data"):
-            GeoVectorDataset(data)
+    with (
+        pytest.warns(UserWarning, match="time"),
+        pytest.raises(ValueError, match="Could not coerce time data"),
+    ):
+        GeoVectorDataset(data)
 
     # reasonable int times are supported
     data.update(time=[1000000000, 1000000060, 1000000120, 1000000240])
@@ -761,9 +767,8 @@ def test_time_parsing(random_geo_path: VectorDataset) -> None:
 
     # random strings cannot be converted
     data.update(time=["hello", "world", "con", "trail"])
-    with pytest.warns(UserWarning, match="time"):
-        with pytest.raises(ValueError, match="time"):
-            GeoVectorDataset(data)
+    with pytest.warns(UserWarning, match="time"), pytest.raises(ValueError, match="time"):
+        GeoVectorDataset(data)
 
     # UTC timezones are stripped
     data.update(


### PR DESCRIPTION
Closes #113 

#### Fixes

- Remove opaque warning issued when all tau_contrail values are nan in `Cocip` evolution.
- Emit warning in `Cocip.eval` if the advected contrail is blown outside of the domain of the met data.

## Tests

- [x] QC test passes locally (`make test`)
- [x] CI tests pass

