### PR TITLE
Fix/short flight resampling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,17 @@
 
 ## v0.50.1
 
+### Breaking changes
+
+- Updates to flight resampling logic now ensure that resampled waypoints include any and all times between flight start and end times that are a multiple of the resampling frequency. This may add an additional waypoint to some flights after resampling, and may result in `Flight.resample_and_fill` returning a flight with a single waypoint rather than an empty flight.
+
 ### Features
 
 - Adds optional ATR20 to CoCiPGrid model.
+
+### Fixes
+
+- Update flight resampling logic to align with expected behavior for very short flights, which is now detailed in the `Flight.resample_and_fill` docstring.
 
 ### Internals
 

--- a/pycontrails/core/flight.py
+++ b/pycontrails/core/flight.py
@@ -2063,11 +2063,9 @@ def _resample_to_freq(df: pd.DataFrame, freq: str) -> tuple[pd.DataFrame, pd.Dat
 
     # Manually create a new index that includes all the original index values
     # and the resampled-to-freq index values.
-    t0 = df.index[0]
+    t0 = df.index[0].ceil(freq)
     t1 = df.index[-1]
-    t = pd.date_range(t0, t1, freq=freq, name="time").floor(freq)
-    if t[0] < t0:
-        t = t[1:]
+    t = pd.date_range(t0, t1, freq=freq, name="time")
 
     concat_arr = np.concatenate([df.index, t])
     concat_arr = np.unique(concat_arr)

--- a/pycontrails/core/flight.py
+++ b/pycontrails/core/flight.py
@@ -787,6 +787,13 @@ class Flight(GeoVectorDataset):
         Waypoints are resampled according to the frequency ``freq``. Values for :attr:`data`
         columns ``longitude``, ``latitude``, and ``altitude`` are interpolated.
 
+        Resampled waypoints will include all multiples of ``freq`` between the flight
+        start and end time. For example, when resampling to a frequency of 1 minute,
+        a flight that starts at 2020/1/1 00:00:59 and ends at 2020/1/1 00:01:01
+        will return a single waypoint at 2020/1/1 00:01:00, whereas a flight that
+        starts at 2020/1/1 00:01:01 and ends at 2020/1/1 00:01:59 will return an empty
+        flight.
+
         Parameters
         ----------
         freq : str, optional

--- a/pycontrails/core/flight.py
+++ b/pycontrails/core/flight.py
@@ -1356,8 +1356,8 @@ class Flight(GeoVectorDataset):
         >>> # Intersect and attach
         >>> fl["air_temperature"] = fl.intersect_met(met['air_temperature'])
         >>> fl["air_temperature"]
-        array([235.94658, 235.95767, 235.96873, ..., 234.59918, 234.60388,
-               234.60846], dtype=float32)
+        array([235.94684, 235.95789, 235.96889, ..., 234.59914, 234.6038 ,
+               234.60838], dtype=float32)
 
         >>> # Length (in meters) of waypoints whose temperature exceeds 236K
         >>> fl.length_met("air_temperature", threshold=236)

--- a/pycontrails/core/flight.py
+++ b/pycontrails/core/flight.py
@@ -1356,8 +1356,8 @@ class Flight(GeoVectorDataset):
         >>> # Intersect and attach
         >>> fl["air_temperature"] = fl.intersect_met(met['air_temperature'])
         >>> fl["air_temperature"]
-        array([235.94684, 235.95789, 235.96889, ..., 234.59914, 234.6038 ,
-               234.60838], dtype=float32)
+        array([235.94658, 235.95767, 235.96873, ..., 234.59918, 234.60388,
+               234.60846], dtype=float32)
 
         >>> # Length (in meters) of waypoints whose temperature exceeds 236K
         >>> fl.length_met("air_temperature", threshold=236)

--- a/tests/unit/test_flight.py
+++ b/tests/unit/test_flight.py
@@ -49,26 +49,6 @@ def random_flight_list(rng: np.random.Generator) -> list[Flight]:
     return [_random_flight() for _ in range(100)]
 
 
-@pytest.fixture()
-def short_fl_spans_minute() -> tuple[Flight, Flight]:
-    return Flight(
-        longitude=[0, 1],
-        latitude=0,
-        altitude=0,
-        time=pd.date_range("2020-01-01 00:00:59", "2020-01-01 00:01:01", periods=2),
-    )
-
-
-@pytest.fixture()
-def short_fl_within_minute() -> tuple[Flight, Flight]:
-    return Flight(
-        longitude=[0, 1],
-        latitude=0,
-        altitude=0,
-        time=pd.date_range("2020-01-01 00:01:01", "2020-01-01 00:01:03", periods=2),
-    )
-
-
 ##########
 # Tests
 ##########
@@ -354,7 +334,7 @@ def test_resampling_10t(fl: Flight, flight_meridian: Flight) -> None:
     """Test Flight.resample_and_fill() with 10T resampling."""
     fl2 = fl.resample_and_fill("10min")
     assert len(fl2) == 14
-    expected = pd.date_range(fl.time_start, fl.time_end, freq="10min").floor("10min")[1:]
+    expected = pd.date_range(fl.time_start.ceil("10min"), fl.time_end, freq="10min")
     np.testing.assert_array_equal(fl2["time"], expected)
 
 
@@ -365,7 +345,7 @@ def test_resample_large_geodesic_threshold(fl: Flight) -> None:
     fl3 = fl.resample_and_fill("1min", "geodesic", 1000e3)
     assert fl2 == fl3
 
-    expected = pd.date_range(fl.time_start, fl.time_end, freq="1min").floor("1min")[1:]
+    expected = pd.date_range(fl.time_start.ceil("1min"), fl.time_end, freq="1min")
     np.testing.assert_array_equal(fl3["time"], expected)
 
 

--- a/tests/unit/test_flight.py
+++ b/tests/unit/test_flight.py
@@ -345,8 +345,8 @@ def test_flight_filtering_methods(flight_data: pd.DataFrame, flight_attrs: dict[
 def test_resampling_10s(fl: Flight) -> None:
     """Test Flight.resample_and_fill() with 10s resampling."""
     fl2 = fl.resample_and_fill("10s")
-    assert len(fl2) == 889
-    expected = pd.date_range(fl.time_start, fl.time_end, freq="10s").floor("10s")[1:]
+    assert len(fl2) == 890
+    expected = pd.date_range(fl.time_start.ceil("10s"), fl.time_end, freq="10s")
     np.testing.assert_array_equal(fl2["time"], expected)
 
 
@@ -376,9 +376,9 @@ def test_resample_over_meridian(flight_meridian: Flight, freq: str) -> None:
     bound = 2.0 if freq == "5min" else 1.0
     assert np.all(np.abs(np.diff(fl2["longitude"] % 360.0)) < bound)
 
-    expected = pd.date_range(flight_meridian.time_start, flight_meridian.time_end, freq=freq).floor(
-        freq
-    )[1:]
+    expected = pd.date_range(
+        flight_meridian.time_start.ceil(freq), flight_meridian.time_end, freq=freq
+    )
     np.testing.assert_array_equal(fl2["time"], expected)
 
 


### PR DESCRIPTION
Addresses https://github.com/contrailcirrus/flights-pipeline/issues/56

## Changes

Updates flight resampling logic to ensure that resampled waypoints include any and all times between flight start and end times that are a multiple of the resampling frequency.

#### Breaking changes

Updates to flight resampling logic may add an additional waypoint to some flights after resampling, and may result in `Flight.resample_and_fill` returning a flight with a single waypoint rather than an empty flight.

#### Fixes

Flight resampling aligns with expected behavior for very short flights, which is now detailed in the `Flight.resample_and_fill` docstring.

## Tests

- [ ] QC test passes locally (`make test`)
- [x] CI tests pass

## Reviewer

@nickmasson
