### PR TITLE
Fix/cocip grid dt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Changelog
 
-## (unreleased)
+## v0.54.1 (unreleased)
 
 ### Features
 
-- Add CoCiP Grid notebook example to documentation
+- Add [CoCiP Grid notebook](https://py.contrails.org/notebooks/CoCiPGrid.html) example to documentation.
+
+### Fixes
+
+- Fix the integration time step in `CocipGrid.calc_evolve_one_step`. The previous implementation assumed a time interval of `params["dt_integration"]`. This may not be the case for all `source` parameters (for example, this could occur if running `CocipGrid` over a collection of ADS-B waypoints).
 
 ## v0.54.0
 

--- a/Makefile
+++ b/Makefile
@@ -216,10 +216,9 @@ nb-test: ensure-era5-cached nb-clean-check nb-format-check nb-check-links
 # https://github.com/jupyterlab/pytest-check-links
 nb-check-links:
 	python -m pytest --check-links \
-		--check-links-ignore "https://doi.org/10.1021/acs.est.9b05608" \
-		--check-links-ignore "https://doi.org/10.1021/acs.est.2c05781" \
 		--check-links-ignore "https://github.com/contrailcirrus/pycontrails-bada" \
 		--check-links-ignore "https://ourairports.com" \
+		--check-links-ignore "https://www.ncei.noaa.gov/products/weather-climate-models/global-forecast" \
 		docs/notebooks/*.ipynb
 
 # Execute all notebooks in docs

--- a/Makefile
+++ b/Makefile
@@ -216,6 +216,8 @@ nb-test: ensure-era5-cached nb-clean-check nb-format-check nb-check-links
 # https://github.com/jupyterlab/pytest-check-links
 nb-check-links:
 	python -m pytest --check-links \
+		--check-links-ignore "https://doi.org/10.1021/acs.est.9b05608" \
+		--check-links-ignore "https://doi.org/10.1021/acs.est.2c05781" \
 		--check-links-ignore "https://github.com/contrailcirrus/pycontrails-bada" \
 		--check-links-ignore "https://ourairports.com" \
 		--check-links-ignore "https://www.ncei.noaa.gov/products/weather-climate-models/global-forecast" \

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -92,7 +92,7 @@ Learn more on `contrails.org <https://contrails.org>`_.
    :alt: Unit test
    :target: https://github.com/contrailcirrus/pycontrails/actions/workflows/test.yaml
 
-.. |Docs| image:: https://github.com/contrailcirrus/pycontrails/actions/workflows/docs.yaml/badge.svg
+.. |Docs| image:: https://github.com/contrailcirrus/pycontrails/actions/workflows/docs.yaml/badge.svg?event=push
    :alt: Docs
    :target: https://github.com/contrailcirrus/pycontrails/actions/workflows/docs.yaml
 

--- a/docs/integrations/ACCF.ipynb
+++ b/docs/integrations/ACCF.ipynb
@@ -65,7 +65,7 @@
     "## Download meteorology data from ECMWF\n",
     "\n",
     "This demo uses [ERA5](https://www.ecmwf.int/en/forecasts/dataset/ecmwf-reanalysis-v5) via the [Copernicus Data Store (CDS)](https://cds.climate.copernicus.eu/) for met data.\n",
-    "This requires account with [Copernicus Data Portal](https://cds.climate.copernicus.eu/cdsapp#!/home) and local `~/.cdsapirc` file with credentials."
+    "This requires account with [Copernicus Data Portal](https://cds.climate.copernicus.eu/how-to-api) and local `~/.cdsapirc` file with credentials."
    ]
   },
   {

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -14,5 +14,5 @@ Models
    notebooks/CoCiP
    notebooks/CoCiPGrid
    notebooks/advection
-   integrations/ACCF.ipynb
-   integrations/APCEMM.ipynb
+   integrations/ACCF
+   integrations/APCEMM

--- a/docs/notebooks/CoCiP.ipynb
+++ b/docs/notebooks/CoCiP.ipynb
@@ -44,7 +44,7 @@
     "## Download meteorology data from ECMWF\n",
     "\n",
     "This demo uses [ERA5](https://www.ecmwf.int/en/forecasts/dataset/ecmwf-reanalysis-v5) via the [Copernicus Data Store (CDS)](https://cds.climate.copernicus.eu/) for met data.\n",
-    "This requires account with [Copernicus Data Portal](https://cds.climate.copernicus.eu/cdsapp#!/home) and  local `~/.cdsapirc` file with credentials.\n",
+    "This requires account with [Copernicus Data Portal](https://cds.climate.copernicus.eu/how-to-api) and  local `~/.cdsapirc` file with credentials.\n",
     "\n",
     "> Note this will download ~1 GB of meteorology data to your computer"
    ]

--- a/docs/notebooks/ISSR.ipynb
+++ b/docs/notebooks/ISSR.ipynb
@@ -11,7 +11,7 @@
     "\n",
     "### Met Data\n",
     "\n",
-    "- Requires account with [Copernicus Data Portal](https://cds.climate.copernicus.eu/cdsapp#!/home) and  local `~/.cdsapirc file` with credentials."
+    "- Requires account with [Copernicus Data Portal](https://cds.climate.copernicus.eu/how-to-api) and  local `~/.cdsapirc file` with credentials."
    ]
   },
   {

--- a/docs/notebooks/SAC.ipynb
+++ b/docs/notebooks/SAC.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "### Met Data\n",
     "\n",
-    "- Requires account with [Copernicus Data Portal](https://cds.climate.copernicus.eu/cdsapp#!/home) and  local `~/.cdsapirc file` with credentials."
+    "- Requires account with [Copernicus Data Portal](https://cds.climate.copernicus.eu/how-to-api) and  local `~/.cdsapirc file` with credentials."
    ]
   },
   {

--- a/pycontrails/datalib/ecmwf/era5.py
+++ b/pycontrails/datalib/ecmwf/era5.py
@@ -34,7 +34,7 @@ class ERA5(ECMWFAPI):
     """Class to support ERA5 data access, download, and organization.
 
     Requires account with
-    `Copernicus Data Portal <https://cds.climate.copernicus.eu/cdsapp#!/home>`_
+    `Copernicus Data Portal <https://cds.climate.copernicus.eu/how-to-api>`_
     and local credentials.
 
     API credentials can be stored in a ``~/.cdsapirc`` file

--- a/pycontrails/datalib/ecmwf/era5_model_level.py
+++ b/pycontrails/datalib/ecmwf/era5_model_level.py
@@ -56,7 +56,7 @@ class ERA5ModelLevel(ECMWFAPI):
     pressure-level with much lower vertical resolution.
 
     Requires account with
-    `Copernicus Data Portal <https://cds.climate.copernicus.eu/cdsapp#!/home>`_
+    `Copernicus Data Portal <https://cds.climate.copernicus.eu/how-to-api>`_
     and local credentials.
 
     API credentials can be stored in a ``~/.cdsapirc`` file

--- a/pycontrails/datalib/ecmwf/model_levels.py
+++ b/pycontrails/datalib/ecmwf/model_levels.py
@@ -384,9 +384,10 @@ def ml_to_pl(
     lnsp : xr.DataArray
         Natural logarithm of surface pressure, [:math:`\ln(\text{Pa})`]. If provided,
         ``sp`` is ignored. At least one of ``lnsp`` or ``sp`` must be provided.
+        The chunking over dimensions in common with ``ds`` must be the same as ``ds``.
     sp : xr.DataArray
-        Surface pressure, [:math:`\text{Pa}`].
-        At least one of ``lnsp`` or ``sp`` must be provided.
+        Surface pressure, [:math:`\text{Pa}`]. At least one of ``lnsp`` or ``sp`` must be provided.
+        The chunking over dimensions in common with ``ds`` must be the same as ``ds``.
 
     Returns
     -------

--- a/pycontrails/models/cocipgrid/cocip_grid.py
+++ b/pycontrails/models/cocipgrid/cocip_grid.py
@@ -1671,6 +1671,8 @@ def calc_evolve_one_step(
             segment_length_t1, segment_length_t2
         )
 
+    dt = next_contrail["time"] - curr_contrail["time"]
+
     sigma_yy_t2, sigma_zz_t2, sigma_yz_t2 = contrail_properties.plume_temporal_evolution(
         width_t1=width_t1,
         depth_t1=depth_t1,
@@ -1679,7 +1681,7 @@ def calc_evolve_one_step(
         diffuse_h_t1=diffuse_h_t1,
         diffuse_v_t1=diffuse_v_t1,
         seg_ratio=seg_ratio_t12,
-        dt=params["dt_integration"],
+        dt=dt,
         max_depth=params["max_depth"],
     )
 
@@ -1716,7 +1718,7 @@ def calc_evolve_one_step(
         dn_dt_agg=dn_dt_agg,
         dn_dt_turb=dn_dt_turb,
         seg_ratio=seg_ratio_t12,
-        dt=params["dt_integration"],
+        dt=dt,
     )
     next_contrail["n_ice_per_m"] = n_ice_per_m_t2
 
@@ -1737,7 +1739,7 @@ def calc_evolve_one_step(
         width_t1=width_t1,
         width_t2=width_t2,
         seg_length_t2=segment_length_t2,
-        dt=params["dt_integration"],
+        dt=dt,
     )
     # NOTE: This will get masked below if `persistent` is False
     # That is, we are taking a right Riemann sum of a decreasing function, so we are

--- a/tests/fixtures/cocip-met.py
+++ b/tests/fixtures/cocip-met.py
@@ -1,7 +1,7 @@
 """
 Build netcdf assets for cocip unit tests.
 
-- Requires account with [Copernicus Data Portal](https://cds.climate.copernicus.eu/cdsapp#!/home)
+- Requires account with [Copernicus Data Portal](https://cds.climate.copernicus.eu/how-to-api)
 and  local `~/.cdsapirc` file with credentials.
 """
 

--- a/tests/unit/test_cocip_grid.py
+++ b/tests/unit/test_cocip_grid.py
@@ -774,15 +774,17 @@ def test_geovector_source(
     assert "ef_per_m" in out
 
     persistent = out["contrail_age"] > np.timedelta64(0, "ns")
-    assert persistent.sum() == 75
+    assert persistent.sum() == 94
+
+    ef_per_m = out["ef_per_m"]
 
     # Contrail age and positive EF are 1-1
-    assert np.all(out["ef_per_m"][persistent] > 0)
-    assert np.all(out["ef_per_m"][~persistent] == 0)
+    assert np.all(ef_per_m[persistent] > 0)
+    assert np.all(ef_per_m[~persistent] == 0)
 
     # Pin the mean EF
-    assert out["ef_per_m"].mean().item() == pytest.approx(832396, rel=1e-3)
-    assert out["ef_per_m"][persistent].mean().item() == pytest.approx(28944911, rel=1e-3)
+    assert ef_per_m.mean().item() == pytest.approx(828481, rel=1e-3)
+    assert ef_per_m[persistent].mean().item() == pytest.approx(22985963, rel=1e-3)
 
 
 @pytest.mark.filterwarnings("ignore:invalid value encountered in remainder")

--- a/tests/unit/test_cocip_grid_parity.py
+++ b/tests/unit/test_cocip_grid_parity.py
@@ -192,7 +192,7 @@ def test_parity(
     # Secondary differences are due to different specific_humidity values between the two models
     ef1 = out1["ef"][filt]
     ef2 = ef_per_waypoint[filt]
-    np.testing.assert_allclose(ef1, ef2, rtol=0.15)
+    np.testing.assert_allclose(ef1, ef2, rtol=0.05)
 
     # ----------------------------------------------------
     # Confirm general agreement between model contrail age


### PR DESCRIPTION
Closes #243 

### Fixes

- Fix the integration time step in `CocipGrid.calc_evolve_one_step`. The previous implementation assumed a time interval of `params["dt_integration"]`. This may not be the case for all `source` parameters (for example, this could occur if running `CocipGrid` over a collection of ADS-B waypoints).

