### PR TITLE
Improve detection of antimeridian crossings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,15 @@
 
 ## v0.52.2 (unreleased)
 
+### Breaking changes
+
+- Flight antimeridian crossings are now detected based on individual flight segments rather than minimum and maximum longitude values. This allows for correct detection of antimeridian crossings for flights that span more than 180 degrees longitude, and may change the output of `Flight.resample_and_fill` for such flights.
+
 ### Features
 
 - Add experimental `fill_low_alt_with_isa_temperature` parameter on the `AircraftPerformance` base class. When set to `True`, aircraft performance models with `Flight` sources will fill points below the lowest altitude in the ``met["air_temperature]`` data with the ISA temperature. This is useful when the met data does not extend to the surface. In this case, we can still estimate fuel flow and other performance metrics through the entire climb phase. By default, this parameter is set to `False`.
 - Add experimental `fill_low_altitude_with_zero_wind` parameter on the `AircraftPerformance` base class. When set to `True`, aircraft performance models will estimate the true airspeed at low altitudes by assuming the wind speed is zero.
 - Add convenience `Flight.plot_profile` method.
-
-### Breaking changes
-
-- Flight antimeridian crossings are now detected based on individual flight segments rather than minimum and maximum longitude values. This allows for correct detection of antimeridian crossings for flights that span more than 180 degrees longitude.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - Add experimental `fill_low_altitude_with_zero_wind` parameter on the `AircraftPerformance` base class. When set to `True`, aircraft performance models will estimate the true airspeed at low altitudes by assuming the wind speed is zero.
 - Add convenience `Flight.plot_profile` method.
 
+### Breaking changes
+
+- Flight antimeridian crossings are now detected based on individual flight segments rather than minimum and maximum longitude values. This allows for correct detection of antimeridian crossings for flights that span more than 180 degrees longitude.
+
 ### Fixes
 
 - Fix missing `Fuel Flow Idle (kg/sec)` value in the `1ZM001` engine in the `edb-gaseous-v29b-engines.csv`.
@@ -15,6 +19,7 @@
 - Fix the `VectorDataset.__eq__` method to check for the same keys. Previously, if the other dataset had a superset of the instance keys, the method may still return `True`.
 - Fix minor bug in `cocip.output_formats.radiation_time_slice_statistics` in which the function previously threw an error if `t_end` did not directly align with the time index in the `rad` dataset.
 - Remove the residual constraint in `cocip.output_formats.contrails_to_hi_res_grid` used during debugging.
+- Improve detection of antimeridian crossings for flights that span more than 180 degrees longitude.
 
 ### Internals
 

--- a/pycontrails/core/flight.py
+++ b/pycontrails/core/flight.py
@@ -1250,7 +1250,7 @@ class Flight(GeoVectorDataset):
     def _crosses_antimeridian(self) -> bool:
         """Determine whether a flight crosses the antimeridian.
 
-        Because flights sometimes span more than half a great circle (for example,
+        Because flights sometimes span more than 180 degree longitude (for example,
         when flight-level winds favor travel in a specific direction, typically eastward),
         antimeridian crossings cannot reliably be detected by looking only at minimum
         and maximum longitudes.

--- a/pycontrails/core/flight.py
+++ b/pycontrails/core/flight.py
@@ -1274,10 +1274,11 @@ class Flight(GeoVectorDataset):
 
         # separate flight into segments that are east and west of crossings
         net_westward = np.insert(np.cumsum(jump12.astype(int) - jump21.astype(int)), 0, 0)
-        if net_westward.max() - net_westward.min() > 1:
+        max_westward = net_westward.max()
+        if max_westward - net_westward.min() > 1:
             msg = "Cannot handle consecutive antimeridian crossings in the same direction"
             raise ValueError(msg)
-        east = (net_westward == 0) if net_westward.max() == 1 else (net_westward == -1)
+        east = (net_westward == 0) if max_westward == 1 else (net_westward == -1)
 
         # shift must be between maximum longitude east of crossings
         # and minimum longitude west of crossings

--- a/pycontrails/core/flight.py
+++ b/pycontrails/core/flight.py
@@ -1249,7 +1249,8 @@ class Flight(GeoVectorDataset):
         and maximum longitudes.
 
         Instead, this function checks each flight segment for an antimeridian crossing,
-        and returns True if at least one segment crosses the antimeridian.
+        and if it finds one returns the coordinate of a meridian that is not crossed by
+        the flight.
 
         Returns
         -------


### PR DESCRIPTION
## Changes

Summary: we shouldn't assume that flights never span more than 180 degree longitude when detecting antimeridian crossings--they sometimes do if flight-level winds strongly favor travel in a particular direction.

Before changes:

<img width="424" alt="image" src="https://github.com/user-attachments/assets/7e1aa827-5044-4c9d-92cf-65c80bb93698">

After changes:

<img width="418" alt="image" src="https://github.com/user-attachments/assets/502c52f8-3e26-4e55-a01a-43f19624d9d3">

### Breaking changes

- Flight antimeridian crossings are now detected based on individual flight segments rather than minimum and maximum longitude values. This allows for correct detection of antimeridian crossings for flights that span more than 180 degrees longitude.

### Fixes

- Improve detection of antimeridian crossings for flights that cover over 180 degrees longitude.

## Tests

- [x] QC test passes locally (`make test`)
- [x] CI tests pass

## Reviewer

> @zebengberg 
