### PR TITLE
Pin black and ruff versions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,10 +3,6 @@
 
 name: Unit tests
 
-defaults:
-  run:
-    shell: bash
-
 on:
   # run on push to main
   push:
@@ -119,6 +115,7 @@ jobs:
           pip list
 
       - name: QC & Test
+        shell: bash
         run: |
           pip check
           black pycontrails --check

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,6 +3,10 @@
 
 name: Unit tests
 
+defaults:
+  run:
+    shell: bash
+
 on:
   # run on push to main
   push:
@@ -116,7 +120,6 @@ jobs:
 
       - name: QC & Test
         run: |
-          set -e
           pip check
           black pycontrails --check
           ruff pycontrails tests

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -86,8 +86,7 @@ jobs:
 
       - name: Install pycontrails (dev)
         run: |
-          pip install -U pip wheel
-          pip install -e .[complete,dev,docs] --verbose
+          make dev-install
 
       # In latest-windows, redirecting stdout to a file uses utf-16 encoding
       # This gives an error when ssh tries to read the key

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -79,6 +79,11 @@ jobs:
           gcloud storage cp -r gs://contrails-301217-bada/bada/bada4 ${{ env.BADA_CACHE_DIR }}
           ls -l ${{ env.BADA_CACHE_DIR }}
 
+      - name: Install make - windows
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: |
+          choco install make
+
       - name: Install pycontrails (dev)
         run: |
           pip install -U pip wheel
@@ -118,7 +123,7 @@ jobs:
         shell: bash
         run: |
           pip check
-          black pycontrails --check
-          ruff pycontrails tests
-          mypy pycontrails
-          pytest tests/unit -vv
+          make black-check
+          make ruff
+          make mypy
+          make pytest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -116,6 +116,7 @@ jobs:
 
       - name: QC & Test
         run: |
+          set -e
           pip check
           black pycontrails --check
           ruff pycontrails tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Internals
 
+- Pin `black` and `ruff` versions for consistency between local and CI/CD environments
 - Update time frequency aliases for `pandas` 2.2 compatibility.
 - Update cython annotations for `scipy` 1.12 compatibility.
 - Improve notebook output testing capabilities (`make nb-test`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Internals
 
+- Modify test workflow to use Makefile recipes and ensure early failures are detected in CI
 - Pin `black` and `ruff` versions for consistency between local and CI/CD environments
 - Update time frequency aliases for `pandas` 2.2 compatibility.
 - Update cython annotations for `scipy` 1.12 compatibility.

--- a/pycontrails/core/models.py
+++ b/pycontrails/core/models.py
@@ -53,7 +53,8 @@ class ModelParams:
     """
 
     #: Copy input ``source`` data on eval
-    copy_source: bool = True
+    copy_source: bool = \
+            True
 
     # -----------
     # Interpolate

--- a/pycontrails/core/models.py
+++ b/pycontrails/core/models.py
@@ -53,8 +53,7 @@ class ModelParams:
     """
 
     #: Copy input ``source`` data on eval
-    copy_source: bool = \
-            True
+    copy_source: bool = True
 
     # -----------
     # Interpolate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ complete = ["pycontrails[ecmwf,gcp,gfs,goes,jupyter,pyproj,vis,zarr]"]
 
 # Development dependencies
 dev = [
-    "black[jupyter]>=23.12",
+    "black[jupyter]==24.1.1",
     "dep_license",
     "fastparquet>=0.8",
     "ipdb>=0.13",
@@ -72,7 +72,7 @@ dev = [
     "pytest>=6.1",
     "pytest-cov>=2.11",
     "requests>=2.25",
-    "ruff>=0.0.259",
+    "ruff==0.1.15",
 ]
 
 # Documentation / Sphinx dependencies
@@ -195,6 +195,7 @@ show_error_codes = true
 [tool.black]
 line-length = 100
 preview = true
+required_version = "24.1.1"
 
 # pytest
 # https://docs.pytest.org/en/7.1.x/reference/customize.html

--- a/tests/unit/test_flightplan.py
+++ b/tests/unit/test_flightplan.py
@@ -33,16 +33,14 @@ def test_flightplan_one() -> None:
     assert fp_dict["level_type"] == "F"
     assert fp_dict["level"] == "360"
     assert (
-        fp_dict["route"]
-        == "IMVUR1Z IMVUR N63 SAM N19 ADKIK DCT MOPAT DCT  "
+        fp_dict["route"] == "IMVUR1Z IMVUR N63 SAM N19 ADKIK DCT MOPAT DCT  "
         "LIMRI/M083F360 DCT 51N020W 47N030W/M083F380 40N040W 34N045W  28N050W/M083F400 "
         "24N055W 19N060W DCT AMTTO DCT ANU DCT"
     )
     assert fp_dict["other_info"] == "E/0740 P/3 R/E S/ J/ A/WHITE BLUE TAIL"
 
     assert (
-        flightplan.to_atc_plan(fp_dict)
-        == "(FPL-GEC8145-IN\n"
+        flightplan.to_atc_plan(fp_dict) == "(FPL-GEC8145-IN\n"
         "-B77L/H-SDE2E3FGHIJ3J4J5M1RWXYZ/SB1D1\n"
         "-EGGL1040\n"
         "-N0474F360 IMVUR1Z IMVUR N63 SAM N19 ADKIK DCT MOPAT DCT  "
@@ -77,8 +75,7 @@ def test_flightplan_two() -> None:
     assert fp_dict["other_info"] == "DOF/170428 RMK/DO NOT POST"
 
     assert (
-        flightplan.to_atc_plan(fp_dict)
-        == "(FPL-N12345-IG\n"
+        flightplan.to_atc_plan(fp_dict) == "(FPL-N12345-IG\n"
         "-SR22/L-S/S\n"
         "-KSEA1414\n"
         "-N0220F090 DCT\n"

--- a/tests/unit/test_met.py
+++ b/tests/unit/test_met.py
@@ -572,7 +572,7 @@ def test_edges_on_median_binary(median_binary: MetDataArray) -> None:
 
 
 def test_polygons_sparse_binary_specify_time_level(
-    sparse_binary: tuple[MetDataArray, dict]
+    sparse_binary: tuple[MetDataArray, dict],
 ) -> None:
     mda, _ = sparse_binary
     # must specify level and time


### PR DESCRIPTION
Closes #145

## Changes

Modify [pyproject.toml](https://github.com/contrailcirrus/pycontrails/compare/enhancement/pin_black_ruff?expand=1#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711) to pin `black` version (currently 24.1.1) and `ruff` version (currently 0.1.15), and add a `black` configuration argument so that `black` errors if it doesn't match the pinned version when run. AFAIK this is the only file that needs modification.

The changes don't quite meet the goal of avoiding duplicate version declarations (we're limited by the TOML file spec), but a mismatch between the `black` version pinned in development dependencies and the required version specified in `tools.black` should show up early in tests.

`ruff` doesn't have a flag that checks for a required version, so these changes won't prevent somebody from using a manually-up/downgraded version.

#### Internals

- Pin `black` and `ruff` versions for consistency between local and CI/CD environments

## Tests

- [x] QC test passes locally (`make test`)
- [ ] CI tests pass

## Reviewer

> @trdean1 
