### PR TITLE
Feature/upper bound polygons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,14 @@
 
 - Geodesic interpolation is now used in `Flight.resample_and_fill` when the great circle distance between waypoints (rather than the total segment length including vertical displacement) exceeds a threshold. This may change the interpolation method used when resampling flight segments with lengths close to the geodesic interpolation threshold.
 - Fixed typo in `thermo.c_pm`  will decrease computed values of moist heat capacity with non-zero specific humidity. We expect the downstream impact on contrail predictions by `ISSR`, `SAC`, `PCR, and `Cocip` models to be minimal.
+- `np.nan` is now used as the default `fill_value` in `MetDataArray.to_polygon_feature` and `MetDataArray.to_polygon_feature_collection`. This ensures that NaN values are never included in polygon interiors unless a non-NaN `fill_value` is explicitly passed as a keyword argument.
 
 ### Features
 
 - Add `ERA5ModelLevel` and `HRESModelLevel` interfaces for accessing ERA5 and HRES data on model levels.
 - Update [ECMWF tutorial notebook](https://py.contrails.org/notebooks/ECMWF.html) with instructions for using model-level datalibs.
 - Add `HistogramMatching` humidity scaling calibrated for model-level ERA5 data.
-- Add ability to use `polygon.find_multipolygon` to find regions with values below a threshold.
+- Modify `polygon.find_multipolygon`, `MetDataArray.to_polygon_feature`, `MetDataArray.to_polygon_feature_collection`, and `MetDataArray.to_polyhedra` to permit finding regions with values above or below a threshold.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Add `ERA5ModelLevel` and `HRESModelLevel` interfaces for accessing ERA5 and HRES data on model levels.
 - Update [ECMWF tutorial notebook](https://py.contrails.org/notebooks/ECMWF.html) with instructions for using model-level datalibs.
 - Add `HistogramMatching` humidity scaling calibrated for model-level ERA5 data.
+- Add ability to use `polygon.find_multipolygon` to find regions with values below a threshold.
 
 ### Fixes
 

--- a/pycontrails/core/met.py
+++ b/pycontrails/core/met.py
@@ -2020,6 +2020,7 @@ class MetDataArray(MetBase):
         time: datetime | None = ...,
         iso_value: float = ...,
         simplify_fraction: float = ...,
+        lower_bound: bool = ...,
         return_type: Literal["geojson"],
         path: str | None = ...,
         altitude_scale: float = ...,
@@ -2034,6 +2035,7 @@ class MetDataArray(MetBase):
         time: datetime | None = ...,
         iso_value: float = ...,
         simplify_fraction: float = ...,
+        lower_bound: bool = ...,
         return_type: Literal["mesh"],
         path: str | None = ...,
         altitude_scale: float = ...,
@@ -2047,6 +2049,7 @@ class MetDataArray(MetBase):
         time: datetime | None = None,
         iso_value: float = 0.0,
         simplify_fraction: float = 1.0,
+        lower_bound: bool = True,
         return_type: str = "geojson",
         path: str | None = None,
         altitude_scale: float = 1.0,
@@ -2067,6 +2070,9 @@ class MetDataArray(MetBase):
             Apply `open3d` `simplify_quadric_decimation` method to simplify the polyhedra geometry.
             This parameter must be in the half-open interval (0.0, 1.0].
             Defaults to 1.0, corresponding to no reduction.
+        lower_bound : bool, optional
+            Whether to use ``iso_value`` as a lower or upper bound on values in polyhedra interiors.
+            By default, True.
         return_type : str, optional
             Must be one of "geojson" or "mesh". Defaults to "geojson".
             If "geojson", this method returns a dictionary representation of a geojson MultiPolygon
@@ -2153,6 +2159,11 @@ class MetDataArray(MetBase):
 
         # 3d array of longitude, latitude, altitude values
         volume = self.data.sel(time=time).values
+
+        # invert if iso_value is an upper bound on interior values
+        if not lower_bound:
+            volume = -volume
+            iso_value = -iso_value
 
         # convert from array index back to coordinates
         longitude = self.indexes["longitude"].values

--- a/pycontrails/core/met.py
+++ b/pycontrails/core/met.py
@@ -1887,6 +1887,14 @@ class MetDataArray(MetBase):
         dict[str, Any]
             Python representation of GeoJSON Feature with MultiPolygon geometry.
 
+        Notes
+        -----
+        :class:`Cocip` and :class:`CocipGrid` set some quantities to 0 and other quantities
+        to ``np.nan`` in regions where no contrails form. When computing polygons from
+        :class:`Cocip` or :class:`CocipGrid` output, take care that the choice of
+        ``fill_value`` correctly includes or excludes contrail-free regions. See the
+        :class:`Cocip` documentation for details about ``np.nan`` in model output.
+
         See Also
         --------
         :meth:`to_polyhedra`

--- a/pycontrails/core/polygon.py
+++ b/pycontrails/core/polygon.py
@@ -283,6 +283,7 @@ def find_multipolygon(
     threshold: float,
     min_area: float,
     epsilon: float,
+    lower_bound: bool = True,
     interiors: bool = True,
     convex_hull: bool = False,
     longitude: npt.NDArray[np.float64] | None = None,
@@ -304,10 +305,13 @@ def find_multipolygon(
     epsilon : float
         Epsilon value to use when simplifying the polygons. Passed into shapely's
         :meth:`shapely.geometry.Polygon.simplify` method.
+    lower_bound : bool, optional
+        Whether to treat ``threshold`` as a lower or upper bound on values in polygon interiors.
+        By default, True.
     interiors : bool, optional
-        Whether to include interior polygons.
+        Whether to include interior polygons. By default, True.
     convex_hull : bool, optional
-        Experimental. Whether to take the convex hull of each polygon.
+        Experimental. Whether to take the convex hull of each polygon. By default, False.
     longitude : npt.NDArray[np.float64] | None, optional
         If provided, the coordinates values corresponding to the longitude dimensions of ``arr``.
         The contour coordinates will be converted to longitude-latitude values by indexing
@@ -339,7 +343,10 @@ def find_multipolygon(
         buffer = 0.5
 
     arr_bin = np.empty(arr.shape, dtype=np.uint8)
-    np.greater_equal(arr, threshold, out=arr_bin)
+    if lower_bound:
+        np.greater_equal(arr, threshold, out=arr_bin)
+    else:
+        np.less_equal(arr, threshold, out=arr_bin)
 
     mode = cv2.RETR_CCOMP if interiors else cv2.RETR_EXTERNAL
     contours, hierarchy = cv2.findContours(arr_bin, mode, cv2.CHAIN_APPROX_SIMPLE)

--- a/tests/unit/test_met.py
+++ b/tests/unit/test_met.py
@@ -734,9 +734,13 @@ def test_polygon_island_lower_upper_bound(
         iso_value=0.5, lower_bound=True, epsilon=0.01, precision=2
     )
     geojson2 = island_slice_neg.to_polygon_feature(
+        iso_value=-0.5, lower_bound=True, epsilon=0.01, precision=2
+    )
+    geojson3 = island_slice_neg.to_polygon_feature(
         iso_value=-0.5, lower_bound=False, epsilon=0.01, precision=2
     )
-    assert geojson1 == geojson2
+    assert geojson1 != geojson2
+    assert geojson1 == geojson3
 
 
 @pytest.mark.parametrize("interiors", [True, False])
@@ -913,9 +917,11 @@ def test_polyhedra_lower_upper_bound(sparse_binary: tuple[MetDataArray, dict]) -
     mda1 = MetDataArray(mda.data.isel(time=[0]))
     mda2 = MetDataArray(-mda.data.isel(time=[0]))
 
-    geojson1 = mda1.to_polyhedra(iso_value=0.5)
-    geojson2 = mda2.to_polyhedra(iso_value=-0.5)
-    assert geojson1 == geojson2
+    geojson1 = mda1.to_polyhedra(iso_value=0.5, lower_bound=True)
+    geojson2 = mda2.to_polyhedra(iso_value=-0.5, lower_bound=True)
+    geojson3 = mda2.to_polyhedra(iso_value=-0.5, lower_bound=False)
+    assert geojson1 != geojson2
+    assert geojson1 == geojson3
 
 
 def test_save_load(met_ecmwf_pl_path: str, met_era5_fake: MetDataset) -> None:


### PR DESCRIPTION
Closes #191

## Changes

Adds a `lower_bound` keyword argument to `polygon.find_multipolygon` that controls whether `threshold` is used as a lower or upper bound on the value of regions inside polygons. The default value (`lower_bound=True`) preserves existing behavior (using `threshold` as a lower bound). 

To find cooling polygons where `threshold` is an upper bound on EF, pass `lower_bound=False`:
```python
threshold = -1e7
mp = polygon.find_multipolygon(ef, threshold, lower_bound=False, ...)
```

#### Features

Add ability to use `polygon.find_multipolygon` to find regions with values below a threshold.

## Tests

- [x] QC test passes locally (`make test`)
- [x] CI tests pass

## Reviewer

> @nickmasson, @mlshapiro 
