### PR TITLE
Try adding ecmwflibs to complete install to address #54

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,7 @@ ecmwf = [
     "cdsapi>=0.4",
     "cfgrib>=0.9",
     "eccodes>=1.4",
+    "ecmwflibs>=0.5",
     "ecmwf-api-client>=1.6",
     "netcdf4>=1.6.1",
     "platformdirs>=3.0",


### PR DESCRIPTION
Closes #54 

## Changes

> Description of changes in this PR.
> Use `make changelog` for starter.
> Should be copied and commit to `CHANGELOG.md`

#### Breaking changes

#### Features

#### Fixes

#### Internals

- Adds `ecmwflibs>0.5` to the list of dependencies for the `pycontrails[ecmwf]` optional dependency list

## Tests

- [ ] QC test passes locally (`make test`)
- [ ] CI tests pass

## Reviewer

> Select @ reviewer
