### PR TITLE
localize pycontrail GOES import

### DIFF
--- a/pycontrails/models/cocip/output_formats.py
+++ b/pycontrails/models/cocip/output_formats.py
@@ -32,7 +32,6 @@ import xarray as xr
 
 from pycontrails.core.met import MetDataArray, MetDataset
 from pycontrails.core.vector import GeoVectorDataset, vector_to_lon_lat_grid
-from pycontrails.datalib.goes import GOES, extract_goes_visualization
 from pycontrails.models.cocip.contrail_properties import contrail_edges, plume_mass_per_distance
 from pycontrails.models.cocip.radiative_forcing import albedo
 from pycontrails.models.humidity_scaling import HumidityScaling
@@ -2124,6 +2123,8 @@ def compare_cocip_with_goes(
     None | pathlib.Path
         File path of saved CoCiP-GOES image if ``path_write_img`` is provided.
     """
+
+    from pycontrails.datalib.goes import GOES, extract_goes_visualization
 
     try:
         import cartopy.crs as ccrs


### PR DESCRIPTION
## Changes
Small refactor to localize the import of the pycontrails datalib GOES module.

In its current manifestation, the GOES module is imported whenever `output_formats.py` is used (which is prevalent).
The GOES module requires [optional dependencies](https://github.com/contrailcirrus/pycontrails/blob/98008ed98690f62d72027596cf23a5930c9a7c61/pyproject.toml#L124), however, that most clients would prefer not to import by default.
