### PR TITLE
Exclude netcdf4 1.7.0 in dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.52.0
+
+### Fixes
+
+- Exclude netCDF version 1.7.0, which causes non-deterministic failures in unit tests primarily due to segmentation faults.
+
 ## v0.51.2
 
 ### Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ ecmwf = [
     "cfgrib>=0.9",
     "eccodes>=1.4",
     "ecmwf-api-client>=1.6",
-    "netcdf4>=1.6.1,!=1.7.0",
+    "netcdf4>=1.6.1,<1.7.0",
     "platformdirs>=3.0",
     "requests>=2.25",
     "lxml>=5.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ ecmwf = [
     "cfgrib>=0.9",
     "eccodes>=1.4",
     "ecmwf-api-client>=1.6",
-    "netcdf4>=1.6.1",
+    "netcdf4>=1.6.1,!=1.7.0",
     "platformdirs>=3.0",
     "requests>=2.25",
     "lxml>=5.1.0"


### PR DESCRIPTION
Unit tests have been failing non-deterministically since the release of [netCDF4 version 1.7.0](https://pypi.org/project/netCDF4/1.7.0/).

To reproduce failures, run
```bash
while pytest tests/unit/test_ecmwf.py; do; done
```
with netCDF4 1.7.0 installed.

For failures in CI, see e.g. https://github.com/contrailcirrus/pycontrails/actions/runs/9519726634.

Downgrading to netCDF4 1.6.5 appears to resolve this problem.

## Changes

#### Fixes

- Exclude netCDF version 1.7.0, which causes non-deterministic failures in unit tests primarily due to segmentation faults.

## Tests

- [x] QC test passes locally (`make test`)
- [x] CI tests pass

## Reviewer

> @mlshapiro 
