### PR TITLE
Feature/py313

### DIFF
--- a/.github/workflows/doctest.yaml
+++ b/.github/workflows/doctest.yaml
@@ -80,6 +80,8 @@ jobs:
         run: |
           make nb-test
 
+      # The doctests require numpy 2.0 or higher
       - name: Test docstrings
         run: |
+          pip install "numpy>=2.0"
           make doctest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,11 +42,11 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.20
         env:
-          CIBW_BUILD: cp39-* cp310-* cp311-* cp312-*
+          CIBW_BUILD: cp310-* cp311-* cp312-* cp313-*
           CIBW_SKIP: '*-win32 *-manylinux_i686 *-musllinux*'
           CIBW_BUILD_VERBOSITY: 3
           CIBW_ARCHS_MACOS: x86_64 arm64
-          CIBW_TEST_SKIP: '*-macosx_arm64'
+          CIBW_TEST_SKIP: '*-macosx_arm64 cp313-*'
           # Completely isolate tests to prevent cibuildwheel from importing the
           # source instead of the wheel. This happens when tests/__init__.py is read.
           CIBW_TEST_EXTRAS: "complete,dev"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,7 +38,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        pyversion: ['3.9', '3.10', '3.11', '3.12']
+        # TODO(Fall 2024): Add 3.13 once all dependencies are available
+        pyversion: ['3.10', '3.11', '3.12']
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## v0.53.0 (unreleased)
+
+### Breaking changes
+
+- Drop python 3.9 support per [NEP 29](https://numpy.org/neps/nep-0029-deprecation_policy.html).
+
+### Features
+
+- Build wheels for [python 3.13](https://peps.python.org/pep-0719/). (These wheels are available on PyPI, but other pycontrails dependencies may not yet support python 3.13.)
+
+### Fixes
+
+- Fix `PycontrailsRegularGridInterpolator` for compatibility with the latest scipy version.
+
+### Internals
+
+- Defer import of `skimage` and `rasterio`.
+
 ## v0.52.3
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.53.0 (unreleased)
+## v0.53.0
 
 ### Breaking changes
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Documentation and examples available at [py.contrails.org](https://py.contrails.
 
 ### Install with pip
 
-You can install pycontrails from PyPI with `pip` (Python 3.9 or later required):
+You can install pycontrails from PyPI with `pip` (Python 3.10 or later required):
 
 ```bash
 $ pip install pycontrails

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -151,6 +151,16 @@ Gridded CoCiP
     models.cocipgrid.CocipGridParams
 
 
+Dry Advection
+"""""""""""""
+
+.. autosummary::
+    :toctree: api/
+
+    models.dry_advection.DryAdvection
+    models.dry_advection.DryAdvectionParams
+
+
 ACCF
 """"
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -17,7 +17,7 @@ The conda-forge package includes all optional runtime dependencies.
 pip install
 -----------
 
-With Python 3.9 or later, install the latest release from PyPI using ``pip``:
+With Python 3.10 or later, install the latest release from PyPI using ``pip``:
 
 .. code-block:: bash
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -27,6 +27,8 @@ With Python 3.10 or later, install the latest release from PyPI using ``pip``:
     # install with all optional dependencies
     $ pip install "pycontrails[complete]"
 
+Wheels are currently built for python 3.10 - 3.13 on Linux, macOS, and Windows. The python 3.13
+wheels are not yet tested in CI/CD and not all runtime dependencies are available for python 3.13.
 
 Install the latest development version directly from GitHub:
 

--- a/pycontrails/core/cache.py
+++ b/pycontrails/core/cache.py
@@ -146,7 +146,7 @@ class CacheStore(ABC):
         """
 
         # TODO: run in parallel?
-        return [self.put(d, cp) for d, cp in zip(data_path, cache_path)]
+        return [self.put(d, cp) for d, cp in zip(data_path, cache_path, strict=True)]
 
     # In the three methods below, child classes have a complete docstring.
 

--- a/pycontrails/core/flight.py
+++ b/pycontrails/core/flight.py
@@ -2056,7 +2056,7 @@ def filter_altitude(
     --------
     :meth:`traffic.core.flight.Flight.filter`
     :func:`scipy.signal.medfilt`
-    """  # noqa: E501
+    """
     if not len(altitude_ft):
         raise ValueError("Altitude must have non-zero length to filter")
 

--- a/pycontrails/core/flight.py
+++ b/pycontrails/core/flight.py
@@ -1356,7 +1356,7 @@ class Flight(GeoVectorDataset):
             # NOTE: geod.npts does not return the initial or terminal points
             lonlats: list[tuple[float, float]] = geod.npts(lon0, lat0, lon1, lat1, n_steps)
 
-            lons, lats = zip(*lonlats)
+            lons, lats = zip(*lonlats, strict=True)
             longitudes.extend(lons)
             latitudes.extend(lats)
 
@@ -1657,10 +1657,11 @@ def _return_linestring(data: dict[str, npt.NDArray[np.float64]]) -> list[list[fl
         The list of coordinates
     """
     # rounding to reduce the size of resultant json arrays
-    points = zip(  # pylint: disable=zip-builtin-not-iterating
+    points = zip(
         np.round(data["longitude"], decimals=4),
         np.round(data["latitude"], decimals=4),
         np.round(data["altitude"], decimals=4),
+        strict=True,
     )
     return [list(p) for p in points]
 
@@ -1949,7 +1950,9 @@ def _altitude_interpolation_climb_descend_middle(
     # Form array of cumulative altitude values if the flight were to climb
     # at nominal_rocd over each group of nan
     cumalt_list = []
-    for start_na_idx, end_na_idx, size in zip(start_na_idxs, end_na_idxs, na_group_size):
+    for start_na_idx, end_na_idx, size in zip(
+        start_na_idxs, end_na_idxs, na_group_size, strict=True
+    ):
         if s[start_na_idx] <= s[end_na_idx]:
             cumalt_list.append(np.arange(1, size, dtype=float))
         else:
@@ -2114,7 +2117,7 @@ def filter_altitude(
 
     result = np.copy(altitude_ft)
     if np.any(start_idxs):
-        for i0, i1 in zip(start_idxs, end_idxs):
+        for i0, i1 in zip(start_idxs, end_idxs, strict=True):
             result[i0:i1] = altitude_filt[i0:i1]
 
     # reapply Savitzky-Golay filter to smooth climb and descent

--- a/pycontrails/core/flightplan.py
+++ b/pycontrails/core/flightplan.py
@@ -93,7 +93,7 @@ def parse_atc_plan(atc_plan: str) -> dict[str, str]:
     See Also
     --------
     :func:`to_atc_plan`
-    """  # noqa: E501
+    """
     atc_plan = atc_plan.replace("\r", "")
     atc_plan = atc_plan.replace("\n", "")
     atc_plan = atc_plan.upper()

--- a/pycontrails/core/interpolation.py
+++ b/pycontrails/core/interpolation.py
@@ -76,6 +76,7 @@ class PycontrailsRegularGridInterpolator(scipy.interpolate.RegularGridInterpolat
         self.method = _pick_method(scipy.__version__, method)
         self.bounds_error = bounds_error
         self.fill_value = fill_value
+        self._spline = None
 
     def _prepare_xi_simple(self, xi: npt.NDArray[np.float64]) -> npt.NDArray[np.bool_]:
         """Run looser version of :meth:`_prepare_xi`.

--- a/pycontrails/core/met.py
+++ b/pycontrails/core/met.py
@@ -920,7 +920,7 @@ class MetDataset(MetBase):
         KeyError
             Raises when dataset does not contain variable in ``vars``
         """
-        if isinstance(vars, (MetVariable, str)):
+        if isinstance(vars, MetVariable | str):
             vars = (vars,)
 
         met_keys: list[str] = []

--- a/pycontrails/core/met.py
+++ b/pycontrails/core/met.py
@@ -1020,7 +1020,7 @@ class MetDataset(MetBase):
 
     @overrides
     def broadcast_coords(self, name: str) -> xr.DataArray:
-        da = xr.ones_like(self.data[list(self.data.keys())[0]]) * self.data[name]
+        da = xr.ones_like(self.data[next(iter(self.data.keys()))]) * self.data[name]
         da.name = name
 
         return da
@@ -1863,7 +1863,7 @@ class MetDataArray(MetBase):
         cachestore = cachestore or DiskCacheStore()
         chunks = chunks or {}
         data = _load(hash, cachestore, chunks)
-        return cls(data[list(data.data_vars)[0]])
+        return cls(data[next(iter(data.data_vars))])
 
     @property
     def proportion(self) -> float:
@@ -2256,7 +2256,7 @@ class MetDataArray(MetBase):
         -----
         Uses the `scikit-image Marching Cubes  <https://scikit-image.org/docs/dev/auto_examples/edges/plot_marching_cubes.html>`_
         algorithm to reconstruct a surface from the point-cloud like arrays.
-        """  # noqa: E501
+        """
         try:
             from skimage import measure
         except ModuleNotFoundError as e:

--- a/pycontrails/core/met.py
+++ b/pycontrails/core/met.py
@@ -489,7 +489,7 @@ class MetBase(ABC, Generic[XArrayType]):
         self.cachestore = self.cachestore or DiskCacheStore()
 
         # group by hour and save one dataset for each hour to temp file
-        times, datasets = zip(*dataset.groupby("time", squeeze=False))
+        times, datasets = zip(*dataset.groupby("time", squeeze=False), strict=True)
 
         # Open ExitStack to control temp_file context manager
         with ExitStack() as stack:
@@ -1074,7 +1074,7 @@ class MetDataset(MetBase):
         coords_vals = [indexes[key].values for key in coords_keys]
         coords_meshes = np.meshgrid(*coords_vals, indexing="ij")
         raveled_coords = (mesh.ravel() for mesh in coords_meshes)
-        data = dict(zip(coords_keys, raveled_coords))
+        data = dict(zip(coords_keys, raveled_coords, strict=True))
 
         out = vector_module.GeoVectorDataset(data, copy=False)
         for key, da in self.data.items():

--- a/pycontrails/core/met_var.py
+++ b/pycontrails/core/met_var.py
@@ -22,7 +22,7 @@ class MetVariable:
     - `NCEP Grib v2 Code Table <https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_table4-2.shtml>`_
 
     Used for defining support parameters in a grib-like fashion.
-    """  # noqa: E501
+    """
 
     #: Short variable name.
     #: Chosen for greatest consistency between data sources.

--- a/pycontrails/core/models.py
+++ b/pycontrails/core/models.py
@@ -11,7 +11,7 @@ import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from dataclasses import dataclass, fields
-from typing import Any, NoReturn, TypeVar, Union, overload
+from typing import Any, NoReturn, TypeVar, overload
 
 import numpy as np
 import numpy.typing as npt
@@ -30,13 +30,13 @@ from pycontrails.utils.types import type_guard
 logger = logging.getLogger(__name__)
 
 #: Model input source types
-ModelInput = Union[MetDataset, GeoVectorDataset, Flight, Sequence[Flight], None]
+ModelInput = MetDataset | GeoVectorDataset | Flight | Sequence[Flight] | None
 
 #: Model output source types
-ModelOutput = Union[MetDataArray, MetDataset, GeoVectorDataset, Flight, list[Flight], NoReturn]
+ModelOutput = MetDataArray | MetDataset | GeoVectorDataset | Flight | list[Flight] | NoReturn
 
 #: Model attribute source types
-SourceType = Union[MetDataset, GeoVectorDataset, Flight, Fleet]
+SourceType = MetDataset | GeoVectorDataset | Flight | Fleet
 
 _Source = TypeVar("_Source")
 
@@ -453,7 +453,7 @@ class Model(ABC):
             return Fleet.from_seq(source)
 
         # Raise error if source is not a MetDataset or GeoVectorDataset
-        if not isinstance(source, (MetDataset, GeoVectorDataset)):
+        if not isinstance(source, MetDataset | GeoVectorDataset):
             msg = f"Unknown source type: {type(source)}"
             raise TypeError(msg)
 

--- a/pycontrails/core/models.py
+++ b/pycontrails/core/models.py
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 ModelInput = MetDataset | GeoVectorDataset | Flight | Sequence[Flight] | None
 
 #: Model output source types
-ModelOutput = MetDataArray | MetDataset | GeoVectorDataset | Flight | list[Flight] | NoReturn
+ModelOutput = MetDataArray | MetDataset | GeoVectorDataset | Flight | list[Flight]
 
 #: Model attribute source types
 SourceType = MetDataset | GeoVectorDataset | Flight | Fleet

--- a/pycontrails/core/vector.py
+++ b/pycontrails/core/vector.py
@@ -847,7 +847,7 @@ class VectorDataset:
         ------
         TypeError
             If ``mask`` is not a boolean array.
-        """  # noqa: E501
+        """
         self.data._validate_array(mask)
         if mask.dtype != bool:
             raise TypeError("Parameter `mask` must be a boolean array.")
@@ -1194,7 +1194,7 @@ class VectorDataset:
         See Also
         --------
         :func:`numpy.array_split`
-        """  # noqa: E501
+        """
         full_index = np.arange(self.size)
         index_splits = np.array_split(full_index, n_splits)
         for index in index_splits:

--- a/pycontrails/core/vector.py
+++ b/pycontrails/core/vector.py
@@ -983,7 +983,7 @@ class VectorDataset:
         numeric_attrs = (
             attr
             for attr, val in self.attrs.items()
-            if (isinstance(val, (int, float, np.number)) and attr not in ignore_keys)
+            if (isinstance(val, int | float | np.number) and attr not in ignore_keys)
         )
         self.broadcast_attrs(numeric_attrs, overwrite)
 
@@ -1072,7 +1072,7 @@ class VectorDataset:
                 obj = obj.to_numpy()
 
             # Convert numpy objects to python objects
-            if isinstance(obj, (np.ndarray, np.generic)):
+            if isinstance(obj, np.ndarray | np.generic):
 
                 # round time to unix seconds
                 if key == "time":
@@ -1166,7 +1166,7 @@ class VectorDataset:
         attrs = {}
 
         for k, v in {**obj, **obj_kwargs}.items():
-            if isinstance(v, (list, np.ndarray)):
+            if isinstance(v, list | np.ndarray):
                 data[k] = v
             else:
                 attrs[k] = v

--- a/pycontrails/datalib/_leo_utils/vis.py
+++ b/pycontrails/datalib/_leo_utils/vis.py
@@ -7,8 +7,6 @@ import numpy as np
 from pycontrails.utils import dependencies
 
 
-
-
 def normalize(channel: np.ndarray) -> np.ndarray:
     """Normalize channel values to range [0, 1], preserving ``np.nan`` in output.
 
@@ -57,5 +55,5 @@ def equalize(channel: np.ndarray, **equalize_kwargs: Any) -> np.ndarray:
     return np.where(
         np.isnan(channel),
         np.nan,
-        ski.exposure.equalize_adapthist(np.nan_to_num(channel, nan=0), **equalize_kwargs),
+        skimage.exposure.equalize_adapthist(np.nan_to_num(channel, nan=0.0), **equalize_kwargs),
     )

--- a/pycontrails/datalib/_leo_utils/vis.py
+++ b/pycontrails/datalib/_leo_utils/vis.py
@@ -6,15 +6,7 @@ import numpy as np
 
 from pycontrails.utils import dependencies
 
-try:
-    import skimage as ski
-except ModuleNotFoundError as exc:
-    dependencies.raise_module_not_found_error(
-        name="landsat module",
-        package_name="scikit-image",
-        module_not_found_error=exc,
-        pycontrails_optional_package="sat",
-    )
+
 
 
 def normalize(channel: np.ndarray) -> np.ndarray:
@@ -53,6 +45,15 @@ def equalize(channel: np.ndarray, **equalize_kwargs: Any) -> np.ndarray:
     NaN values are converted to 0 before passing to :py:func:`ski.exposure.equalize_adapthist`
     and may affect equalized values in the neighborhood where they occur.
     """
+    try:
+        import skimage.exposure
+    except ModuleNotFoundError as exc:
+        dependencies.raise_module_not_found_error(
+            name="landsat module",
+            package_name="scikit-image",
+            module_not_found_error=exc,
+            pycontrails_optional_package="sat",
+        )
     return np.where(
         np.isnan(channel),
         np.nan,

--- a/pycontrails/datalib/_met_utils/metsource.py
+++ b/pycontrails/datalib/_met_utils/metsource.py
@@ -8,7 +8,7 @@ import logging
 import pathlib
 from collections.abc import Sequence
 from datetime import datetime
-from typing import Any
+from typing import Any, TypeAlias
 
 import numpy as np
 import pandas as pd
@@ -20,7 +20,8 @@ from pycontrails.utils.types import DatetimeLike
 
 logger = logging.getLogger(__name__)
 
-TimeInput = str | DatetimeLike | Sequence[str | DatetimeLike]
+# https://github.com/python/mypy/issues/14824
+TimeInput: TypeAlias = str | DatetimeLike | Sequence[str | DatetimeLike]
 VariableInput = (
     str | int | MetVariable | np.ndarray | Sequence[str | int | MetVariable | Sequence[MetVariable]]
 )

--- a/pycontrails/datalib/_met_utils/metsource.py
+++ b/pycontrails/datalib/_met_utils/metsource.py
@@ -68,7 +68,7 @@ def parse_timesteps(time: TimeInput | None, freq: str | None = "1h") -> list[dat
     ------
     ValueError
         Raises when the time has len > 2 or when time elements fail to be parsed with pd.to_datetime
-    """  # noqa: E501
+    """
 
     if time is None:
         return []

--- a/pycontrails/datalib/_met_utils/metsource.py
+++ b/pycontrails/datalib/_met_utils/metsource.py
@@ -8,7 +8,7 @@ import logging
 import pathlib
 from collections.abc import Sequence
 from datetime import datetime
-from typing import Any, Union
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -20,11 +20,12 @@ from pycontrails.utils.types import DatetimeLike
 
 logger = logging.getLogger(__name__)
 
-TimeInput = Union[str, DatetimeLike, Sequence[Union[str, DatetimeLike]]]
-VariableInput = Union[
-    str, int, MetVariable, np.ndarray, Sequence[Union[str, int, MetVariable, Sequence[MetVariable]]]
-]
-PressureLevelInput = Union[int, float, np.ndarray, Sequence[Union[int, float]]]
+TimeInput = str | DatetimeLike | Sequence[str | DatetimeLike]
+VariableInput = (
+    str | int | MetVariable | np.ndarray | Sequence[str | int | MetVariable | Sequence[MetVariable]]
+)
+
+PressureLevelInput = int | float | np.ndarray | Sequence[int | float]
 
 #: NetCDF engine to use for parsing netcdf files
 NETCDF_ENGINE: str = "netcdf4"
@@ -72,7 +73,7 @@ def parse_timesteps(time: TimeInput | None, freq: str | None = "1h") -> list[dat
         return []
 
     # confirm input is tuple or list-like of length 2
-    if isinstance(time, (str, datetime, pd.Timestamp, np.datetime64)):
+    if isinstance(time, str | datetime | pd.Timestamp | np.datetime64):
         time = (time, time)
     elif len(time) == 1:
         time = (time[0], time[0])
@@ -151,7 +152,7 @@ def parse_pressure_levels(
         Raises ValueError if pressure level is not supported by ECMWF data source
     """
     # Ensure pressure_levels is array-like
-    if isinstance(pressure_levels, (int, float)):
+    if isinstance(pressure_levels, int | float):
         pressure_levels = [pressure_levels]
 
     # Cast array-like to int dtype and sort
@@ -212,7 +213,7 @@ def parse_variables(variables: VariableInput, supported: list[MetVariable]) -> l
     met_var_list: list[MetVariable] = []
 
     # ensure input variables are a list of str
-    if isinstance(variables, (str, int, MetVariable)):
+    if isinstance(variables, str | int | MetVariable):
         parsed_variables = [variables]
     elif isinstance(variables, np.ndarray):
         parsed_variables = variables.tolist()
@@ -257,7 +258,7 @@ def _find_match(
 
     # list of MetVariable options
     # here we extract the first MetVariable in var that is supported
-    elif isinstance(var, (list, tuple)):
+    elif isinstance(var, list | tuple):
         for v in var:
             # sanity check since we don't support other types as lists
             if not isinstance(v, MetVariable):

--- a/pycontrails/datalib/ecmwf/era5.py
+++ b/pycontrails/datalib/ecmwf/era5.py
@@ -121,7 +121,7 @@ class ERA5(ECMWFAPI):
     ...     pressure_levels=[350, 300],
     ...     cachestore=gcp_cache
     ... )
-    """  # noqa: E501
+    """
 
     __slots__ = (
         "product_type",

--- a/pycontrails/datalib/ecmwf/era5_model_level.py
+++ b/pycontrails/datalib/ecmwf/era5_model_level.py
@@ -349,7 +349,7 @@ class ERA5ModelLevel(ECMWFAPI):
         unique_dates = set(t.strftime("%Y-%m-%d") for t in times)
         unique_times = set(t.strftime("%H:%M:%S") for t in times)
         # param 152 = log surface pressure, needed for metview level conversion
-        grib_params = set(self.variable_ecmwfids + [152])
+        grib_params = set((*self.variable_ecmwfids, 152))
         common = {
             "class": "ea",
             "date": "/".join(sorted(unique_dates)),

--- a/pycontrails/datalib/ecmwf/hres_model_level.py
+++ b/pycontrails/datalib/ecmwf/hres_model_level.py
@@ -473,8 +473,8 @@ class HRESModelLevel(ECMWFAPI):
             LOG.debug("Opening GRIB file")
             fs_ml = mv.read(target)
 
-            # reduce memory overhead by cacheing one timestep at a time
-            for time, step in zip(times, self.get_forecast_steps(times)):
+            # reduce memory overhead by caching one timestep at a time
+            for time, step in zip(times, self.get_forecast_steps(times), strict=True):
                 fs_pl = mv.Fieldset()
                 selection = dict(step=step)
                 lnsp = fs_ml.select(shortName="lnsp", **selection)

--- a/pycontrails/datalib/ecmwf/hres_model_level.py
+++ b/pycontrails/datalib/ecmwf/hres_model_level.py
@@ -377,7 +377,7 @@ class HRESModelLevel(ECMWFAPI):
         time = self.forecast_time.strftime("%H:%M:%S")
         steps = self.get_forecast_steps(times)
         # param 152 = log surface pressure, needed for metview level conversion
-        grib_params = set(self.variable_ecmwfids + [152])
+        grib_params = set((*self.variable_ecmwfids, 152))
         return (
             f"retrieve,\n"
             f"class=od,\n"

--- a/pycontrails/datalib/ecmwf/variables.py
+++ b/pycontrails/datalib/ecmwf/variables.py
@@ -118,7 +118,7 @@ RelativeHumidity = MetVariable(
         "At temperatures below -23°C it is calculated for saturation over ice. "
         "Between -23°C and 0°C this parameter is calculated by interpolating between the ice and"
         " water values using a quadratic function."
-        "See https://www.ecmwf.int/sites/default/files/elibrary/2016/17117-part-iv-physical-processes.pdf#subsection.7.4.2"  # noqa: E501
+        "See https://www.ecmwf.int/sites/default/files/elibrary/2016/17117-part-iv-physical-processes.pdf#subsection.7.4.2"
     ),
 )
 
@@ -166,7 +166,7 @@ TopNetSolarRadiation = MetVariable(
         "The incoming solar radiation is the amount received from the Sun. "
         "The outgoing solar radiation is the amount reflected and scattered by the Earth's"
         " atmosphere and surface"
-        "See https://www.ecmwf.int/sites/default/files/elibrary/2015/18490-radiation-quantities-ecmwf-model-and-mars.pdf"  # noqa: E501
+        "See https://www.ecmwf.int/sites/default/files/elibrary/2015/18490-radiation-quantities-ecmwf-model-and-mars.pdf"
     ),
 )
 
@@ -183,7 +183,7 @@ TopNetThermalRadiation = MetVariable(
         "radiation emitted to space at the top of the atmosphere is commonly known as the Outgoing"
         " Longwave Radiation (OLR). "
         "The top net thermal radiation (this parameter) is equal to the negative of OLR."
-        "See https://www.ecmwf.int/sites/default/files/elibrary/2015/18490-radiation-quantities-ecmwf-model-and-mars.pdf"  # noqa: E501
+        "See https://www.ecmwf.int/sites/default/files/elibrary/2015/18490-radiation-quantities-ecmwf-model-and-mars.pdf"
     ),
 )
 

--- a/pycontrails/datalib/gfs/gfs.py
+++ b/pycontrails/datalib/gfs/gfs.py
@@ -114,7 +114,7 @@ class GFSForecast(metsource.MetDataSource):
     - `Documentation <https://www.ncei.noaa.gov/products/weather-climate-models/global-forecast>`_
     - `Parameter sets <https://www.nco.ncep.noaa.gov/pmb/products/gfs/>`_
     - `GFS Documentation <https://www.emc.ncep.noaa.gov/emc/pages/numerical_forecast_systems/gfs/documentation.php>`_
-    """  # noqa: E501
+    """
 
     __slots__ = ("client", "grid", "cachestore", "show_progress", "forecast_time")
 
@@ -496,7 +496,7 @@ class GFSForecast(metsource.MetDataSource):
             GFS dataset
         """
         # translate into netcdf from grib
-        logger.debug(f"Translating {filepath} for timestep {str(t)} into netcdf")
+        logger.debug(f"Translating {filepath} for timestep {t!s} into netcdf")
 
         # get step for timestep
         step = pd.Timedelta(t - self.forecast_time) // pd.Timedelta(1, "h")

--- a/pycontrails/datalib/gfs/gfs.py
+++ b/pycontrails/datalib/gfs/gfs.py
@@ -13,8 +13,9 @@ import hashlib
 import logging
 import pathlib
 import warnings
+from collections.abc import Callable
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import pandas as pd

--- a/pycontrails/datalib/landsat.py
+++ b/pycontrails/datalib/landsat.py
@@ -33,15 +33,6 @@ except ModuleNotFoundError as exc:
         pycontrails_optional_package="sat",
     )
 
-try:
-    import rasterio
-except ModuleNotFoundError as exc:
-    dependencies.raise_module_not_found_error(
-        name="landsat module",
-        package_name="rasterio",
-        module_not_found_error=exc,
-        pycontrails_optional_package="sat",
-    )
 
 #: BigQuery table with imagery metadata
 BQ_TABLE = "bigquery-public-data.cloud_storage_geo_index.landsat_index"
@@ -313,6 +304,16 @@ def _check_band_resolution(bands: set[str]) -> None:
 
 def _read(path: str, meta: str, band: str, processing: str) -> xr.DataArray:
     """Read imagery data from Landsat files."""
+    try:
+        import rasterio
+    except ModuleNotFoundError as exc:
+        dependencies.raise_module_not_found_error(
+            name="landsat module",
+            package_name="rasterio",
+            module_not_found_error=exc,
+            pycontrails_optional_package="sat",
+        )
+
     src = rasterio.open(path)
     img = src.read(1)
     crs = pyproj.CRS.from_epsg(src.crs.to_epsg())

--- a/pycontrails/ext/synthetic_flight.py
+++ b/pycontrails/ext/synthetic_flight.py
@@ -417,7 +417,7 @@ class SyntheticFlight:
         times_arr = np.asarray(times).T
         data = [
             {"longitude": lon, "latitude": lat, "level": level, "time": time}
-            for lon, lat, level, time in zip(lons_arr, lats_arr, level, times_arr)
+            for lon, lat, level, time in zip(lons_arr, lats_arr, level, times_arr, strict=True)
         ]
         dfs = [pd.DataFrame(d).dropna() for d in data]
         dfs = [df for df in dfs if len(df) >= self.min_n_waypoints]

--- a/pycontrails/models/accf.py
+++ b/pycontrails/models/accf.py
@@ -154,7 +154,7 @@ class ACCF(Model):
     sur_variables = (ecmwf.SurfaceSolarDownwardRadiation, ecmwf.TopNetThermalRadiation)
     default_params = ACCFParams
 
-    short_vars = {v.short_name for v in (*met_variables, *sur_variables)}
+    short_vars = frozenset(v.short_name for v in (*met_variables, *sur_variables))
 
     # This variable won't get used since we are not writing the output
     # anywhere, but the library will complain if it's not defined

--- a/pycontrails/models/apcemm/apcemm.py
+++ b/pycontrails/models/apcemm/apcemm.py
@@ -84,10 +84,10 @@ class APCEMMParams(models.ModelParams):
     engine_uid: str | None = None
 
     #: Aircraft performance model
-    aircraft_performance: AircraftPerformance = PSFlight()
+    aircraft_performance: AircraftPerformance = dataclasses.field(default_factory=PSFlight)
 
     #: Fuel type
-    fuel: Fuel = JetA()
+    fuel: Fuel = dataclasses.field(default_factory=JetA)
 
     #: List of flight waypoints to simulate in APCEMM.
     #: By default, runs a simulation for every waypoint.
@@ -371,7 +371,7 @@ class APCEMM(models.Model):
     @overload
     def eval(self, source: None = ..., **params: Any) -> NoReturn: ...
 
-    def eval(self, source: Flight | None = None, **params: Any) -> Flight | NoReturn:
+    def eval(self, source: Flight | None = None, **params: Any) -> Flight:
         """Set up and run APCEMM simulations initialized at flight waypoints.
 
         Simulates the formation and evolution of contrails from a Flight
@@ -776,8 +776,8 @@ class APCEMM(models.Model):
         # Compute azimuth
         # Use forward and backward differences for first and last waypoints
         # and centered differences elsewhere
-        ileft = [0] + list(range(self.source.size - 1))
-        iright = list(range(1, self.source.size)) + [self.source.size - 1]
+        ileft = [0, *range(self.source.size - 1)]
+        iright = [*range(1, self.source.size), self.source.size - 1]
         lon0 = self.source["longitude"][ileft]
         lat0 = self.source["latitude"][ileft]
         lon1 = self.source["longitude"][iright]

--- a/pycontrails/models/cocip/cocip.py
+++ b/pycontrails/models/cocip/cocip.py
@@ -1132,7 +1132,7 @@ class Cocip(Model):
         )
         vector = GeoVectorDataset(
             {
-                key: np.concat((latest_contrail[key], future_contrails[key]))
+                key: np.concatenate((latest_contrail[key], future_contrails[key]))
                 for key in ("longitude", "latitude", "level", "time")
             }
         )

--- a/pycontrails/models/cocip/cocip.py
+++ b/pycontrails/models/cocip/cocip.py
@@ -335,7 +335,7 @@ class Cocip(Model):
         self,
         source: Flight | Sequence[Flight] | None = None,
         **params: Any,
-    ) -> Flight | list[Flight] | NoReturn:
+    ) -> Flight | list[Flight]:
         """Run CoCiP simulation on flight.
 
         Simulates the formation and evolution of contrails from a Flight
@@ -1516,7 +1516,7 @@ def _process_rad(rad: MetDataset) -> MetDataset:
     -----
     - https://www.ecmwf.int/sites/default/files/elibrary/2015/18490-radiation-quantities-ecmwf-model-and-mars.pdf
     - https://confluence.ecmwf.int/pages/viewpage.action?pageId=155337784
-    """  # noqa: E501
+    """
     # If the time coordinate has already been shifted, early return
     if "shift_radiation_time" in rad["time"].attrs:
         return rad

--- a/pycontrails/models/cocip/output_formats.py
+++ b/pycontrails/models/cocip/output_formats.py
@@ -638,7 +638,7 @@ def regional_statistics(da_var: xr.DataArray, *, agg: str) -> pd.Series:
     -----
     - The spatial bounding box for each region is defined in Teoh et al. (2023)
     - Teoh, R., Engberg, Z., Shapiro, M., Dray, L., and Stettler, M.: A high-resolution Global
-        Aviation emissions Inventory based on ADS-B (GAIA) for 2019–2021, EGUsphere [preprint],
+        Aviation emissions Inventory based on ADS-B (GAIA) for 2019-2021, EGUsphere [preprint],
         https://doi.org/10.5194/egusphere-2023-724, 2023.
     """
     if (agg == "mean") and (len(da_var.time) > 1):
@@ -715,7 +715,7 @@ def _regional_data_arrays(da_global: xr.DataArray) -> dict[str, xr.DataArray]:
     -----
     - The spatial bounding box for each region is defined in Teoh et al. (2023)
     - Teoh, R., Engberg, Z., Shapiro, M., Dray, L., and Stettler, M.: A high-resolution Global
-        Aviation emissions Inventory based on ADS-B (GAIA) for 2019–2021, EGUsphere [preprint],
+        Aviation emissions Inventory based on ADS-B (GAIA) for 2019-2021, EGUsphere [preprint],
         https://doi.org/10.5194/egusphere-2023-724, 2023.
     """
     return {

--- a/pycontrails/models/cocip/radiative_forcing.py
+++ b/pycontrails/models/cocip/radiative_forcing.py
@@ -942,7 +942,7 @@ def contrail_contrail_overlap_radiative_effects(
     References
     ----------
     - Schumann et al. (2021) Air traffic and contrail changes over Europe during COVID-19:
-        A model study, Atmos. Chem. Phys., 21, 7429–7450, https://doi.org/10.5194/ACP-21-7429-2021.
+        A model study, Atmos. Chem. Phys., 21, 7429-7450, https://doi.org/10.5194/ACP-21-7429-2021.
     - Teoh et al. (2023) Global aviation contrail climate effects from 2019 to 2021.
 
     Notes

--- a/pycontrails/models/cocip/radiative_forcing.py
+++ b/pycontrails/models/cocip/radiative_forcing.py
@@ -10,6 +10,7 @@ References
 from __future__ import annotations
 
 import dataclasses
+import itertools
 
 import numpy as np
 import numpy.typing as npt
@@ -999,8 +1000,7 @@ def contrail_contrail_overlap_radiative_effects(
     # Account for contrail overlapping starting from bottom to top layers
     altitude_layers = np.arange(min_altitude_m, max_altitude_m + 1.0, dz_overlap_m)
 
-    # TODO: replace zip with itertools.pairwise after we drop python3.9 support
-    for alt_layer0, alt_layer1 in zip(altitude_layers, altitude_layers[1:]):
+    for alt_layer0, alt_layer1 in itertools.pairwise(altitude_layers):
         is_in_layer = (altitude >= alt_layer0) & (altitude < alt_layer1)
 
         # Get contrail waypoints at current altitude layer

--- a/pycontrails/models/cocipgrid/cocip_grid.py
+++ b/pycontrails/models/cocipgrid/cocip_grid.py
@@ -143,7 +143,7 @@ class CocipGrid(models.Model):
 
     def eval(
         self, source: GeoVectorDataset | MetDataset | None = None, **params: Any
-    ) -> GeoVectorDataset | MetDataset | NoReturn:
+    ) -> GeoVectorDataset | MetDataset:
         """Run CoCiP simulation on a 4d coordinate grid or arbitrary set of 4d points.
 
         If the :attr:`params` ``verbose_outputs_evolution`` is True, the model holds

--- a/pycontrails/models/cocipgrid/cocip_grid.py
+++ b/pycontrails/models/cocipgrid/cocip_grid.py
@@ -446,9 +446,9 @@ class CocipGrid(models.Model):
         if ap_model := self.params["aircraft_performance"]:
             attrs["ap_model"] = type(ap_model).__name__
 
-        if isinstance(azimuth, (np.floating, np.integer)):
+        if isinstance(azimuth, np.floating | np.integer):
             attrs["azimuth"] = azimuth.item()
-        elif isinstance(azimuth, (float, int)):
+        elif isinstance(azimuth, float | int):
             attrs["azimuth"] = azimuth
 
         if isinstance(self.source, MetDataset):
@@ -897,7 +897,7 @@ def _setdefault_from_params(key: str, vector: GeoVectorDataset, params: dict[str
     if scalar is None:
         return
 
-    if not isinstance(scalar, (int, float)):
+    if not isinstance(scalar, int | float):
         msg = (
             f"Parameter {key} must be a scalar. For non-scalar values, directly "
             "set the data on the 'source'."

--- a/pycontrails/models/ps_model/ps_model.py
+++ b/pycontrails/models/ps_model/ps_model.py
@@ -312,7 +312,7 @@ class PSFlight(AircraftPerformance):
                 atyp_param.wing_surface_area,
                 q_fuel,
             )
-        elif isinstance(fuel_flow, (int, float)):
+        elif isinstance(fuel_flow, int | float):
             fuel_flow = np.full_like(true_airspeed, fuel_flow)
 
         # Flight phase
@@ -339,11 +339,11 @@ class PSFlight(AircraftPerformance):
 
         # XXX: Explicitly broadcast scalar inputs as needed to keep a consistent
         # output spec.
-        if isinstance(aircraft_mass, (int, float)):
+        if isinstance(aircraft_mass, int | float):
             aircraft_mass = np.full_like(true_airspeed, aircraft_mass)
-        if isinstance(engine_efficiency, (int, float)):
+        if isinstance(engine_efficiency, int | float):
             engine_efficiency = np.full_like(true_airspeed, engine_efficiency)
-        if isinstance(thrust, (int, float)):
+        if isinstance(thrust, int | float):
             thrust = np.full_like(true_airspeed, thrust)
 
         return AircraftPerformanceData(

--- a/pycontrails/models/sac.py
+++ b/pycontrails/models/sac.py
@@ -236,7 +236,7 @@ def T_sat_liquid(G: ArrayLike) -> ArrayLike:
     # This comment is pasted several places in `pycontrails` -- they should all be
     # addressed at the same time.
     log_ = np.log(G - 0.053)
-    return -46.46 - constants.absolute_zero + 9.43 * log_ + 0.72 * log_**2  # type: ignore[return-value]  # noqa: E501
+    return -46.46 - constants.absolute_zero + 9.43 * log_ + 0.72 * log_**2  # type: ignore[return-value]
 
 
 def _e_sat_liquid_prime(T: ArrayScalarLike) -> ArrayScalarLike:

--- a/pycontrails/models/sac.py
+++ b/pycontrails/models/sac.py
@@ -150,7 +150,7 @@ class SAC(Model):
         if scale_humidity:
             for k, v in humidity_scaling.description.items():
                 self.source.attrs[f"humidity_scaling_{k}"] = v
-        if isinstance(engine_efficiency, (int, float)):
+        if isinstance(engine_efficiency, int | float):
             self.source.attrs["engine_efficiency"] = engine_efficiency
 
         return self.source

--- a/pycontrails/physics/thermo.py
+++ b/pycontrails/physics/thermo.py
@@ -163,7 +163,7 @@ def e_sat_liquid(T: ArrayScalarLike) -> ArrayScalarLike:
     # 6.1121 * np.exp((18.678 * (T - 273.15) / 234.5) * (T - 273.15) / (257.14 + (T - 273.15)))
 
     # Magnus Tetens (Murray, 1967)
-    # 6.1078 * np.exp(17.269388 * (T - 273.16) / (T – 35.86))
+    # 6.1078 * np.exp(17.269388 * (T - 273.16) / (T - 35.86))
 
     # Guide to Meteorological Instruments and Methods of Observation (CIMO Guide) (WMO, 2008)
     # 6.112 * np.exp(17.62 * (T - 273.15) / (243.12 + T - 273.15))

--- a/pycontrails/utils/json.py
+++ b/pycontrails/utils/json.py
@@ -48,23 +48,21 @@ class NumpyEncoder(json.JSONEncoder):
         """
         if isinstance(
             obj,
-            (
-                np.int_,
-                np.intc,
-                np.intp,
-                np.int8,
-                np.int16,
-                np.int32,
-                np.int64,
-                np.uint8,
-                np.uint16,
-                np.uint32,
-                np.uint64,
-            ),
+            np.int_
+            | np.intc
+            | np.intp
+            | np.int8
+            | np.int16
+            | np.int32
+            | np.int64
+            | np.uint8
+            | np.uint16
+            | np.uint32
+            | np.uint64,
         ):
             return int(obj)
 
-        if isinstance(obj, (np.float16, np.float32, np.float64)):
+        if isinstance(obj, np.float16 | np.float32 | np.float64):
             return float(obj)
 
         # TODO: this is not easily reversible - np.timedelta64(str(np.timedelta64(1, "h"))) raises
@@ -74,10 +72,10 @@ class NumpyEncoder(json.JSONEncoder):
         if isinstance(obj, (np.datetime64)):
             return str(obj)
 
-        if isinstance(obj, (np.complex64, np.complex128)):
+        if isinstance(obj, np.complex64 | np.complex128):
             return {"real": obj.real, "imag": obj.imag}
 
-        if isinstance(obj, (np.ndarray,)):
+        if isinstance(obj, np.ndarray):
             return obj.tolist()
 
         if isinstance(obj, (np.bool_)):
@@ -86,7 +84,7 @@ class NumpyEncoder(json.JSONEncoder):
         if isinstance(obj, (np.void)):
             return None
 
-        if isinstance(obj, (pd.Series, pd.Index)):
+        if isinstance(obj, pd.Series | pd.Index):
             return obj.to_numpy().tolist()
 
         try:

--- a/pycontrails/utils/json.py
+++ b/pycontrails/utils/json.py
@@ -144,7 +144,7 @@ def dataframe_to_geojson_points(
         )
 
     # downselect dataframe
-    cols = ["longitude", "latitude", "altitude", "time"] + properties
+    cols = ["longitude", "latitude", "altitude", "time", *properties]
     df = df[cols]
 
     # filter out coords with nan values, or filter just on "filter_nan" labels

--- a/pycontrails/utils/types.py
+++ b/pycontrails/utils/types.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import functools
+from collections.abc import Callable
 from datetime import datetime
-from typing import Any, Callable, TypeVar, Union
+from typing import Any, TypeVar
 
 import numpy as np
 import numpy.typing as npt
@@ -12,11 +13,11 @@ import pandas as pd
 import xarray as xr
 
 #: Array like (np.ndarray, xr.DataArray)
-ArrayLike = TypeVar("ArrayLike", np.ndarray, xr.DataArray, Union[xr.DataArray, np.ndarray])
+ArrayLike = TypeVar("ArrayLike", np.ndarray, xr.DataArray, xr.DataArray | np.ndarray)
 
 #: Array or Float (np.ndarray, float)
 ArrayOrFloat = TypeVar(
-    "ArrayOrFloat", npt.NDArray[np.float64], float, Union[float, npt.NDArray[np.float64]]
+    "ArrayOrFloat", npt.NDArray[np.float64], float, float | npt.NDArray[np.float64]
 )
 
 #: Array like input (np.ndarray, xr.DataArray, np.float64, float)
@@ -26,8 +27,8 @@ ArrayScalarLike = TypeVar(
     xr.DataArray,
     np.float64,
     float,
-    Union[np.ndarray, float],
-    Union[xr.DataArray, np.ndarray],
+    np.ndarray | float,
+    xr.DataArray | np.ndarray,
 )
 
 #: Datetime like input (datetime, pd.Timestamp, np.datetime64)
@@ -71,7 +72,7 @@ def support_arraylike(
             return ret
 
         # Keep python native numeric types native
-        if isinstance(arr, (float, int, np.float64)):
+        if isinstance(arr, float | int | np.float64):
             return ret.item()
 
         # Recreate pd.Series

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ dev = [
     "pytest>=8.2",
     "pytest-cov>=2.11",
     "requests>=2.25",
-    "ruff==0.5.3",
+    "ruff==0.5.7",
     "setuptools",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,8 @@ requires = [
     "wheel",
     "cython",
     # https://numpy.org/devdocs/dev/depending_on_numpy.html#numpy-2-abi-handling
-    "numpy>=2.0.0",
+    "numpy>=2.0.0; python_version<'3.13'",
+    "numpy>=2.1.0rc1; python_version>='3.13'"
 ]
 build-backend = "setuptools.build_meta"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ complete = ["pycontrails[ecmwf,gcp,gfs,jupyter,pyproj,sat,vis,zarr]"]
 
 # Development dependencies
 dev = [
-    "black[jupyter]==24.4.2",
+    "black[jupyter]==24.8.0",
     "dep_license",
     "fastparquet>=0.8",
     "ipdb>=0.13",
@@ -209,7 +209,7 @@ show_error_codes = true
 [tool.black]
 line-length = 100
 preview = true
-required-version = "24.4.2"
+required-version = "24.8.0"
 
 # pytest
 # https://docs.pytest.org/en/7.1.x/reference/customize.html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,17 +22,17 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Scientific/Engineering :: Atmospheric Science",
     "Topic :: Scientific/Engineering :: GIS",
     "Typing :: Typed",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = { text = "Apache-2.0" }
 readme = { file = "README.md", content-type = "text/markdown" }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires = [
     "cython",
     # https://numpy.org/devdocs/dev/depending_on_numpy.html#numpy-2-abi-handling
     "numpy>=2.0.0; python_version<'3.13'",
-    "numpy>=2.1.0rc1; python_version>='3.13'"
+    "numpy>=2.1.0rc1; python_version>='3.13'",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -132,7 +132,7 @@ sat = [
     "pillow>=10.3",
     "pyproj>=3.5",
     "rasterio>=1.3",
-    "scikit-image>=0.18"
+    "scikit-image>=0.18",
 ]
 
 # Polyhedra contruction methods

--- a/tests/_deprecated.py
+++ b/tests/_deprecated.py
@@ -233,7 +233,7 @@ def _m_to_T_isa(h: np.ndarray) -> np.ndarray:
     T_stratosphere_isa = constants.T_msl + (constants.T_lapse_rate * constants.h_tropopause)
 
     # array
-    if isinstance(T_isa, (np.ndarray, xr.DataArray)):
+    if isinstance(T_isa, np.ndarray | xr.DataArray):
         # If h is ArrayLike, it supports indexing
         T_isa[h > constants.h_tropopause] = T_stratosphere_isa
         return T_isa
@@ -274,7 +274,7 @@ def m_to_pl(h: np.ndarray) -> np.ndarray:
     TODO: reference
     """
     # array
-    if isinstance(h, (np.ndarray, xr.DataArray)):
+    if isinstance(h, np.ndarray | xr.DataArray):
         pl = _low_altitude_m_to_pl(h)
         pl[h > constants.h_tropopause] = _high_altitude_m_to_pl(h[h > constants.h_tropopause])
         return pl

--- a/tests/unit/test_fleet.py
+++ b/tests/unit/test_fleet.py
@@ -41,7 +41,7 @@ def test_fleet_io(syn: SyntheticFlight) -> None:
     assert fleet.n_flights == 100
 
     out_fls = fleet.to_flight_list()
-    for fl1, fl2 in zip(in_fls, out_fls):
+    for fl1, fl2 in zip(in_fls, out_fls, strict=True):
         assert fl1 == fl2
 
 
@@ -135,7 +135,7 @@ def test_fleet_waypoints(syn: SyntheticFlight) -> None:
 
     flight_ids = fleet.filter(~continuous)["flight_id"]
     # expect one of each flight_id
-    for id1, id2 in zip(flight_ids, fleet.fl_attrs):
+    for id1, id2 in zip(flight_ids, fleet.fl_attrs, strict=True):
         assert id1 == id2
 
 

--- a/tests/unit/test_flight.py
+++ b/tests/unit/test_flight.py
@@ -543,7 +543,9 @@ def test_geojson_methods(fl: Flight, rng: np.random.Generator) -> None:
     assert d2["type"] == "FeatureCollection"
     assert json.dumps(d2)
     assert len(d1["features"]) == len(d2["features"][0]["geometry"]["coordinates"])
-    for feature, coord in zip(d1["features"], d2["features"][0]["geometry"]["coordinates"]):
+    for feature, coord in zip(
+        d1["features"], d2["features"][0]["geometry"]["coordinates"], strict=True
+    ):
         assert feature["geometry"]["coordinates"] == coord
 
     with pytest.raises(KeyError):

--- a/tests/unit/test_met.py
+++ b/tests/unit/test_met.py
@@ -28,7 +28,7 @@ def test_sl_path_to_met(met_ecmwf_sl_path: str) -> None:
     assert list(ds.data_vars) == ["sp"]
 
     mds = MetDataset(ds)
-    assert mds.dim_order == ["longitude", "latitude", "level", "time"]
+    assert mds.dim_order == ("longitude", "latitude", "level", "time")
 
     # longitude and latitude correctly translated
     assert np.all(mds.data["longitude"].values >= -180)
@@ -73,7 +73,7 @@ def test_pl_path_to_met(met_ecmwf_pl_path: str) -> None:
     assert list(ds.data_vars) == ["t", "r", "q", "ciwc"]
 
     mds = MetDataset(ds)
-    assert mds.dim_order == ["longitude", "latitude", "level", "time"]
+    assert mds.dim_order == ("longitude", "latitude", "level", "time")
 
     # longitude and latitude correctly translated
     assert np.all(mds.data["longitude"].values < 180)

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -101,7 +101,7 @@ class ModelTestGridMissingRequiredVariables(Model):
 
     name = "grid"
     long_name = "missing required met variables"
-    met_variables = [AirTemperature, OtherVar]
+    met_variables = (AirTemperature, OtherVar)
 
     def eval(self, source: None = None) -> MetDataArray:
         pass
@@ -112,7 +112,7 @@ class ModelTestFlightMissingRequiredVariables(Model):
 
     name = "flight"
     long_name = "missing required met variables"
-    met_variables = [AirTemperature, OtherVar]
+    met_variables = (AirTemperature, OtherVar)
     default_params = ModelParams
 
     def eval(self, source: None = None) -> MetDataArray:
@@ -406,7 +406,7 @@ class ModelTestVerifyMet(Model):
     name = "flight"
     long_name = "two variable flight model"
     default_params = VerifyMetParams
-    met_variables = [AirTemperature, SpecificHumidity]
+    met_variables = (AirTemperature, SpecificHumidity)
 
     source: Flight | MetDataset
 

--- a/tests/unit/test_ps_model.py
+++ b/tests/unit/test_ps_model.py
@@ -201,7 +201,7 @@ def test_mach_number_limits():
     mmin = []
     mmax = []
     air_temperature = units.m_to_T_isa(units.ft_to_m(altitude_ft))
-    for alt, pres, temp in zip(altitude_ft, air_pressure, air_temperature):
+    for alt, pres, temp in zip(altitude_ft, air_pressure, air_temperature, strict=True):
         mmin.append(ps_lims.minimum_mach_num(pres, aircraft_mass, atyp_param))
         mmax.append(ps_lims.maximum_mach_num(alt, pres, aircraft_mass, temp, 0.0, atyp_param))
 

--- a/tests/unit/test_sac_issr.py
+++ b/tests/unit/test_sac_issr.py
@@ -168,7 +168,10 @@ def test_PCR_grid(met_issr: MetDataset) -> None:
 
     met_copy = met_issr.copy()
     del met_copy.data["air_temperature"]
-    met_copy.data["engine_efficiency"] = np.float32(0.35)
+    met_copy.data["engine_efficiency"] = (
+        met_copy.data.dims,
+        np.full(met_copy.shape, 0.35, dtype=np.float32),
+    )
     out2 = model.eval(source=met_copy)
 
     assert isinstance(out2, MetDataset)

--- a/tests/unit/test_tau_cirrus.py
+++ b/tests/unit/test_tau_cirrus.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Callable
+from collections.abc import Callable
 
 import numpy as np
 import pytest

--- a/tests/unit/test_tau_cirrus.py
+++ b/tests/unit/test_tau_cirrus.py
@@ -25,7 +25,7 @@ def test_shape_and_coords(met_cocip1: MetDataset, formula: Callable) -> None:
     assert da.dtype == np.float32
 
     assert da.sizes == met_cocip1.data.sizes
-    assert list(da.dims) == met_cocip1.dim_order
+    assert da.dims == met_cocip1.dim_order
 
     xr.testing.assert_equal(da.level, met_cocip1.data["level"])
     xr.testing.assert_equal(da.time, met_cocip1.data["time"])

--- a/tests/unit/test_units.py
+++ b/tests/unit/test_units.py
@@ -157,13 +157,13 @@ def test_arraylike_support(func):
     # Some functions can handle Series or DataArrays
     # Others convert to numpy
     da = xr.DataArray(z)
-    assert isinstance(func(da), (xr.DataArray, np.ndarray))
+    assert isinstance(func(da), xr.DataArray | np.ndarray)
 
     # Calling xr.apply_ufunc gives same result
     xr.testing.assert_equal(func(da), xr.apply_ufunc(func, da))
 
     s = pd.Series(z)
-    assert isinstance(func(s), (pd.Series, np.ndarray))
+    assert isinstance(func(s), pd.Series | np.ndarray)
 
 
 @pytest.mark.parametrize("func", [units.pl_to_m, units.m_to_pl])

--- a/tests/unit/test_vector.py
+++ b/tests/unit/test_vector.py
@@ -320,7 +320,7 @@ def test_to_dataframe(random_path: VectorDataset, random_geo_path: GeoVectorData
     # reverse gives same data dictionary
     data = df.to_dict(orient="list")
     assert random_path.data.keys() == data.keys()
-    for arr1, arr2 in zip(random_path.data.values(), data.values()):
+    for arr1, arr2 in zip(random_path.data.values(), data.values(), strict=True):
         np.testing.assert_array_equal(arr1, arr2)
 
     df = random_geo_path.to_dataframe()


### PR DESCRIPTION
### Breaking changes

- Drop python 3.9 support per [NEP 29](https://numpy.org/neps/nep-0029-deprecation_policy.html).

### Features

- Build wheels for [python 3.13](https://peps.python.org/pep-0719/). (These wheels are available on PyPI, but other pycontrails dependencies may not yet support python 3.13.)

### Fixes

- Fix `PycontrailsRegularGridInterpolator` for compatibility with the latest scipy version.

### Internals

- Defer import of `skimage` and `rasterio`.

## Tests

- [ ] QC test passes locally (`make test`)
- [ ] CI tests pass

## Reviewer

> Select @ reviewer
