### PR TITLE
Fix/cds beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.53.1
+
+### Features
+
+- Support `ERA5` downloads from [CDS-Beta](https://cds-beta.climate.copernicus.eu/). The updated interface is backwards compatible with the legacy CDS server. The choice of CDS server is governed by the `url` parameter in the `ERA5` constructor.
+
 ## v0.53.0
 
 ### Breaking changes
@@ -88,13 +94,13 @@
 ### Features
 
 - Add tools for running [APCEMM](https://github.com/MIT-LAE/APCEMM) from within pycontrails. This includes:
-    - utilities for generating APCEMM input files and running APCEMM (`pycontrails.models.apcemm.utils`)
-    - an interface (`pycontrails.models.apcemm.apcemm`) that allows users to run APCEMM as a pycontrails `Model`.
+  - utilities for generating APCEMM input files and running APCEMM (`pycontrails.models.apcemm.utils`)
+  - an interface (`pycontrails.models.apcemm.apcemm`) that allows users to run APCEMM as a pycontrails `Model`.
 - Add [APCEMM tutorial notebook](https://py.contrails.org/integrations/APCEMM.html).
 - Add prescribed sedimentation rate to `DryAdvection` model.
 - Add `Landsat` and `Sentinel` datalibs for searching, retrieving, and visualizing Landsat 8-9 and Sentinel-2 imagery. The datalibs include:
-    - Tools for querying Landsat and Sentinel-2 imagery for intersections with user-defined regions (`landsat.query`, `sentinel.query`) or flights (`landsat.intersect`, `sentinel.intersect`). These tools use BigQuery tables and require a Google Cloud Platform account with access to the BigQuery API.
-    - Tools for downloading and visualizing imagery from Landsat (`Landsat`) and Sentinel-2 (`Sentinel`). These tools retrieve data anonymously from Google Cloud Platform storage buckets and can be used without a Google Cloud Platform account.
+  - Tools for querying Landsat and Sentinel-2 imagery for intersections with user-defined regions (`landsat.query`, `sentinel.query`) or flights (`landsat.intersect`, `sentinel.intersect`). These tools use BigQuery tables and require a Google Cloud Platform account with access to the BigQuery API.
+  - Tools for downloading and visualizing imagery from Landsat (`Landsat`) and Sentinel-2 (`Sentinel`). These tools retrieve data anonymously from Google Cloud Platform storage buckets and can be used without a Google Cloud Platform account.
 - Add tutorial notebooks demonstrating how to use `Landsat` and `Sentinel` datalibs to find flights in high-resolution satellite imagery.
 - Modify `Flight.to_geojson_multilinestring` to make grouping key optional and to support multiple antimeridian crossings.
 - Update the `pycontrails` build system to require `numpy 2.0` per the [official numpy guidelines](https://numpy.org/devdocs/dev/depending_on_numpy.html#numpy-2-0-specific-advice). Note that the runtime requirement for `pycontrails` remains `numpy>=1.22`.

--- a/docs/notebooks/ECMWF.ipynb
+++ b/docs/notebooks/ECMWF.ipynb
@@ -16,7 +16,7 @@
     "\n",
     "Support provided for:\n",
     "\n",
-    "- [ERA5](https://www.ecmwf.int/en/forecasts/dataset/ecmwf-reanalysis-v5) via the [Copernicus Data Store (CDS)](https://cds.climate.copernicus.eu/) using [cdsapi](https://github.com/ecmwf/cdsapi) or user provided files\n",
+    "- [ERA5](https://www.ecmwf.int/en/forecasts/dataset/ecmwf-reanalysis-v5) via the [Copernicus Data Store (CDS-Beta)](https://cds-beta.climate.copernicus.eu/) using [cdsapi](https://github.com/ecmwf/cdsapi) or user provided files\n",
     "- [HRES](https://confluence.ecmwf.int/display/FUG/Section+2.1.1.2+Rationale+for+High+Resolution) and [ENS](https://confluence.ecmwf.int/display/FUG/Section+2.1.2.1+ENS+-+Ensemble+Forecasts) via [MARS](https://confluence.ecmwf.int/display/UDOC/MARS+user+documentation) using [ecmwf-api-client](https://github.com/ecmwf/ecmwf-api-client) or user provided files.\n",
     "\n",
     "For both ERA5 and HRES, we provide interfaces for accessing \"pressure-level data\" (fields pre-interpolated to a fixed set of pressure levels) or \"model-level data\" (fields retrieved on the native vertical grid and [interpolated after retrieval to an arbitrary set of pressure levels](model-levels.ipynb)). We recommend using model-level data when possible, as the resolution of pressure-level data is coarse relative to the vertical scale of ice-supersaturated regions.\n",
@@ -32,8 +32,8 @@
     "\n",
     "### Access\n",
     "\n",
-    "- Requires account with [Copernicus Data Portal](https://cds.climate.copernicus.eu/cdsapp#!/home)\n",
-    "- Provide `url` and `key` credentials on input, or refer to the [CDS API Documentation](https://github.com/ecmwf/cdsapi#configure) for how to create `~/.cdsapirc` file to configure access.\n",
+    "- Requires account with [Copernicus Data Portal](https://cds-beta.climate.copernicus.eu/)\n",
+    "- Provide `url` and `key` credentials on input, or refer to the [CDS API Documentation](https://cds-beta.climate.copernicus.eu/how-to-api) for how to create `~/.cdsapirc` file to configure access.\n",
     "\n",
     "### Reference\n",
     "\n",
@@ -87,7 +87,7 @@
     "    time=\"2022-03-01 00:00:00\",\n",
     "    variables=[\"t\", \"q\", \"u\", \"v\", \"w\", \"ciwc\", \"z\", \"cc\"],  # supports CF name or short names\n",
     "    pressure_levels=[200, 250, 300],\n",
-    "    # url=\"https://cds.climate.copernicus.eu/api/v2\",\n",
+    "    # url=\"https://cds-beta.climate.copernicus.eu/api\",\n",
     "    # key=\"<key>\"\n",
     ")\n",
     "era5"
@@ -132,7 +132,7 @@
     "        \"cc\",\n",
     "    ],  # supports CF name or short names\n",
     "    pressure_levels=[300, 250, 200],\n",
-    "    # url=\"https://cds.climate.copernicus.eu/api/v2\",\n",
+    "    # url=\"https://cds-beta.climate.copernicus.eu/api\",\n",
     "    # key=\"<key>\"\n",
     ")\n",
     "era5"
@@ -1429,7 +1429,7 @@
     "era5 = ERA5(\n",
     "    time=(\"2022-03-01 00:00:00\", \"2022-03-01 03:00:00\"),\n",
     "    variables=[\"tsr\", \"ttr\"],\n",
-    "    # url=\"https://cds.climate.copernicus.eu/api/v2\",\n",
+    "    # url=\"https://cds-beta.climate.copernicus.eu/api\",\n",
     "    # key=\"<key>\"\n",
     ")\n",
     "era5"
@@ -6072,7 +6072,7 @@
     "    variables=variables,\n",
     "    pressure_levels=[300, 250, 150],\n",
     "    cachestore=gcp,\n",
-    "    # url=\"https://cds.climate.copernicus.eu/api/v2\",\n",
+    "    # url=\"https://cds-beta.climate.copernicus.eu/api\",\n",
     "    # key=\"<key>\"\n",
     ")"
    ]

--- a/pycontrails/datalib/ecmwf/common.py
+++ b/pycontrails/datalib/ecmwf/common.py
@@ -63,7 +63,7 @@ class ECMWFAPI(metsource.MetDataSource):
             except KeyError as exc:
                 # this snippet shows the missing times for convenience
                 np_timesteps = {np.datetime64(t, "ns") for t in self.timesteps}
-                missing_times = sorted(np_timesteps.difference(ds["time"].values))
+                missing_times = sorted(np_timesteps.difference(ds["time"].values))  # type: ignore[type-var]
                 msg = f"Input dataset is missing time coordinates {[str(t) for t in missing_times]}"
                 raise KeyError(msg) from exc
 

--- a/pycontrails/datalib/ecmwf/era5.py
+++ b/pycontrails/datalib/ecmwf/era5.py
@@ -522,13 +522,17 @@ class ERA5(ECMWFAPI):
         xr.Dataset
             Processed :class:`xr.Dataset`
         """
+        if "pycontrails_version" in ds.attrs:
+            LOG.debug("Input dataset processed with pycontrails > 0.29")
+            return ds
+
         # For "reanalysis-era5-single-levels" or if self.pressure_levels length == 1,
         # then the netcdf file does not contain the dimension "level"
         if len(self.pressure_levels) == 1:
             ds = ds.expand_dims(level=self.pressure_levels)
 
-        # New CDS-beta gives "valid_time" instead of "time"
-        # Legacy CDS gives "time"
+        # New CDS-Beta gives "valid_time" instead of "time"
+        # and "pressure_level" instead of "level"
         if "valid_time" in ds:
             ds = ds.rename(valid_time="time")
         if "pressure_level" in ds:

--- a/pycontrails/datalib/ecmwf/era5.py
+++ b/pycontrails/datalib/ecmwf/era5.py
@@ -522,17 +522,17 @@ class ERA5(ECMWFAPI):
         xr.Dataset
             Processed :class:`xr.Dataset`
         """
-
-        if "pycontrails_version" in ds.attrs:
-            LOG.debug("Input dataset processed with pycontrails > 0.29")
-            return ds
-
-        # not pre-processed source file from `download` or `paths`
-
-        # for "reanalysis-era5-single-levels" or if self.pressure_levels length == 1,
+        # For "reanalysis-era5-single-levels" or if self.pressure_levels length == 1,
         # then the netcdf file does not contain the dimension "level"
         if len(self.pressure_levels) == 1:
-            ds = ds.expand_dims({"level": self.pressure_levels})
+            ds = ds.expand_dims(level=self.pressure_levels)
+
+        # New CDS-beta gives "valid_time" instead of "time"
+        # Legacy CDS gives "time"
+        if "valid_time" in ds:
+            ds = ds.rename(valid_time="time")
+        if "pressure_level" in ds:
+            ds = ds.rename(pressure_level="level")
 
         ds.attrs["pycontrails_version"] = pycontrails.__version__
         return ds

--- a/pycontrails/datalib/ecmwf/era5.py
+++ b/pycontrails/datalib/ecmwf/era5.py
@@ -80,10 +80,17 @@ class ERA5(ECMWFAPI):
         Cache data store for staging ECMWF ERA5 files.
         Defaults to :class:`cache.DiskCacheStore`.
         If None, cache is turned off.
-    url : str
-        Override `cdsapi <https://github.com/ecmwf/cdsapi>`_ url
-    key : str
-        Override `cdsapi <https://github.com/ecmwf/cdsapi>`_ key
+    url : str | None
+        Override the default `cdsapi <https://github.com/ecmwf/cdsapi>`_ url.
+        As of August 2024, the url for the `CDS-Beta <https://cds-beta.climate.copernicus.eu>`_
+        is "https://cds-beta.climate.copernicus.eu/api", and the url for the legacy server is
+        "https://cds.climate.copernicus.eu/api/v2". If None, the url is set
+        by the ``CDSAPI_URL`` environment variable. If this is not defined, the
+        ``cdsapi`` package will determine the url.
+    key : str | None
+        Override default `cdsapi <https://github.com/ecmwf/cdsapi>`_ key. If None,
+        the key is set by the ``CDSAPI_KEY`` environment variable. If this is not defined,
+        the ``cdsapi`` package will determine the key.
 
     Notes
     -----

--- a/pycontrails/datalib/ecmwf/era5_model_level.py
+++ b/pycontrails/datalib/ecmwf/era5_model_level.py
@@ -54,8 +54,8 @@ ALL_ENSEMBLE_MEMBERS = list(range(10))
 class ERA5ModelLevel(ECMWFAPI):
     """Class to support model-level ERA5 data access, download, and organization.
 
-    The interface is similar to :class:`pycontrails.datalib.ecmwf.ERA5`, which downloads pressure-level
-    with much lower vertical resolution.
+    The interface is similar to :class:`pycontrails.datalib.ecmwf.ERA5`, which downloads
+    pressure-level with much lower vertical resolution.
 
     Requires account with
     `Copernicus Data Portal <https://cds.climate.copernicus.eu/cdsapp#!/home>`_
@@ -114,11 +114,18 @@ class ERA5ModelLevel(ECMWFAPI):
     cache_grib: bool, optional
         If True, cache downloaded GRIB files rather than storing them in a temporary file.
         By default, False.
-    url : str
-        Override `cdsapi <https://github.com/ecmwf/cdsapi>`_ url
-    key : str
-        Override `cdsapi <https://github.com/ecmwf/cdsapi>`_ key
-    """  # noqa: E501
+    url : str | None
+        Override the default `cdsapi <https://github.com/ecmwf/cdsapi>`_ url.
+        As of August 2024, the url for the `CDS-Beta <https://cds-beta.climate.copernicus.eu>`_
+        is "https://cds-beta.climate.copernicus.eu/api", and the url for the legacy server is
+        "https://cds.climate.copernicus.eu/api/v2". If None, the url is set
+        by the ``CDSAPI_URL`` environment variable. If this is not defined, the
+        ``cdsapi`` package will determine the url.
+    key : str | None
+        Override default `cdsapi <https://github.com/ecmwf/cdsapi>`_ key. If None,
+        the key is set by the ``CDSAPI_KEY`` environment variable. If this is not defined,
+        the ``cdsapi`` package will determine the key.
+    """
 
     __marker = object()
 

--- a/pycontrails/models/cocipgrid/cocip_grid.py
+++ b/pycontrails/models/cocipgrid/cocip_grid.py
@@ -322,7 +322,7 @@ class CocipGrid(models.Model):
 
         if met is None:
             # idx is the first index at which self.met.variables["time"].to_numpy() >= time_end
-            idx = np.searchsorted(self.met.indexes["time"].to_numpy(), time_end)
+            idx = np.searchsorted(self.met.indexes["time"].to_numpy(), time_end).item()
             sl = slice(max(0, idx - 1), idx + 1)
             logger.debug("Select met slice %s", sl)
             met = MetDataset(self.met.data.isel(time=sl), copy=False)
@@ -331,7 +331,7 @@ class CocipGrid(models.Model):
             current_times = met.indexes["time"].to_numpy()
             all_times = self.met.indexes["time"].to_numpy()
             # idx is the first index at which all_times >= time_end
-            idx = np.searchsorted(all_times, time_end)
+            idx = np.searchsorted(all_times, time_end).item()
             sl = slice(max(0, idx - 1), idx + 1)
 
             # case 1: cannot re-use end of current met as start of new met
@@ -353,7 +353,7 @@ class CocipGrid(models.Model):
 
         if rad is None:
             # idx is the first index at which self.rad.variables["time"].to_numpy() >= time_end
-            idx = np.searchsorted(self.rad.indexes["time"].to_numpy(), time_end)
+            idx = np.searchsorted(self.rad.indexes["time"].to_numpy(), time_end).item()
             sl = slice(max(0, idx - 1), idx + 1)
             logger.debug("Select rad slice %s", sl)
             rad = MetDataset(self.rad.data.isel(time=sl), copy=False)
@@ -362,7 +362,7 @@ class CocipGrid(models.Model):
             current_times = rad.indexes["time"].to_numpy()
             all_times = self.rad.indexes["time"].to_numpy()
             # idx is the first index at which all_times >= time_end
-            idx = np.searchsorted(all_times, time_end)
+            idx = np.searchsorted(all_times, time_end).item()
             sl = slice(max(0, idx - 1), idx + 1)
 
             # case 1: cannot re-use end of current rad as start of new rad

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -247,8 +247,8 @@ ignore-path = [
 ]
 
 # Python linter
-# https://beta.ruff.rs/docs/
-# https://beta.ruff.rs/docs/settings/#select
+# https://docs.astral.sh/ruff/
+# https://docs.astral.sh/ruff/settings/#select
 # https://www.pydocstyle.org/en/6.3.0/error_codes.html
 [tool.ruff]
 lint.select = ["B", "D", "E", "F", "I", "NPY", "PL", "PT", "SIM", "UP"]
@@ -270,7 +270,11 @@ lint.ignore = [
 "docs/conf.py" = ["E501"]
 "tests/*" = ["D"]
 
-# https://beta.ruff.rs/docs/settings/#pydocstyle
+# https://docs.astral.sh/ruff/settings/#pydocstyle
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"
 ignore-decorators = ["overrides.overrides"]
+
+# https://docs.astral.sh/ruff/settings/#flake8-pytest-style
+[tool.ruff.lint.flake8-pytest-style]
+fixture-parentheses = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,7 @@ requires = [
     "setuptools_scm",
     "wheel",
     "cython",
-    # https://numpy.org/devdocs/dev/depending_on_numpy.html#numpy-2-abi-handling
-    "numpy>=2.0.0; python_version<'3.13'",
-    "numpy>=2.1.0rc1; python_version>='3.13'",
+    "numpy>=2.0.0",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/tests/benchmark/cocip/review.ipynb
+++ b/tests/benchmark/cocip/review.ipynb
@@ -61,7 +61,7 @@
    "outputs": [],
    "source": [
     "# load flight metadata\n",
-    "flights_metadata = pd.read_parquet(f\"inputs/flight/flight-metadata.pq\")\n",
+    "flights_metadata = pd.read_parquet(\"inputs/flight/flight-metadata.pq\")\n",
     "flights_metadata.set_index(\"flight_id\", inplace=True)"
    ]
   },


### PR DESCRIPTION
Closes #232 

## Changes

Support `ERA5` downloads from [CDS-Beta](https://cds-beta.climate.copernicus.eu/). The updated interface is backwards compatible with the legacy CDS server. The choice of CDS server is governed by the `url` parameter in the `ERA5` constructor.

## Tests

- [x] QC test passes locally (`make test`)
- [x] CI tests pass

