### PR TITLE
Temporarily restrict numpy to 1.x in runtime dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixes
 
 - Exclude netCDF version 1.7.0, which causes non-deterministic failures in unit tests primarily due to segmentation faults.
+- Pin numpy to 1.x in runtime dependencies until a working numpy 2.x-compatible netCDF4 release is available.
 
 ### Internals
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ readme = { file = "README.md", content-type = "text/markdown" }
 
 dependencies = [
     "dask>=2022.3",
-    "numpy>=1.22",
+    "numpy>=1.22,<2.0.0",
     "overrides>=6.1",
     "pandas>=1.4",
     "scipy>=1.10",


### PR DESCRIPTION
Numpy 2.x appears to be incompatible with netCDF4 1.6.x: see https://github.com/contrailcirrus/pycontrails/actions/runs/9545611015.

However, netCDF4 1.7.0 appears to be broken: see https://github.com/contrailcirrus/pycontrails/pull/204.

So, this PR pins numpy to 1.x in runtime dependencies. (Building wheels using numpy 2.x doesn't seem to cause problems, so changes from https://github.com/contrailcirrus/pycontrails/pull/205 remain in place.)

## Changes

#### Fixes

- Pin numpy to 1.x in runtime dependencies until a working numpy 2.x-compatible netCDF4 release is available.

## Tests

- [x] QC test passes locally (`make test`)
- [ ] CI tests pass

## Reviewer

> @mlshapiro 
