### PR TITLE
A few performance improvements when running CoCiP with a Fleet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,14 @@
 
 ### Fixes
 
-- Fix missing `Fuel Flow Idle (kg/sec)` value in the `1ZM001` engine in the `edb-gaseous-v29b-engines.csv`
+- Fix missing `Fuel Flow Idle (kg/sec)` value in the `1ZM001` engine in the `edb-gaseous-v29b-engines.csv`.
+- Fix the `step_threshold` in `Flight._altitude_interpolation`. This correction is only relevant when passing in a non-default value for `freq` in `Flight.resample_and_fill`.
+- Fix the `VectorDataset.__eq__` method to check for the same keys. Previously, if the other dataset had a superset of the instance keys, the method may still return `True`.
+
+### Internals
+
+- Improve the runtime performance of `Fleet.to_flight_list`. For a large `Fleet`, this method is now 5x faster.
+- Improve the runtime performance and memory footprint of `Cocip._bundle_results`. When running `Cocip` with a large `Fleet` source, `Cocip.eval` is now slightly faster and uses much less memory.
 
 ## v0.52.1
 

--- a/pycontrails/core/fleet.py
+++ b/pycontrails/core/fleet.py
@@ -226,28 +226,29 @@ class Fleet(Flight):
         return len(self.fl_attrs)
 
     def to_flight_list(self, copy: bool = True) -> list[Flight]:
-        """De-concatenate merged waypoints into a list of Flight instances.
+        """De-concatenate merged waypoints into a list of :class:`Flight` instances.
 
         Any global :attr:`attrs` are lost.
 
         Parameters
         ----------
         copy : bool, optional
-            If True, make copy of each flight instance in `seq`.
+            If True, make copy of each :class:`Flight` instance.
 
         Returns
         -------
         list[Flight]
-            List of Flights in the same order as was passed into the `Fleet` instance.
+            List of Flights in the same order as was passed into the ``Fleet`` instance.
         """
-
-        # Avoid self.dataframe to purposely drop global attrs
-        tmp = pd.DataFrame(self.data, copy=copy)
-        grouped = tmp.groupby("flight_id", sort=False)
-
+        indices = self.dataframe.groupby("flight_id", sort=False).indices
         return [
-            Flight(df, attrs=self.fl_attrs[flight_id], fuel=self.fuel, copy=copy)
-            for flight_id, df in grouped
+            Flight(
+                data=VectorDataDict({k: v[idx] for k, v in self.data.items()}),
+                attrs=self.fl_attrs[flight_id],
+                copy=copy,
+                fuel=self.fuel,
+            )
+            for flight_id, idx in indices.items()
         ]
 
     ###################################

--- a/pycontrails/core/flight.py
+++ b/pycontrails/core/flight.py
@@ -2234,16 +2234,14 @@ def segment_rocd(
     if air_temperature is None:
         return out
 
-    else:
-        altitude_m = units.ft_to_m(altitude_ft)
-        T_isa = units.m_to_T_isa(altitude_m)
+    altitude_m = units.ft_to_m(altitude_ft)
+    T_isa = units.m_to_T_isa(altitude_m)
 
-        T_correction = np.empty_like(altitude_ft)
-        T_correction[:-1] = (0.5 * (air_temperature[:-1] + air_temperature[1:])) / (
-            0.5 * (T_isa[:-1] + T_isa[1:])
-        )
-        T_correction[-1] = np.nan
-        return T_correction * out
+    T_correction = np.empty_like(altitude_ft)
+    T_correction[:-1] = (air_temperature[:-1] + air_temperature[1:]) / (T_isa[:-1] + T_isa[1:])
+    T_correction[-1] = np.nan
+
+    return T_correction * out
 
 
 def _resample_to_freq(df: pd.DataFrame, freq: str) -> tuple[pd.DataFrame, pd.DatetimeIndex]:

--- a/pycontrails/core/flight.py
+++ b/pycontrails/core/flight.py
@@ -1506,25 +1506,25 @@ class Flight(GeoVectorDataset):
 
         >>> # Build flight
         >>> df = pd.DataFrame()
-        >>> df['time'] = pd.date_range('2022-03-01T00', '2022-03-01T03', periods=11)
-        >>> df['longitude'] = np.linspace(-20, 20, 11)
-        >>> df['latitude'] = np.linspace(-20, 20, 11)
-        >>> df['altitude'] = np.linspace(9500, 10000, 11)
-        >>> fl = Flight(df).resample_and_fill('10s')
+        >>> df["time"] = pd.date_range("2022-03-01T00", "2022-03-01T03", periods=11)
+        >>> df["longitude"] = np.linspace(-20, 20, 11)
+        >>> df["latitude"] = np.linspace(-20, 20, 11)
+        >>> df["altitude"] = np.linspace(9500, 10000, 11)
+        >>> fl = Flight(df).resample_and_fill("10s")
 
         >>> # Intersect and attach
-        >>> fl["air_temperature"] = fl.intersect_met(met['air_temperature'])
+        >>> fl["air_temperature"] = fl.intersect_met(met["air_temperature"])
         >>> fl["air_temperature"]
-        array([235.94657007, 235.95766965, 235.96873412, ..., 234.59917962,
+        array([235.94657007, 235.55745645, 235.56709768, ..., 234.59917962,
                234.60387402, 234.60845312])
 
         >>> # Length (in meters) of waypoints whose temperature exceeds 236K
         >>> fl.length_met("air_temperature", threshold=236)
-        np.float64(4132178.159...)
+        np.float64(3589705.998...)
 
         >>> # Proportion (with respect to distance) of waypoints whose temperature exceeds 236K
         >>> fl.proportion_met("air_temperature", threshold=236)
-        np.float64(0.663552...)
+        np.float64(0.576...)
         """
         if key not in self.data:
             raise KeyError(f"Column {key} does not exist in data.")

