### PR TITLE
Clarify cause of warnings about met data time coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 
 ### Features
 
-- Improve clarity of warnings produced when meteorology data doesn't cover the time range required by a gridded Cocip model.
 - Add support for 9 additional aircraft types in the [Poll-Schumann](https://py.contrails.org/notebooks/AircraftPerformance.html) (PS) aircraft performance model. The new aircraft types are:
   - A338
   - A339
@@ -20,6 +19,7 @@
 
 ### Fixes
 
+- Improve clarity of warnings produced when meteorology data doesn't cover the time range required by a gridded Cocip model.
 - No longer emit `pandas` warning when `Flight.resample_and_fill(..., drop=True, ...)` is called with non-float data.
 
 ## v0.49.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Features
 
+- Improve clarity of warnings produced when meteorology data doesn't cover the time range required by a gridded Cocip model.
 - Add support for 9 additional aircraft types in the [Poll-Schumann](https://py.contrails.org/notebooks/AircraftPerformance.html) (PS) aircraft performance model. The new aircraft types are:
   - A338
   - A339

--- a/pycontrails/core/met.py
+++ b/pycontrails/core/met.py
@@ -1123,15 +1123,15 @@ class MetDataset(MetBase):
         >>> met = MetDataset.from_coords(longitude, latitude, level, time)
         >>> met
         MetDataset with data:
-        <xarray.Dataset>
+        <xarray.Dataset> Size: 360B
         Dimensions:       (longitude: 20, latitude: 20, level: 2, time: 1)
         Coordinates:
-          * longitude     (longitude) float64 0.0 0.5 1.0 1.5 2.0 ... 8.0 8.5 9.0 9.5
-          * latitude      (latitude) float64 0.0 0.5 1.0 1.5 2.0 ... 7.5 8.0 8.5 9.0 9.5
-          * level         (level) float64 250.0 300.0
-          * time          (time) datetime64[ns] 2019-01-01
-            air_pressure  (level) float32 2.5e+04 3e+04
-            altitude      (level) float32 1.036e+04 9.164e+03
+          * longitude     (longitude) float64 160B 0.0 0.5 1.0 1.5 ... 8.0 8.5 9.0 9.5
+          * latitude      (latitude) float64 160B 0.0 0.5 1.0 1.5 ... 8.0 8.5 9.0 9.5
+          * level         (level) float64 16B 250.0 300.0
+          * time          (time) datetime64[ns] 8B 2019-01-01
+            air_pressure  (level) float32 8B 2.5e+04 3e+04
+            altitude      (level) float32 8B 1.036e+04 9.164e+03
         Data variables:
             *empty*
 
@@ -1146,18 +1146,18 @@ class MetDataset(MetBase):
         >>> met["humidity"] = xr.DataArray(np.full(met.shape, 0.5), coords=met.coords)
         >>> met
         MetDataset with data:
-        <xarray.Dataset>
+        <xarray.Dataset> Size: 13kB
         Dimensions:       (longitude: 20, latitude: 20, level: 2, time: 1)
         Coordinates:
-          * longitude     (longitude) float64 0.0 0.5 1.0 1.5 2.0 ... 8.0 8.5 9.0 9.5
-          * latitude      (latitude) float64 0.0 0.5 1.0 1.5 2.0 ... 7.5 8.0 8.5 9.0 9.5
-          * level         (level) float64 250.0 300.0
-          * time          (time) datetime64[ns] 2019-01-01
-            air_pressure  (level) float32 2.5e+04 3e+04
-            altitude      (level) float32 1.036e+04 9.164e+03
+          * longitude     (longitude) float64 160B 0.0 0.5 1.0 1.5 ... 8.0 8.5 9.0 9.5
+          * latitude      (latitude) float64 160B 0.0 0.5 1.0 1.5 ... 8.0 8.5 9.0 9.5
+          * level         (level) float64 16B 250.0 300.0
+          * time          (time) datetime64[ns] 8B 2019-01-01
+            air_pressure  (level) float32 8B 2.5e+04 3e+04
+            altitude      (level) float32 8B 1.036e+04 9.164e+03
         Data variables:
-            temperature   (longitude, latitude, level, time) float64 234.5 ... 234.5
-            humidity      (longitude, latitude, level, time) float64 0.5 0.5 ... 0.5 0.5
+            temperature   (longitude, latitude, level, time) float64 6kB 234.5 ... 234.5
+            humidity      (longitude, latitude, level, time) float64 6kB 0.5 0.5 ... 0.5
 
         >>> # Convert to a GeoVectorDataset
         >>> vector = met.to_vector()

--- a/pycontrails/core/vector.py
+++ b/pycontrails/core/vector.py
@@ -2041,8 +2041,8 @@ def vector_to_lon_lat_grid(
     >>> da = ds["foo"]
     >>> da.coords
     Coordinates:
-      * longitude  (longitude) float64 -10.0 -9.5 -9.0 -8.5 -8.0 ... 8.0 8.5 9.0 9.5
-      * latitude   (latitude) float64 -10.0 -9.5 -9.0 -8.5 -8.0 ... 8.0 8.5 9.0 9.5
+      * longitude  (longitude) float64 320B -10.0 -9.5 -9.0 -8.5 ... 8.0 8.5 9.0 9.5
+      * latitude   (latitude) float64 320B -10.0 -9.5 -9.0 -8.5 ... 8.0 8.5 9.0 9.5
 
     >>> da.values.round(2)
     array([[2.23, 0.67, 1.29, ..., 4.66, 3.91, 1.93],

--- a/pycontrails/models/cocipgrid/cocip_grid.py
+++ b/pycontrails/models/cocipgrid/cocip_grid.py
@@ -45,6 +45,15 @@ class CocipGrid(models.Model, cocip_time_handling.CocipTimeHandlingMixin):
     param_kwargs : Any
         Override CocipGridParams defaults with arbitrary keyword arguments.
 
+    Notes
+    -----
+    - If ``rad`` contains accumulated radiative fluxes, differencing to obtain
+      time-averaged fluxes will reduce the time coverage of ``rad`` by half a forecast
+      step. A warning will be produced during :meth:`eval` if the time coverage of
+      ``rad`` (after differencing) is too short given the model evaluation parameters.
+      If this occurs, provide an additional step of radiation data at the start or end
+      of ``rad``.
+
     References
     ----------
     - :cite:`schumannPotentialReduceClimate2011`

--- a/pycontrails/models/cocipgrid/cocip_time_handling.py
+++ b/pycontrails/models/cocipgrid/cocip_time_handling.py
@@ -148,10 +148,12 @@ class CocipTimeHandlingMixin:
         tmax:pd.Timestamp
             End of required time range
         """
-        met_tmin = pd.to_datetime(self.met.data["time"].min().values)
-        met_tmax = pd.to_datetime(self.met.data["time"].max().values)
-        rad_tmin = pd.to_datetime(self.rad.data["time"].min().values)
-        rad_tmax = pd.to_datetime(self.rad.data["time"].max().values)
+        met_time = self.met.data["time"].values
+        met_tmin = pd.to_datetime(met_time.min())
+        met_tmax = pd.to_datetime(met_time.max())
+        rad_time = self.rad.data["time"].values
+        rad_tmin = pd.to_datetime(rad_time.min())
+        rad_tmax = pd.to_datetime(rad_time.max())
         differencing_note = (
             "differencing reduces time coverage when providing accumulated radiative fluxes."
         )
@@ -351,7 +353,7 @@ class CocipRuntimeStats:
 
 
 def _check_start_time(
-    met_start: pd.Timestap, model_start: pd.TimeStamp, name: str, note: str | None = None
+    met_start: pd.Timestamp, model_start: pd.Timestamp, name: str, *, note: str | None = None
 ) -> None:
     if met_start > model_start:
         note = f" Note: {note}" if note else ""
@@ -364,7 +366,7 @@ def _check_start_time(
 
 
 def _check_end_time(
-    met_end: pd.Timestap, model_end: pd.TimeStamp, name: str, note: str | None = None
+    met_end: pd.Timestamp, model_end: pd.Timestamp, name: str, *, note: str | None = None
 ) -> None:
     if met_end < model_end:
         note = f" Note: {note}" if note else ""

--- a/tests/unit/test_cocip_grid.py
+++ b/tests/unit/test_cocip_grid.py
@@ -95,7 +95,12 @@ def test_met_too_short(met_cocip1: MetDataset, rad_cocip1: MetDataset, source: M
 
     source = CocipGrid.create_source(level=5, time=np.datetime64("2019-01-01T04"))
     gc.set_source(source)
-    with pytest.warns(UserWarning, match="too short in the time dimension"):
+    with pytest.warns(UserWarning, match="before model end time"):
+        gc.attach_timedict()
+
+    source = CocipGrid.create_source(level=5, time=np.datetime64("2018-12-31T23"))
+    gc.set_source(source)
+    with pytest.warns(UserWarning, match="after model start time"):
         gc.attach_timedict()
 
     source = CocipGrid.create_source(level=5, time=np.datetime64("2019-01-01"))

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -221,7 +221,7 @@ def test_model_grid_required_met_variables(met_era5_fake: MetDataset) -> None:
 def test_model_grid_hash(met_era5_fake: MetDataset) -> None:
     """Model hash."""
     grid_model = ModelTestGrid(met=met_era5_fake)
-    assert grid_model.hash == "28648ed00ce10e05aaa198325a8991ef79910d47"
+    assert grid_model.hash == "b0c26d747887f86ab1942667c3befcb5693688a3"
 
 
 def test_model_met_not_copied(met_era5_fake: MetDataset) -> None:
@@ -329,7 +329,7 @@ def test_model_flight_required_met_variables(met_era5_fake: MetDataset) -> None:
 def test_model_flight_hash(met_era5_fake: MetDataset) -> None:
     """Ensure pinned hash matches as check for model degradation."""
     flight_model = ModelTestFlight(met_era5_fake)
-    assert flight_model.hash == "2789e8bef2606322984d6733e8072f501507f114"
+    assert flight_model.hash == "a5b35e16632ff819e49499a832a1ba1787d3dd27"
 
 
 def test_model_flight_met_not_copied(met_era5_fake: MetDataset) -> None:


### PR DESCRIPTION
Closes #153 

## Changes

Improves the clarity of warnings produced when meteorology data doesn't cover the time range required by a gridded Cocip model.

Example:
```python
model = CocipGrid(
    met=met,   # HRES data starting at 2024-02-19T00
    rad=rad,   # HRES data starting at 2024-02-19T00
    max_age=np.timedelta64(10, "h"),
    ...
)

# Gridded model that also starts at 2024-02-19T00
source = CocipGrid.create_source(level=5, time=np.datetime64("2024-02-19T00"))
_ = model.eval(source)
```

Previous warnings (time-related only):
```
UserWarning: Met data 'rad' does not overlap the grid domain along the time axis. This causes interpolated values to be nan, leading to meaningless results.
UserWarning: Parameter 'rad' is too short in the time dimension. Include additional time in 'rad' or reduce 'max_age' parameter.Model start time: 2024-02-19 00:00:00 Model end time: 2024-02-19 10:00:00
```

New warnings (time-related only):
```
UserWarning: Met data 'rad' does not overlap the grid domain along the time axis. This causes interpolated values to be nan, leading to meaningless results.
UserWarning: Start time of parameter 'rad' (2024-02-19 00:30:00) is after model start time (2024-02-19 00:00:00). Include additional time at the start of 'rad'. Note: differencing reduces time coverage when providing accumulated radiative fluxes.
```

#### Internals

- Modify unit tests to test updated warnings

## Tests

- [x] QC test passes locally (`make test`)
- [x] CI tests pass

## Reviewer

> @zebengberg 
