### PR TITLE
Ensure CDS-beta compatibility, improve aCCF calculation performance, and fix aCCF parameters

### DIFF
--- a/pycontrails/datalib/ecmwf/era5.py
+++ b/pycontrails/datalib/ecmwf/era5.py
@@ -488,6 +488,11 @@ class ERA5(ECMWFAPI):
 
             # run preprocessing before cache
             ds = self._preprocess_era5_dataset(ds)
+            # renaming to comply with new CDS-beta
+            # date of shutdown of the previous API: September 3rd, 2024
+            ds = ds.rename({"valid_time": "time"}).drop_vars("number")
+            if len(self.pressure_levels) > 1:
+                ds = ds.rename({"pressure_level": "level"})
 
             self.cache_dataset(ds)
 

--- a/pycontrails/models/accf.py
+++ b/pycontrails/models/accf.py
@@ -340,7 +340,7 @@ def _get_accf_config(params: dict[str, Any]) -> dict[str, Any]:
         "horizontal_resolution": params["horizontal_resolution"],
         "forecast_step": params["forecast_step"],
         "NOx_aCCF": True,
-        "NOx&inverse_EIs": params["nox_ei"],
+        "NOx_EI&F_km": params["nox_ei"],
         "output_format": "netCDF",
         "mean": False,
         "std": False,
@@ -361,6 +361,7 @@ def _get_accf_config(params: dict[str, Any]) -> dict[str, Any]:
             "H2O": params["h2o_scaling"],
             "O3": params["o3_scaling"],
         },
+        "unit_K/kg(fuel)": True,
         "PCFA": params["pfca"],
         "PCFA-ISSR": {
             "rhi_threshold": params["issr_rhi_threshold"],

--- a/pycontrails/models/accf.py
+++ b/pycontrails/models/accf.py
@@ -267,7 +267,7 @@ class ACCF(Model):
         aCCFs, _ = clim_imp.get_xarray()
 
         # assign ACCF outputs to source
-        maCCFs = MetDataset(aCCFs)
+        maCCFs = MetDataset(aCCFs, sort=True)
         for key, arr in maCCFs.data.items():
             # skip met variables
             if key in self.short_vars:

--- a/pycontrails/models/accf.py
+++ b/pycontrails/models/accf.py
@@ -267,7 +267,7 @@ class ACCF(Model):
         aCCFs, _ = clim_imp.get_xarray()
 
         # assign ACCF outputs to source
-        maCCFs = MetDataset(aCCFs, sort=True)
+        maCCFs = MetDataset(aCCFs, sort=False)
         for key, arr in maCCFs.data.items():
             # skip met variables
             if key in self.short_vars:


### PR DESCRIPTION
Soon ERA5 will only be accessible via the new API, however some variable names are different. This PR renames those variables.

The CLIMaCCF interface is not implemented correctly: one parameter was wrong and the assumption that all aCCFs are returned with unit K/kg(fuel) was also not correct.

Furthermore, the result from CLIMaCCF does not need to be sorted, as it is already sorted.