### PR TITLE
Prevent rad attributes from being lost during _process_rad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 
 # Changelog
 
+## v0.49.5
+
+## Fixes
+
+- Fix bug where `Cocip._process_rad` lost radiation dataset attributes
+
 ## v0.49.4
 
 ### Breaking changes

--- a/pycontrails/models/cocip/cocip.py
+++ b/pycontrails/models/cocip/cocip.py
@@ -1457,6 +1457,10 @@ def _process_rad(rad: MetDataset) -> MetDataset:
             # Keep the original attrs -- we need these later on
             old_attrs = {k: v.attrs for k, v in rad.data.items()}
 
+            # Also need to keep dataset-level attrs, which are lost
+            # when dividing a Dataset by a DataArray
+            old_rad_attrs = rad.data.attrs
+
             # NOTE: Taking the diff will remove the first time step
             # This is typically what we want (forecast step 0 is all zeros)
             # But, if the data has been downselected for a particular Flight / Fleet,
@@ -1468,6 +1472,7 @@ def _process_rad(rad: MetDataset) -> MetDataset:
             # accumulations by number of hours between steps
             time_diff_h = time_diff / np.timedelta64(1, "h")
             rad.data = rad.data.diff("time", label="upper") / time_diff_h
+            rad.data.attrs = old_rad_attrs
 
             # Add back the original attrs
             for k, v in rad.data.items():

--- a/tests/unit/test_cocip.py
+++ b/tests/unit/test_cocip.py
@@ -374,18 +374,18 @@ def test_cocip_processes_rad_with_warnings(met: MetDataset, rad: MetDataset) -> 
         Cocip(met, rad=rad)
 
 
-def test_cocip_preserves_hres_rad_attrs(
-    hres_dummy_met: MetDataset, hres_dummy_rad: MetDataset
-) -> None:
-    """Test that Cocip preserves dataset-level attributes after processing rad data"""
+def test_cocip_preserves_hres_attrs(hres_dummy_met: MetDataset, hres_dummy_rad: MetDataset) -> None:
+    """Test that Cocip preserves dataset-level attributes after preprocessing met and rad data"""
 
     met = hres_dummy_met
     rad = hres_dummy_rad
-    attrs = rad.data.attrs
+    rad_attrs = rad.data.attrs
+    met_attrs = met.data.attrs
 
     with pytest.warns(UserWarning, match="humidity scaling"):
         Cocip(met=met, rad=rad)
-    assert attrs == rad.data.attrs
+    assert met_attrs == met.data.attrs
+    assert rad_attrs == rad.data.attrs
 
 
 def test_cocip_processes_hres_rad_even_time(

--- a/tests/unit/test_cocip.py
+++ b/tests/unit/test_cocip.py
@@ -374,6 +374,20 @@ def test_cocip_processes_rad_with_warnings(met: MetDataset, rad: MetDataset) -> 
         Cocip(met, rad=rad)
 
 
+def test_cocip_preserves_hres_rad_attrs(
+    hres_dummy_met: MetDataset, hres_dummy_rad: MetDataset
+) -> None:
+    """Test that Cocip preserves dataset-level attributes after processing rad data"""
+
+    met = hres_dummy_met
+    rad = hres_dummy_rad
+    attrs = rad.data.attrs
+
+    with pytest.warns(UserWarning, match="humidity scaling"):
+        Cocip(met=met, rad=rad)
+    assert attrs == rad.data.attrs
+
+
 def test_cocip_processes_hres_rad_even_time(
     hres_dummy_met: MetDataset, hres_dummy_rad: MetDataset
 ) -> None:


### PR DESCRIPTION
Fixes a bug (introduced by my changes in https://github.com/contrailcirrus/pycontrails/pull/155) that causes radiation data attributes to be lost during preprocessing, and adds a unit test to check for this bug.

#### Fixes

> Fix bug where `Cocip._process_rad` lost radiation dataset attributes

## Tests

- [x] QC test passes locally (`make test`)
- [ ] CI tests pass

## Reviewer

> @zebengberg 