--- a/pycontrails/core/flight.py
+++ b/pycontrails/core/flight.py
@@ -1898,7 +1898,7 @@ def _altitude_interpolation_climb_descend_middle(
     s = pd.Series(altitude)
 
     # Check to see if we have gaps greater than two hours
-    step_threshold = 120.0 * freq / np.timedelta64(1, "m")
+    step_threshold = np.timedelta64(2, "h") / freq
     step_groups = na_group_size > step_threshold
     if np.any(step_groups):
         # If there are gaps greater than two hours, step through one by one

--- a/pycontrails/core/vector.py
+++ b/pycontrails/core/vector.py
@@ -983,7 +983,7 @@ class VectorDataset:
         numeric_attrs = (
             attr
             for attr, val in self.attrs.items()
-            if (isinstance(val, (int, float)) and attr not in ignore_keys)
+            if (isinstance(val, (int, float, np.number)) and attr not in ignore_keys)
         )
         self.broadcast_attrs(numeric_attrs, overwrite)
 

--- a/pycontrails/core/vector.py
+++ b/pycontrails/core/vector.py
@@ -657,7 +657,7 @@ class VectorDataset:
         8  15  18
 
         """
-        vectors = [v for v in vectors if v]  # remove empty vectors
+        vectors = [v for v in vectors if v is not None]  # remove None values
 
         if not vectors:
             return cls()

--- a/pycontrails/core/vector.py
+++ b/pycontrails/core/vector.py
@@ -707,36 +707,33 @@ class VectorDataset:
         bool
             True if both instances have identical :attr:`data` and :attr:`attrs`.
         """
-        if isinstance(other, VectorDataset):
-            # assert attrs equal
-            for key in self.attrs:
-                if isinstance(self.attrs[key], np.ndarray):
-                    # equal_nan not supported for non-numeric data
-                    equal_nan = not np.issubdtype(self.attrs[key].dtype, "O")
-                    try:
-                        eq = np.array_equal(self.attrs[key], other.attrs[key], equal_nan=equal_nan)
-                    except KeyError:
-                        return False
-                else:
-                    eq = self.attrs[key] == other.attrs[key]
+        if not isinstance(other, VectorDataset):
+            return False
 
-                if not eq:
+        # Check attrs
+        if self.attrs.keys() != other.attrs.keys():
+            return False
+
+        for key, val in self.attrs.items():
+            if isinstance(val, np.ndarray):
+                # equal_nan not supported for non-numeric data
+                equal_nan = not np.issubdtype(val.dtype, "O")
+                if not np.array_equal(val, other.attrs[key], equal_nan=equal_nan):
                     return False
+            elif val != other.attrs[key]:
+                return False
 
-            # assert data equal
-            for key in self:
-                # equal_nan not supported for non-numeric data (e.g. strings)
-                equal_nan = not np.issubdtype(self[key].dtype, "O")
-                try:
-                    eq = np.array_equal(self[key], other[key], equal_nan=equal_nan)
-                except KeyError:
-                    return False
+        # Check data
+        if self.data.keys() != other.data.keys():
+            return False
 
-                if not eq:
-                    return False
+        for key, val in self.data.items():
+            # equal_nan not supported for non-numeric data (e.g. strings)
+            equal_nan = not np.issubdtype(val.dtype, "O")
+            if not np.array_equal(val, other[key], equal_nan=equal_nan):
+                return False
 
-            return True
-        return False
+        return True
 
     @property
     def size(self) -> int:

--- a/pycontrails/models/cocip/cocip.py
+++ b/pycontrails/models/cocip/cocip.py
@@ -1166,10 +1166,10 @@ class Cocip(Model):
         # ---
         # Create contrail dataframe (self.contrail)
         # ---
-        for t_idx, contrail in enumerate(self.contrail_list):
-            contrail["timestep"] = np.full(contrail.size, t_idx)
-
         self.contrail = GeoVectorDataset.sum(self.contrail_list).dataframe
+        self.contrail["timestep"] = np.concatenate(
+            [np.full(c.size, i) for i, c in enumerate(self.contrail_list)]
+        )
 
         # add age in hours to the contrail waypoint outputs
         age_hours = np.empty_like(self.contrail["ef"])

--- a/pycontrails/models/cocip/cocip.py
+++ b/pycontrails/models/cocip/cocip.py
@@ -1166,9 +1166,10 @@ class Cocip(Model):
         # ---
         # Create contrail dataframe (self.contrail)
         # ---
-        dfs = [contrail.dataframe for contrail in self.contrail_list]
-        dfs = [df.assign(timestep=t_idx) for t_idx, df in enumerate(dfs)]
-        self.contrail = pd.concat(dfs)
+        for t_idx, contrail in enumerate(self.contrail_list):
+            contrail["timestep"] = np.full(contrail.size, t_idx)
+
+        self.contrail = GeoVectorDataset.sum(self.contrail_list).dataframe
 
         # add age in hours to the contrail waypoint outputs
         age_hours = np.empty_like(self.contrail["ef"])

--- a/tests/unit/test_fleet.py
+++ b/tests/unit/test_fleet.py
@@ -31,7 +31,13 @@ def test_fleet_io(syn: SyntheticFlight) -> None:
     Check that the flights coming out of method `to_flight_list` agree with inputs.
     """
     in_fls = [syn() for _ in range(100)]
-    fleet = Fleet.from_seq(in_fls)
+    for fl in in_fls:
+        # In the Fleet constructor, a waypoint and flight_id field are added
+        # Do this here to ensure the data is the same
+        fl["waypoint"] = np.arange(len(fl))
+        fl.broadcast_numeric_attrs()  # add flight_id
+
+    fleet = Fleet.from_seq(in_fls, broadcast_numeric=False)
     assert fleet.n_flights == 100
 
     out_fls = fleet.to_flight_list()

--- a/tests/unit/test_vector.py
+++ b/tests/unit/test_vector.py
@@ -721,12 +721,12 @@ def test_vector_copy(random_path: VectorDataset) -> None:
     assert len(data) == 3
 
     # Here, when we grab the original data, the base is None
-    random_path4 = VectorDataset(data, copy=False)
+    random_path4 = VectorDataset(data, copy=False, attrs=random_path.attrs)
     assert random_path4 == random_path
     assert random_path4["a"].base is None
     assert np.may_share_memory(random_path4["a"], random_path["a"])
 
-    random_path5 = VectorDataset(data, copy=True)
+    random_path5 = VectorDataset(data, copy=True, attrs=random_path.attrs)
     assert random_path5 == random_path
     assert random_path5["a"].base is None
     assert not np.may_share_memory(random_path5["a"], random_path["a"])


### PR DESCRIPTION
### Fixes

- Fix the `step_threshold` in `Flight._altitude_interpolation`. This correction is only relevant when passing in a non-default value for `freq` in `Flight.resample_and_fill`.
- Fix the `VectorDataset.__eq__` method to check for the same keys. Previously, if the other dataset had a superset of the instance keys, the method may still return `True`.

### Internals

- Improve the runtime performance of `Fleet.to_flight_list`. For a large `Fleet`, this method is now 5x faster. The plot below shows my benchmarking.
<img width="593" alt="Screenshot 2024-07-22 at 6 22 57 PM" src="https://github.com/user-attachments/assets/c86162b0-c140-4b88-91d8-5bf2ccf264f1">


- Improve the runtime performance and memory footprint of `Cocip._bundle_results`. When running `Cocip` with a large `Fleet` source, `Cocip.eval` is now slightly faster and uses much less memory.

## Tests

- [ ] QC test passes locally (`make test`)
- [ ] CI tests pass

