### PR TITLE
Build wheels with numpy 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,20 @@
 
 - Exclude netCDF version 1.7.0, which causes non-deterministic failures in unit tests primarily due to segmentation faults.
 
+### Features
+
+- Update the `pycontrails` build system to require `numpy 2.0` per the [official numpy guidelines](https://numpy.org/devdocs/dev/depending_on_numpy.html#numpy-2-0-specific-advice). Note that the runtime requirement for `pycontrails` remains `numpy>=1.22`.
+- Update `pycontrails` for breaking changes introduced in `numpy 2.0` (e.g., [NEP 50](https://numpy.org/neps/nep-0050-scalar-promotion.html)). All changes are backward compatible with `numpy>=1.22`.
+
 ## v0.51.2
 
 ### Features
 
-- Add functionality to automatically compare  simulated contrails from `cocip.Cocip` with GOES satellite imagery (`compare_cocip_with_goes`)
+- Add functionality to automatically compare  simulated contrails from `cocip.Cocip` with GOES satellite imagery (`compare_cocip_with_goes`).
 
 ### Internals
 
-- Fix documentation build in CI
+- Fix documentation build in CI.
 
 ## v0.51.1
 
@@ -24,9 +29,9 @@
 
 ### Features
 
-- PS model: Support four aircraft types, including `E75L`, `E75S`, `E290`, and `E295`
-- PS model: Integrate `ps_synonym_list` to increase PS model aircraft type coverage to 102
-- PS model: Account for increase in fuel consumption due to engine deterioration between maintenance cycle
+- PS model: Support four aircraft types, including `E75L`, `E75S`, `E290`, and `E295`.
+- PS model: Integrate `ps_synonym_list` to increase PS model aircraft type coverage to 102.
+- PS model: Account for increase in fuel consumption due to engine deterioration between maintenance cycle.
 
 ### Internals
 

--- a/pycontrails/models/cocipgrid/cocip_grid.py
+++ b/pycontrails/models/cocipgrid/cocip_grid.py
@@ -749,12 +749,13 @@ class CocipGrid(models.Model):
 
         # These should probably not be included in model input ... so
         # we'll get a warning if they get overwritten
-        vector["longitude_head"], vector["latitude_head"] = geo.forward_azimuth(
-            lons=lons, lats=lats, az=azimuth, dist=dist
-        )
-        vector["longitude_tail"], vector["latitude_tail"] = geo.forward_azimuth(
-            lons=lons, lats=lats, az=azimuth, dist=-dist
-        )
+        lon_head, lat_head = geo.forward_azimuth(lons=lons, lats=lats, az=azimuth, dist=dist)
+        vector["longitude_head"] = lon_head.astype(self._target_dtype, copy=False)
+        vector["latitude_head"] = lat_head.astype(self._target_dtype, copy=False)
+
+        lon_tail, lat_tail = geo.forward_azimuth(lons=lons, lats=lats, az=azimuth, dist=-dist)
+        vector["longitude_tail"] = lon_tail.astype(self._target_dtype, copy=False)
+        vector["latitude_tail"] = lat_tail.astype(self._target_dtype, copy=False)
 
         return vector
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,8 @@ requires = [
     "setuptools_scm",
     "wheel",
     "cython",
-    "oldest-supported-numpy",
+    # https://numpy.org/devdocs/dev/depending_on_numpy.html#numpy-2-abi-handling
+    "numpy>=2.0.0rc2",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -199,7 +199,7 @@ show_error_codes = true
 [tool.black]
 line-length = 100
 preview = true
-required_version = "24.4.1"
+required-version = "24.4.1"
 
 # pytest
 # https://docs.pytest.org/en/7.1.x/reference/customize.html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ dev = [
     "pytest-cov>=2.11",
     "requests>=2.25",
     "ruff==0.4.1",
-    "setuptools"
+    "setuptools",
 ]
 
 # Documentation / Sphinx dependencies
@@ -102,7 +102,7 @@ ecmwf = [
     "netcdf4>=1.6.1,<1.7.0",
     "platformdirs>=3.0",
     "requests>=2.25",
-    "lxml>=5.1.0"
+    "lxml>=5.1.0",
 ]
 
 # Google Cloud Platform caching interface
@@ -117,11 +117,7 @@ gfs = [
     "tqdm>=4.61",
 ]
 
-goes = [
-    "cartopy>=0.22",
-    "gcsfs>=2022.3",
-    "h5netcdf>=1.2",
-]
+goes = ["cartopy>=0.22", "gcsfs>=2022.3", "h5netcdf>=1.2"]
 
 # Jupyter notebook and lab interface
 jupyter = ["ipywidgets>=7.6", "jupyterlab>=2.2"]
@@ -215,7 +211,7 @@ filterwarnings = [
     "ignore:Engine 'cfgrib' loading failed:RuntimeWarning:xarray.backends.plugins",
     "ignore:.*IPyNbFile:pytest.PytestRemovedIn9Warning:_pytest.nodes",
     "ignore:.*pkg_resources:DeprecationWarning",
-    "ignore:The default level_type will change:DeprecationWarning"
+    "ignore:The default level_type will change:DeprecationWarning",
 ]
 testpaths = ["tests/unit"]
 

--- a/tests/unit/test_cocip_grid.py
+++ b/tests/unit/test_cocip_grid.py
@@ -781,8 +781,8 @@ def test_geovector_source(
     assert np.all(out["ef_per_m"][~persistent] == 0)
 
     # Pin the mean EF
-    assert out["ef_per_m"].mean().item() == pytest.approx(832396, abs=10)
-    assert out["ef_per_m"][persistent].mean().item() == pytest.approx(28944911, abs=10)
+    assert out["ef_per_m"].mean().item() == pytest.approx(832396, rel=1e-3)
+    assert out["ef_per_m"][persistent].mean().item() == pytest.approx(28944911, rel=1e-3)
 
 
 @pytest.mark.filterwarnings("ignore:invalid value encountered in remainder")

--- a/tests/unit/test_cocip_uncertainty.py
+++ b/tests/unit/test_cocip_uncertainty.py
@@ -70,15 +70,16 @@ def test_unspecified_seed() -> None:
 def test_rng_class_variable() -> None:
     """Test class variable `rng`."""
     c1 = CocipUncertaintyParams(seed=5)
-    state1 = CocipUncertaintyParams.rng.__getstate__()
+    rng1 = CocipUncertaintyParams.rng
     c2 = CocipUncertaintyParams()
-    state2 = CocipUncertaintyParams.rng.__getstate__()
-    assert state1 != state2
+    rng2 = CocipUncertaintyParams.rng
+    assert rng1 is rng2
 
     c3 = CocipUncertaintyParams(seed=5)
-    assert state1 == CocipUncertaintyParams.rng.__getstate__()
+    rng3 = CocipUncertaintyParams.rng
     c4 = CocipUncertaintyParams()
-    assert state2 == CocipUncertaintyParams.rng.__getstate__()
+    rng4 = CocipUncertaintyParams.rng
+    assert rng3 is rng4
 
     for param in _get_overriden(c1):
         assert getattr(c1, param) == getattr(c3, param)

--- a/tests/unit/test_flight.py
+++ b/tests/unit/test_flight.py
@@ -446,7 +446,7 @@ def test_altitude_interpolation(fl: Flight) -> None:
     # confirm that all values exist in previous resampling
     fl11 = fl_alt.resample_and_fill("5min")
     assert _check_rocd(fl11)
-    assert np.in1d(fl11["altitude"], fl10["altitude"]).all()
+    assert np.isin(fl11["altitude"], fl10["altitude"]).all()
 
     # test altitude interpolation with level
     fl_lev = Flight(


### PR DESCRIPTION
### Features

- Update the `pycontrails` build system to require `numpy 2.0` per the [official numpy guidelines](https://numpy.org/devdocs/dev/depending_on_numpy.html#numpy-2-0-specific-advice). Note that the runtime requirement for `pycontrails` remains `numpy>=1.22`.
- Update `pycontrails` for breaking changes introduced in `numpy 2.0` (e.g., [NEP 50](https://numpy.org/neps/nep-0050-scalar-promotion.html)). All changes are backward compatible with `numpy>=1.22`.

## Tests

- [x] QC test passes locally (`make test`)
- [x] CI tests pass

## Reviewer

> Select @ reviewer
