### PR TITLE
Pass GITHUB_ACTIONS from host when building and testing linux wheels

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,6 +50,10 @@ jobs:
           # Completely isolate tests to prevent cibuildwheel from importing the
           # source instead of the wheel. This happens when tests/__init__.py is read.
           CIBW_TEST_EXTRAS: "complete,dev"
+          # Make sure GITHUB_ACTIONS
+          # (used to selectively skip expensive unit test)
+          # is passed through when testing linux wheels
+          CIBW_ENVIRONMENT_PASS_LINUX: GITHUB_ACTIONS
           CIBW_TEST_COMMAND: >
             mv {project}/pycontrails {project}/pycontrails-bak &&
             python -m pytest {project}/tests -vv &&

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Create unit tests for the `APCEMM` interface that run if an `APCEMM` executable is found on the `PATH` inside a clean APCEMM git repository with a pinned git hash. These tests will be skipped unless users carefully configure their local test environment and will not run in CI.
 - Exclude APCEMM tutorial notebook from notebook tests.
 - Add unit tests for Landsat and Sentinel search tools and datalibs, but disable any tests that retrieve imagery data when running tests in GitHub Actions to limit resource consumption in GitHub runners. Users can disable these units tests locally by setting the environment variable `GITHUB_ACTIONS=true`.
+- Ensure `GITHUB_ACTIONS` environment variable is available when building and testing wheels on linux.
 - Skip cells that retrieve imagery data when running tests on Landsat and Sentinel tutorial notebooks.
 - Add tests for `Flight.to_geojson_multilinestring` with grouping key omitted and update tests with multiple antimeridian crossings.
 - Minimum pandas version is bumped to 2.2 to ensure the the `include_groups` keyword argument used in `Flight.to_geojson_multilinestring` is available.


### PR DESCRIPTION
Run times for the release workflow have increased significantly since v0.51.2: compare https://github.com/contrailcirrus/pycontrails/actions/runs/9563516040 (1 hour, limited by linux wheels) to https://github.com/contrailcirrus/pycontrails/actions/runs/9411025885 (20 minutes, limited by windows wheels).

This is because the GITHUB_ACTIONS environment variable, which is used to selectively skip tests in [`test_leo.py`](https://github.com/contrailcirrus/pycontrails/blob/main/tests/unit/test_leo.py) that download large imagery files, is not passed from the host to the container used to build and test wheels on linux.

This PR ensures that the GITHUB_ACTIONS environment variable is correctly set when building and testing wheels on all hosts. (See https://cibuildwheel.pypa.io/en/stable/options/#environment-pass.)

Release workflow runtime with this change is similar to v0.51.2: https://github.com/contrailcirrus/pycontrails/actions/runs/9568292058/job/26378142375.

## Changes

#### Internals

- Ensure GITHUB_ACTIONS environment variable is available when building and testing wheels on linux.

## Tests

- [x] QC test passes locally (`make test`)
- [ ] CI tests pass

## Reviewer

> @mlshapiro 
