### PR TITLE
Bugfix/pytest removal error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Add `ecmwf.Divergence` (a subclass of `MetVariable`) for accessing ERA5 divergence data.
 - Update the [specific humidity interpolation notebook](https://py.contrails.org/notebooks/specific-humidity-interpolation.html) to use the new `ARCOERA5` interface.
 - Adds two parameters to `CoCipParams`, `compute_atr20` and `global_rf_to_atr20_factor`. Setting the former to `True` will add both `global_yearly_mean_rf` and `atr20` to the CoCiP output. 
+- Bump minimum pytest version to 8.1 to avoid failures in release workflow.
 
 ## v0.49.5
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ dev = [
     "pre-commit>=2.10",
     "psutil",
     "pyarrow>=5.0",
-    "pytest>=6.1",
+    "pytest>=8.1",
     "pytest-cov>=2.11",
     "requests>=2.25",
     "ruff==0.1.15",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -210,7 +210,7 @@ filterwarnings = [
     "ignore:`np.bool8` is a deprecated alias:DeprecationWarning:skimage.util.dtype",
     "ignore:'cgi' is deprecated and slated:DeprecationWarning:google.cloud.storage.blob",
     "ignore:Engine 'cfgrib' loading failed:RuntimeWarning:xarray.backends.plugins",
-    "ignore:.*IPyNbFile:pytest.PytestRemovedIn8Warning:_pytest.nodes",
+    "ignore:.*IPyNbFile:pytest.PytestRemovedIn9Warning:_pytest.nodes",
     "ignore:.*pkg_resources:DeprecationWarning",
 ]
 testpaths = ["tests/unit"]


### PR DESCRIPTION
## Changes

Bumps the minimum pytest version to 8.1 for consistency with the version currently being used in the release workflow.

Inconsistencies in pytest versions can produce unexpected errors in the release workflow. For example, https://github.com/contrailcirrus/pycontrails/actions/runs/8254181733 failed because the release workflow used pytest 8.1.1, and 8.1 is the first minor version without `pytest.PytestRemovedIn8Warning` (https://docs.pytest.org/en/7.1.x/backwards-compatibility.html?highlight=removedin). This wasn't caught in earlier testing (https://github.com/contrailcirrus/pycontrails/actions/runs/8253888054), which used pytest 7.4.4.

These changes are a bandaid solution in that they don't prevent similar future errors. These could occur if, for example, the release workflow starts using pytest >=9.1 but the test workflow stays on pytest <=9.0.

#### Internals

- Bump minimum pytest version to 8.1

## Tests

- [x] QC test passes locally (`make test`)
- [x] CI tests pass

## Reviewer

> @mlshapiro 
