### PR TITLE
Fix/geodesic interpolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,19 @@
 
 ## v0.50.3
 
+### Breaking changes
+
+- Geodesic interpolation is now used in `Flight.resample_and_fill` when the great circle distance between waypoints (rather than the total segment length including vertical displacement) exceeds a threshold. This may change the interpolation method used when resampling flight segments with lengths close to the geodesic interpolation threshold.
+
 ### Features
 
 - Add `ERA5ModelLevel` and `HRESModelLevel` interfaces for accessing ERA5 and HRES data on model levels.
 - Update [ECMWF tutorial notebook](https://py.contrails.org/notebooks/ECMWF.html) with instructions for using model-level datalibs.
 - Add `HistogramMatching` humidity scaling calibrated for model-level ERA5 data.
+
+### Fixes
+
+- Use horizontal great circle distance to determine whether geodesic interpolation is used in `Flight.resample_and_fill`. This ensures geodesic interpolation is used between sufficiently distant waypoints even when one or both waypoints contain NaN altitude data.
 
 ### Internals
 

--- a/pycontrails/core/flight.py
+++ b/pycontrails/core/flight.py
@@ -454,7 +454,7 @@ class Flight(GeoVectorDataset):
         `np.nan` appended so the length of the output is the same as number of waypoints.
 
         To account for vertical displacements when computing segment lengths,
-        use :meth:`segment_length`
+        use :meth:`segment_length`.
 
         Returns
         -------

--- a/tests/unit/test_flight.py
+++ b/tests/unit/test_flight.py
@@ -384,6 +384,19 @@ def test_geodesic_interpolation(fl: Flight) -> None:
         fl_alt.resample_and_fill(fill_method="nearest")
 
 
+def test_geodesic_interpolation_nan_altitude(fl: Flight) -> None:
+    """Test geodesic interpolation with NaN altitudes."""
+    fl_valid_alt = Flight(fl.dataframe)
+    fl_valid_alt["altitude"][:] = 10000.0
+    fl2 = fl_valid_alt.resample_and_fill("1min", "geodesic", geodesic_threshold=1e3)
+    fl_missing_alt = Flight(fl.dataframe)
+    fl_missing_alt["altitude"][:] = 10000.0
+    fl_missing_alt["altitude"][1:-1] = np.nan
+    fl3 = fl_missing_alt.resample_and_fill("1min", "geodesic", geodesic_threshold=1e3)
+    for col in ["longitude", "latitude", "altitude", "time"]:
+        np.testing.assert_array_equal(fl2[col], fl3[col])
+
+
 def test_resample_keep_original(fl: Flight) -> None:
     """Test Flight.resample_and_fill() with keep_original_index=True."""
     fl2 = fl.resample_and_fill("1min", keep_original_index=True)


### PR DESCRIPTION
Closes #182

## Changes

This PR changes the condition for using geodesic interpolation in `Flight.resample_and_fill` from one based on total segment length to one based on (horizontal) great circle distance. This seems reasonable on physical grounds (the error in using linear interpolation to estimate the position of a flight following a great circle is a function of the horizontal distance between waypoints), and fixes the bug documented in #182:

![image](https://github.com/contrailcirrus/pycontrails/assets/11680078/1aacf678-0a64-4af1-943b-0ab60bfcfe89)

#### Breaking changes

- Geodesic interpolation is now used in `Flight.resample_and_fill` when the great circle distance between waypoints (rather than the total segment length including vertical displacement) exceeds a threshold. This may change the interpolation method used when resampling flight segments with lengths close to the geodesic interpolation threshold.

#### Fixes

- Use horizontal great circle distance to determine whether geodesic interpolation is used in `Flight.resample_and_fill`. This ensures geodesic interpolation is used between sufficiently distant waypoints even when one or both waypoints contain NaN altitude data.

## Tests

- [x] QC test passes locally (`make test`)
- [x] CI tests pass

## Reviewer

> @mlshapiro 
