### PR TITLE
Bug fix: CoCiP output formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - Fix missing `Fuel Flow Idle (kg/sec)` value in the `1ZM001` engine in the `edb-gaseous-v29b-engines.csv`.
 - Fix the `step_threshold` in `Flight._altitude_interpolation`. This correction is only relevant when passing in a non-default value for `freq` in `Flight.resample_and_fill`.
 - Fix the `VectorDataset.__eq__` method to check for the same keys. Previously, if the other dataset had a superset of the instance keys, the method may still return `True`.
+- Fix minor bug in `cocip.output_formats.radiation_time_slice_statistics` in which the function previously threw an error if `t_end` did not directly align with the time index in the `rad` dataset.
+- Remove the residual constraint in `cocip.output_formats.contrails_to_hi_res_grid` used during debugging.
 
 ### Internals
 

--- a/pycontrails/models/cocip/output_formats.py
+++ b/pycontrails/models/cocip/output_formats.py
@@ -1191,6 +1191,7 @@ def meteorological_time_slice_statistics(
     # ISSR: Volume of airspace with RHi > 100% between FL300 and FL450
     met = humidity_scaling.eval(met)
     rhi = met["rhi"].data.sel(level=slice(150, 300))
+    rhi = rhi.interp(time=time)
     is_issr = rhi > 1
 
     # Cirrus in a longitude-latitude grid
@@ -1245,9 +1246,15 @@ def radiation_time_slice_statistics(
     surface_area = geo.grid_surface_area(rad["longitude"].values, rad["latitude"].values)
     weights = surface_area.values / np.nansum(surface_area)
     stats = {
-        "mean_sdr_domain": np.nansum(rad["sdr"].data.sel(level=-1, time=time).values * weights),
-        "mean_rsr_domain": np.nansum(rad["rsr"].data.sel(level=-1, time=time).values * weights),
-        "mean_olr_domain": np.nansum(rad["olr"].data.sel(level=-1, time=time).values * weights),
+        "mean_sdr_domain": np.nansum(
+            np.squeeze(rad["sdr"].data.interp(time=time).values) * weights
+        ),
+        "mean_rsr_domain": np.nansum(
+            np.squeeze(rad["rsr"].data.interp(time=time).values) * weights
+        ),
+        "mean_olr_domain": np.nansum(
+            np.squeeze(rad["olr"].data.interp(time=time).values) * weights
+        ),
     }
     return pd.Series(stats)
 

--- a/pycontrails/models/cocip/output_formats.py
+++ b/pycontrails/models/cocip/output_formats.py
@@ -1605,7 +1605,7 @@ def contrails_to_hi_res_grid(
             module_not_found_error=exc,
         )
 
-    for i in tqdm(heads_t.index[:2000]):
+    for i in tqdm(heads_t.index):
         contrail_segment = GeoVectorDataset(
             pd.concat([heads_t[cols_req].loc[i], tails_t[cols_req].loc[i]], axis=1).T, copy=True
         )


### PR DESCRIPTION
Closes #XX

## Changes

Identified several bugs while creating a tutorial notebook to generate the additional CoCiP output formats.

#### Breaking changes

#### Features

#### Fixes

- Fix minor bug in `time_slice_statistics`, where the function throws an error if `t_end` does not directly match with the time index in the `rad` dataset
- Remove residual constrain in `contrails_to_hi_res_grid` used during debugging.

#### Internals

## Tests

- [ ] QC test passes locally (`make test`)
- [ ] CI tests pass

## Reviewer

> Select @ reviewer
