### PR TITLE
Bugfix/persistent contrails formed

### DIFF
--- a/pycontrails/models/cocip/output_formats.py
+++ b/pycontrails/models/cocip/output_formats.py
@@ -217,7 +217,7 @@ def contrail_flight_summary_statistics(flight_waypoints: GeoVectorDataset) -> pd
     )
 
     flight_waypoints["persistent_contrail_length"] = np.where(
-        np.isnan(flight_waypoints["ef"]), 0.0, flight_waypoints["segment_length"]
+        np.nan_to_num(flight_waypoints["ef"]) == 0.0, 0.0, flight_waypoints["segment_length"]
     )
 
     # Calculate contrail statistics for each flight

--- a/tests/unit/test_cocip.py
+++ b/tests/unit/test_cocip.py
@@ -1020,7 +1020,7 @@ def test_flight_waypoint_and_flight_summary_statistics() -> None:
         rtol=1,
     )
     assert (flight_summary["total_persistent_contrails_formed"] == 0.0).sum() == (
-        flight_summary["mean_lifetime_rf_net"].isna()
+        np.nan_to_num(flight_summary["mean_lifetime_rf_net"]) == 0.0
     ).sum()
     np.testing.assert_allclose(
         np.nansum(flight_summary["total_energy_forcing"]),

--- a/tests/unit/test_cocip.py
+++ b/tests/unit/test_cocip.py
@@ -1020,7 +1020,7 @@ def test_flight_waypoint_and_flight_summary_statistics() -> None:
         rtol=1,
     )
     assert (flight_summary["total_persistent_contrails_formed"] == 0.0).sum() == (
-        np.nan_to_num(flight_summary["mean_lifetime_rf_net"]) == 0.0
+        np.nan_to_num(flight_summary["total_energy_forcing"]) == 0.0
     ).sum()
     np.testing.assert_allclose(
         np.nansum(flight_summary["total_energy_forcing"]),

--- a/tests/unit/test_cocip.py
+++ b/tests/unit/test_cocip.py
@@ -1022,6 +1022,9 @@ def test_flight_waypoint_and_flight_summary_statistics() -> None:
     assert (flight_summary["total_persistent_contrails_formed"] == 0.0).sum() == (
         np.nan_to_num(flight_summary["total_energy_forcing"]) == 0.0
     ).sum()
+    assert (flight_summary["total_persistent_contrails_formed"] == 0.0).sum() >= (
+        flight_summary["mean_lifetime_rf_net"].isna()
+    ).sum()
     np.testing.assert_allclose(
         np.nansum(flight_summary["total_energy_forcing"]),
         np.nansum(flight_waypoints_out["ef"]),


### PR DESCRIPTION
#### Fixes

Fixes bug in `output_format.py` so that `total_persistent_contrails_formed` is computed in a manner that is consistent for the convention of computing EF.

Zero EF = no contrail formed (or if it did it was less than one segment length)
NaN EF = missing input to compute contrail output

Both cases should be excluded from `total_persistent_contrails_formed`.

## Tests

- [x] QC test passes locally (`make test`)
- [ ] CI tests pass

## Reviewer
