### PR TITLE
Feature/grid atr20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Internals
 
-- Adds two parameters to `CoCipParams`, `compute_atr20` and `global_rf_to_atr20_factor`. Setting the former to `True` will add both `global_yearly_mean_rf` and `atr20` to the CoCiP output. 
+- Adds two parameters to `CoCipGridParams`, `compute_atr20` and `global_rf_to_atr20_factor`. Setting the former to `True` will add both `global_yearly_mean_rf` and `atr20` to the CoCiP output. 
 
 ## v0.50.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 
 # Changelog
 
+## v0.50.1
+
+### Features
+
+- Adds optional ATR20 to CoCiPGrid model.
+
+### Internals
+
+- Adds two parameters to `CoCipParams`, `compute_atr20` and `global_rf_to_atr20_factor`. Setting the former to `True` will add both `global_yearly_mean_rf` and `atr20` to the CoCiP output. 
+
 ## v0.50.0
 
 ### Features

--- a/pycontrails/models/cocipgrid/cocip_grid.py
+++ b/pycontrails/models/cocipgrid/cocip_grid.py
@@ -401,7 +401,9 @@ class CocipGrid(models.Model):
 
             if self.params["compute_atr20"]:
                 self.source["global_yearly_mean_rf_per_m"] = (
-                    self.source["ef_per_m"].data / constants.surface_area_earth / constants.seconds_per_year
+                    self.source["ef_per_m"].data
+                    / constants.surface_area_earth
+                    / constants.seconds_per_year
                 )
                 self.source["atr20_per_m"] = (
                     self.params["global_rf_to_atr20_factor"]
@@ -418,7 +420,9 @@ class CocipGrid(models.Model):
 
             if self.params["compute_atr20"]:
                 self.source["global_yearly_mean_rf_per_m"] = (
-                    self.source["ef_per_m"] / constants.surface_area_earth / constants.seconds_per_year
+                    self.source["ef_per_m"]
+                    / constants.surface_area_earth
+                    / constants.seconds_per_year
                 )
                 self.source["atr20_per_m"] = (
                     self.params["global_rf_to_atr20_factor"]

--- a/pycontrails/models/cocipgrid/cocip_grid_params.py
+++ b/pycontrails/models/cocipgrid/cocip_grid_params.py
@@ -1,4 +1,4 @@
-"""Default CocipGrid parameters."""
+"""Default :class:`CocipGrid` parameters."""
 
 from __future__ import annotations
 
@@ -17,7 +17,7 @@ class CocipGridParams(CocipParams):
     # Algorithm
     # ---------
 
-    #: Approximate size of a typical `np.array` used with in CoCiP calculations.
+    #: Approximate size of a typical :class:`numpy.ndarray` used with in CoCiP calculations.
     #: The 4-dimensional array defining the waypoint is raveled and split into
     #: batches of this size.
     #: A smaller number for this parameter will reduce memory footprint at the
@@ -26,25 +26,27 @@ class CocipGridParams(CocipParams):
 
     #: Additional boost to target split size before SAC is computed. For typical meshes, only
     #: 10% of waypoints will survive SAC and initial downwash filtering. Accordingly, this parameter
-    #: magnifies mesh split size before SAC is computed.
+    #: magnifies mesh split size before SAC is computed. See :attr:`target_split_size`.
     target_split_size_pre_SAC_boost: float = 3.0
 
-    #: Display `tqdm` progress bar showing batch evaluation progress.
+    #: Display ``tqdm`` progress bar showing batch evaluation progress.
     show_progress: bool = True
 
     # ------------------
     # Simulated Aircraft
     # ------------------
 
-    #: Nominal segment length to place at each grid point [unit `m`]. Round-off error
+    #: Nominal segment length to place at each grid point [:math:`m`]. Round-off error
     #: can be problematic with a small nominal segment length and a large
-    #: `dt_integration` parameter. On the other hand, too large of a nominal segment
-    #: length diminishes the "locality" of the grid point.
+    #: :attr:`dt_integration` parameter. On the other hand,
+    #: too large of a nominal segment length diminishes the "locality" of the grid point.
     #:
-    #: .. versionadded 0.32.2:: EXPERIMENTAL: If None, run CoCiP in "segment-free"
-    #: mode. This mode does not include any terms involving segments (wind shear,
-    #: segment_length, any derived terms). See :attr:`CocipGridParams.azimuth`
-    #: and :attr:`CocipGridParams.dsn_dz_factor` for more details.
+    #:     .. versionadded:: 0.32.2
+    #:
+    #:     EXPERIMENTAL: If None, run CoCiP in "segment-free"
+    #:     mode. This mode does not include any terms involving segments (wind shear,
+    #:     segment length, any derived terms). See :attr:`azimuth`
+    #:     and :attr:`dsn_dz_factor` for more details.
     segment_length: float | None = 1000.0
 
     #: Fuel type
@@ -60,10 +62,13 @@ class CocipGridParams(CocipParams):
 
     #: Navigation bearing [:math:`\deg`] measured in clockwise direction from
     #: true north, by default 0.0.
-    #: .. versionadded 0.32.2:: EXPERIMENTAL: If None, run CoCiP in "segment-free"
-    #: mode. This mode does not include any terms involving segments (wind shear,
-    #: segment_length, any derived terms), unless :attr:`CocipGridParams.dsn_dz_factor`
-    #: is non-zero.
+    #:
+    #:    .. versionadded:: 0.32.2
+    #:
+    #:    EXPERIMENTAL: If None, run CoCiP in "segment-free"
+    #:    mode. This mode does not include any terms involving segments (wind shear,
+    #:    segment_length, any derived terms), unless :attr:`dsn_dz_factor`
+    #:    is non-zero.
     azimuth: float | None = 0.0
 
     #: Experimental parameter used to approximate ``dsn_dz`` from ``ds_dz`` via
@@ -73,7 +78,7 @@ class CocipGridParams(CocipParams):
     #: ``dsn_dz_factor = 0.665`` adequately approximates the mean EF predictions
     #: of :class:`CocipGrid` over all azimuths.
     #:
-    #: .. versionadded:: 0.32.2.
+    #:     .. versionadded:: 0.32.2
     dsn_dz_factor: float = 0.0
 
     #: --------------------
@@ -90,7 +95,7 @@ class CocipGridParams(CocipParams):
     #: :attr:`aircraft_performance` model is used to estimate the aircraft mass.
     aircraft_mass: float | None = None
 
-    #: Cruising true airspeed, [:math:`m * s^{-1}`]. If included in :attr:`CocipGrid.source`,
+    #: Cruising true airspeed, [:math:`m \ s^{-1}`]. If included in :attr:`CocipGrid.source`,
     #: this parameter is unused. Otherwise, if this parameter is None, the
     #: :attr:`aircraft_performance` model is used to estimate the true airspeed.
     true_airspeed: float | None = None
@@ -100,13 +105,14 @@ class CocipGridParams(CocipParams):
     #: :attr:`aircraft_performance` model is used to estimate the engine efficiency.
     engine_efficiency: float | None = None
 
-    #: Nominal fuel flow, [:math:`kg s^{-1}`]. If included in :attr:`CocipGrid.source`,
+    #: Nominal fuel flow, [:math:`kg \ s^{-1}`]. If included in :attr:`CocipGrid.source`,
     #: this parameter is unused. Otherwise, if this parameter is None, the
     #: :attr:`aircraft_performance` model is used to estimate the fuel flow.
     fuel_flow: float | None = None
 
     #: Aircraft performance model. Required unless ``source`` or ``params``
     #: provide all of the following variables:
+    #:
     #: - wingspan
     #: - true_airspeed (or mach_number)
     #: - fuel_flow
@@ -123,7 +129,7 @@ class CocipGridParams(CocipParams):
     # ------------
 
     #: Attach additional formation specific data to the output. If True, attach
-    #: all possible formation data. See :ref:pycontrails.models.cocipgrid.cocip_grid`
+    #: all possible formation data. See :mod:`pycontrails.models.cocipgrid.cocip_grid`
     #: for a list of supported formation data.
     verbose_outputs_formation: bool | set[str] = False
 

--- a/pycontrails/models/cocipgrid/cocip_grid_params.py
+++ b/pycontrails/models/cocipgrid/cocip_grid_params.py
@@ -1,4 +1,4 @@
-"""Default :class:`CocipGrid` parameters."""
+"""Default CocipGrid parameters."""
 
 from __future__ import annotations
 
@@ -17,7 +17,7 @@ class CocipGridParams(CocipParams):
     # Algorithm
     # ---------
 
-    #: Approximate size of a typical :class:`numpy.ndarray` used with in CoCiP calculations.
+    #: Approximate size of a typical `np.array` used with in CoCiP calculations.
     #: The 4-dimensional array defining the waypoint is raveled and split into
     #: batches of this size.
     #: A smaller number for this parameter will reduce memory footprint at the
@@ -26,27 +26,25 @@ class CocipGridParams(CocipParams):
 
     #: Additional boost to target split size before SAC is computed. For typical meshes, only
     #: 10% of waypoints will survive SAC and initial downwash filtering. Accordingly, this parameter
-    #: magnifies mesh split size before SAC is computed. See :attr:`target_split_size`.
+    #: magnifies mesh split size before SAC is computed.
     target_split_size_pre_SAC_boost: float = 3.0
 
-    #: Display ``tqdm`` progress bar showing batch evaluation progress.
+    #: Display `tqdm` progress bar showing batch evaluation progress.
     show_progress: bool = True
 
     # ------------------
     # Simulated Aircraft
     # ------------------
 
-    #: Nominal segment length to place at each grid point [:math:`m`]. Round-off error
+    #: Nominal segment length to place at each grid point [unit `m`]. Round-off error
     #: can be problematic with a small nominal segment length and a large
-    #: :attr:`dt_integration` parameter. On the other hand,
-    #: too large of a nominal segment length diminishes the "locality" of the grid point.
+    #: `dt_integration` parameter. On the other hand, too large of a nominal segment
+    #: length diminishes the "locality" of the grid point.
     #:
-    #:     .. versionadded:: 0.32.2
-    #:
-    #:     EXPERIMENTAL: If None, run CoCiP in "segment-free"
-    #:     mode. This mode does not include any terms involving segments (wind shear,
-    #:     segment length, any derived terms). See :attr:`azimuth`
-    #:     and :attr:`dsn_dz_factor` for more details.
+    #: .. versionadded 0.32.2:: EXPERIMENTAL: If None, run CoCiP in "segment-free"
+    #: mode. This mode does not include any terms involving segments (wind shear,
+    #: segment_length, any derived terms). See :attr:`CocipGridParams.azimuth`
+    #: and :attr:`CocipGridParams.dsn_dz_factor` for more details.
     segment_length: float | None = 1000.0
 
     #: Fuel type
@@ -62,13 +60,10 @@ class CocipGridParams(CocipParams):
 
     #: Navigation bearing [:math:`\deg`] measured in clockwise direction from
     #: true north, by default 0.0.
-    #:
-    #:    .. versionadded:: 0.32.2
-    #:
-    #:    EXPERIMENTAL: If None, run CoCiP in "segment-free"
-    #:    mode. This mode does not include any terms involving segments (wind shear,
-    #:    segment_length, any derived terms), unless :attr:`dsn_dz_factor`
-    #:    is non-zero.
+    #: .. versionadded 0.32.2:: EXPERIMENTAL: If None, run CoCiP in "segment-free"
+    #: mode. This mode does not include any terms involving segments (wind shear,
+    #: segment_length, any derived terms), unless :attr:`CocipGridParams.dsn_dz_factor`
+    #: is non-zero.
     azimuth: float | None = 0.0
 
     #: Experimental parameter used to approximate ``dsn_dz`` from ``ds_dz`` via
@@ -78,7 +73,7 @@ class CocipGridParams(CocipParams):
     #: ``dsn_dz_factor = 0.665`` adequately approximates the mean EF predictions
     #: of :class:`CocipGrid` over all azimuths.
     #:
-    #:     .. versionadded:: 0.32.2
+    #: .. versionadded:: 0.32.2.
     dsn_dz_factor: float = 0.0
 
     #: --------------------
@@ -95,7 +90,7 @@ class CocipGridParams(CocipParams):
     #: :attr:`aircraft_performance` model is used to estimate the aircraft mass.
     aircraft_mass: float | None = None
 
-    #: Cruising true airspeed, [:math:`m \ s^{-1}`]. If included in :attr:`CocipGrid.source`,
+    #: Cruising true airspeed, [:math:`m * s^{-1}`]. If included in :attr:`CocipGrid.source`,
     #: this parameter is unused. Otherwise, if this parameter is None, the
     #: :attr:`aircraft_performance` model is used to estimate the true airspeed.
     true_airspeed: float | None = None
@@ -105,14 +100,13 @@ class CocipGridParams(CocipParams):
     #: :attr:`aircraft_performance` model is used to estimate the engine efficiency.
     engine_efficiency: float | None = None
 
-    #: Nominal fuel flow, [:math:`kg \ s^{-1}`]. If included in :attr:`CocipGrid.source`,
+    #: Nominal fuel flow, [:math:`kg s^{-1}`]. If included in :attr:`CocipGrid.source`,
     #: this parameter is unused. Otherwise, if this parameter is None, the
     #: :attr:`aircraft_performance` model is used to estimate the fuel flow.
     fuel_flow: float | None = None
 
     #: Aircraft performance model. Required unless ``source`` or ``params``
     #: provide all of the following variables:
-    #:
     #: - wingspan
     #: - true_airspeed (or mach_number)
     #: - fuel_flow
@@ -129,10 +123,20 @@ class CocipGridParams(CocipParams):
     # ------------
 
     #: Attach additional formation specific data to the output. If True, attach
-    #: all possible formation data. See :mod:`pycontrails.models.cocipgrid.cocip_grid`
+    #: all possible formation data. See :ref:pycontrails.models.cocipgrid.cocip_grid`
     #: for a list of supported formation data.
     verbose_outputs_formation: bool | set[str] = False
 
     #: Attach contrail evolution data to :attr:`CocipGrid.contrail_list`. Requires
     #: substantial memory overhead.
     verbose_outputs_evolution: bool = False
+
+    #: Add additional metric of ATR20 and global yearly mean RF to model output.
+    #: These are not standard CoCiP outputs but based on the derivation used
+    #: in the first supplement to :cite:`yin_predicting_2023`. ATR20 is defined
+    #: as the average temperature response over a 20 year horizon.
+    compute_atr20: bool = False
+
+    #: Constant factor used to convert global- and year-mean RF, [:math:`W m^{-2}`],
+    #: to ATR20, [:math:`K`], given by :cite:`yin_predicting_2023`.
+    global_rf_to_atr20_factor: float = 0.0151

--- a/pycontrails/models/cocipgrid/cocip_grid_params.py
+++ b/pycontrails/models/cocipgrid/cocip_grid_params.py
@@ -136,13 +136,3 @@ class CocipGridParams(CocipParams):
     #: Attach contrail evolution data to :attr:`CocipGrid.contrail_list`. Requires
     #: substantial memory overhead.
     verbose_outputs_evolution: bool = False
-
-    #: Add additional metric of ATR20 and global yearly mean RF to model output.
-    #: These are not standard CoCiP outputs but based on the derivation used
-    #: in the first supplement to :cite:`yin_predicting_2023`. ATR20 is defined
-    #: as the average temperature response over a 20 year horizon.
-    compute_atr20: bool = False
-
-    #: Constant factor used to convert global- and year-mean RF, [:math:`W m^{-2}`],
-    #: to ATR20, [:math:`K`], given by :cite:`yin_predicting_2023`.
-    global_rf_to_atr20_factor: float = 0.0151

--- a/tests/unit/test_cocip_grid.py
+++ b/tests/unit/test_cocip_grid.py
@@ -295,7 +295,6 @@ def test_atr20_outputs(
     """Confirm each verbose_outputs parameter is attached to results."""
     instance_params["compute_atr20"] = True
     model = CocipGrid(**instance_params)
-    t_step = np.timedelta64(20, "m")
     start_time = np.datetime64("2019-01-01")
     source = CocipGrid.create_source(
         level=[220, 230, 240, 250],

--- a/tests/unit/test_cocip_grid.py
+++ b/tests/unit/test_cocip_grid.py
@@ -323,6 +323,7 @@ def test_atr20_outputs(
     assert ds["atr20_per_m"].mean() == pytest.approx(2.504e-18, rel=rel)
     assert ds["global_yearly_mean_rf_per_m"].mean() == pytest.approx(1.659e-16, rel=rel)
 
+
 ##############################################################
 # NOTE: No tests below here will run unless BADA is available.
 ##############################################################

--- a/tests/unit/test_cocip_grid.py
+++ b/tests/unit/test_cocip_grid.py
@@ -269,6 +269,11 @@ def test_cocip_grid_met_nonuniform_time(
     assert df.isna().sum().sum() == 0
 
 
+##############################################################
+# NOTE: No tests below here will run unless BADA is available.
+##############################################################
+
+
 @pytest.fixture()
 def grid_results(
     instance_params: dict[str, Any],
@@ -321,11 +326,6 @@ def test_atr20_outputs(
     rel = 1e-2
     assert ds["atr20_per_m"].mean() == pytest.approx(2.504e-18, rel=rel)
     assert ds["global_yearly_mean_rf_per_m"].mean() == pytest.approx(1.659e-16, rel=rel)
-
-
-##############################################################
-# NOTE: No tests below here will run unless BADA is available.
-##############################################################
 
 
 @pytest.mark.parametrize("aircraft_type", ["B737", "A320", "A359", "B772"])


### PR DESCRIPTION
## Changes

> Adds optional ATR20 to CoCiPGrid model.

#### Internals

> Adds two parameters to `CoCipGridParams`, `compute_atr20` and `global_rf_to_atr20_factor`. Setting the former to `True` will add both `global_yearly_mean_rf` and `atr20` to the CoCiP output.

## Tests

- [x] QC test passes locally (`make test`)
- [x] CI tests pass

