### PR TITLE
Fix/metdataset level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixes
 
 - Fix the integration time step in `CocipGrid.calc_evolve_one_step`. The previous implementation assumed a time interval of `params["dt_integration"]`. This may not be the case for all `source` parameters (for example, this could occur if running `CocipGrid` over a collection of ADS-B waypoints).
+- Raise an exception in constructing `MetDataset(ds, copy=False)` when `ds["level"]` has float32 dtype. Per interpolation conventions, all coordinate variables must have float64 dtype. (This was previously enforced in longitude and latitude, but was overlooked in the level coordinate.)
 
 ## v0.54.0
 

--- a/pycontrails/core/met.py
+++ b/pycontrails/core/met.py
@@ -102,11 +102,10 @@ class MetBase(ABC, Generic[XArrayType]):
             return
 
         dim = sorted(missing)
-        dim_str = ", ".join(f"'{dim}'")
-        msg = f"Meteorology data must contain dimension(s) {dim_str}."
+        msg = f"Meteorology data must contain dimension(s): {dim}."
         if "level" in dim:
             msg += (
-                "For single level data, set 'level' coordinate to constant -1 "
+                " For single level data, set 'level' coordinate to constant -1 "
                 "using `ds = ds.expand_dims({'level': [-1]})`"
             )
         raise ValueError(msg)

--- a/pycontrails/core/met.py
+++ b/pycontrails/core/met.py
@@ -228,6 +228,12 @@ class MetBase(ABC, Generic[XArrayType]):
         self._validate_longitude()
         self._validate_latitude()
         self._validate_transpose()
+        if self.data["level"].dtype != COORD_DTYPE:
+            raise ValueError(
+                "Level values must be of type float64. "
+                "Initiate with 'copy=True' to convert to float64. "
+                "Initiate with 'validate=False' to skip validation."
+            )
 
     def _preprocess_dims(self, wrap_longitude: bool) -> None:
         """Confirm DataArray or Dataset include required dimension in a consistent format.

--- a/pycontrails/core/met.py
+++ b/pycontrails/core/met.py
@@ -105,10 +105,10 @@ class MetBase(ABC, Generic[XArrayType]):
         dim_str = ", ".join(f"'{dim}'")
         msg = f"Meteorology data must contain dimension(s) {dim_str}."
         if "level" in dim:
-           msg += (
-               "For single level data, set 'level' coordinate to constant -1 "
+            msg += (
+                "For single level data, set 'level' coordinate to constant -1 "
                 "using `ds = ds.expand_dims({'level': [-1]})`"
-           )
+            )
         raise ValueError(msg)
 
     def _validate_longitude(self) -> None:
@@ -125,8 +125,8 @@ class MetBase(ABC, Generic[XArrayType]):
         if longitude.dtype != COORD_DTYPE:
             raise ValueError(
                 "Longitude values must be of type float64. "
-                "Initiate with 'copy=True' to convert to float64. "
-                "Initiate with 'validate=False' to skip validation."
+                "Instantiate with 'copy=True' to convert to float64. "
+                "Instantiate with 'validate=False' to skip validation."
             )
 
         if self.is_wrapped:
@@ -169,8 +169,8 @@ class MetBase(ABC, Generic[XArrayType]):
         if latitude.dtype != COORD_DTYPE:
             raise ValueError(
                 "Latitude values must be of type float64. "
-                "Initiate with 'copy=True' to convert to float64. "
-                "Initiate with 'validate=False' to skip validation."
+                "Instantiate with 'copy=True' to convert to float64. "
+                "Instantiate with 'validate=False' to skip validation."
             )
 
         if latitude[0] < -90.0:
@@ -194,10 +194,10 @@ class MetBase(ABC, Generic[XArrayType]):
         """
         indexes = self.indexes
         if not np.all(np.diff(indexes["time"]) > np.timedelta64(0, "ns")):
-            raise ValueError("Coordinate `time` not sorted. Initiate with `copy=True`.")
+            raise ValueError("Coordinate `time` not sorted. Instantiate with `copy=True`.")
         for coord in self.dim_order[:3]:  # exclude time, the 4th dimension
             if not np.all(np.diff(indexes[coord]) > 0.0):
-                raise ValueError(f"Coordinate '{coord}' not sorted. Initiate with 'copy=True'.")
+                raise ValueError(f"Coordinate '{coord}' not sorted. Instantiate with 'copy=True'.")
 
     def _validate_transpose(self) -> None:
         """Check that data is transposed according to :attr:`dim_order`."""
@@ -206,11 +206,11 @@ class MetBase(ABC, Generic[XArrayType]):
             if da.dims != self.dim_order:
                 if key is not None:
                     msg = (
-                        f"Data dimension not transposed on variable '{key}'. Initiate with"
+                        f"Data dimension not transposed on variable '{key}'. Instantiate with"
                         " 'copy=True'."
                     )
                 else:
-                    msg = "Data dimension not transposed. Initiate with 'copy=True'."
+                    msg = "Data dimension not transposed. Instantiate with 'copy=True'."
                 raise ValueError(msg)
 
         data = self.data
@@ -233,8 +233,8 @@ class MetBase(ABC, Generic[XArrayType]):
         if self.data["level"].dtype != COORD_DTYPE:
             raise ValueError(
                 "Level values must be of type float64. "
-                "Initiate with 'copy=True' to convert to float64. "
-                "Initiate with 'validate=False' to skip validation."
+                "Instantiate with 'copy=True' to convert to float64. "
+                "Instantiate with 'validate=False' to skip validation."
             )
 
     def _preprocess_dims(self, wrap_longitude: bool) -> None:

--- a/pycontrails/core/met.py
+++ b/pycontrails/core/met.py
@@ -70,7 +70,7 @@ class MetBase(ABC, Generic[XArrayType]):
     cachestore: CacheStore | None
 
     #: Default dimension order for DataArray or Dataset (x, y, z, t)
-    dim_order: tuple[Hashable, Hashable, Hashable, Hashable] = (
+    dim_order = (
         "longitude",
         "latitude",
         "level",

--- a/pycontrails/core/met.py
+++ b/pycontrails/core/met.py
@@ -194,7 +194,7 @@ class MetBase(ABC, Generic[XArrayType]):
         """
         indexes = self.indexes
         if not np.all(np.diff(indexes["time"]) > np.timedelta64(0, "ns")):
-            raise ValueError("Coordinate `time` not sorted. Instantiate with `copy=True`.")
+            raise ValueError("Coordinate 'time' not sorted. Instantiate with 'copy=True'.")
         for coord in self.dim_order[:3]:  # exclude time, the 4th dimension
             if not np.all(np.diff(indexes[coord]) > 0.0):
                 raise ValueError(f"Coordinate '{coord}' not sorted. Instantiate with 'copy=True'.")
@@ -753,8 +753,8 @@ class MetDataset(MetBase):
         except KeyError as e:
             raise KeyError(
                 f"Variable {key} not found. Available variables: {', '.join(self.data.data_vars)}. "
-                "To get items (e.g. `time` or `level`) from underlying `xr.Dataset` object, "
-                "use the `data` attribute."
+                "To get items (e.g. 'time' or 'level') from underlying xr.Dataset object, "
+                "use the 'data' attribute."
             ) from e
         return MetDataArray(da, copy=False, validate=False)
 

--- a/pycontrails/core/met.py
+++ b/pycontrails/core/met.py
@@ -101,15 +101,14 @@ class MetBase(ABC, Generic[XArrayType]):
         if not missing:
             return
 
-        dim = sorted(missing)[0]
-        if dim == "level":
-            msg = (
-                f"Meteorology data must contain dimension '{dim}'. "
-                "For single level data, set 'level' coordinate to constant -1 "
+        dim = sorted(missing)
+        dim_str = ", ".join(f"'{dim}'")
+        msg = f"Meteorology data must contain dimension(s) {dim_str}."
+        if "level" in dim:
+           msg += (
+               "For single level data, set 'level' coordinate to constant -1 "
                 "using `ds = ds.expand_dims({'level': [-1]})`"
-            )
-        else:
-            msg = f"Meteorology data must contain dimension '{dim}'."
+           )
         raise ValueError(msg)
 
     def _validate_longitude(self) -> None:

--- a/pycontrails/core/met.py
+++ b/pycontrails/core/met.py
@@ -97,17 +97,20 @@ class MetBase(ABC, Generic[XArrayType]):
         ValueError
             If data does not contain all four coordinates (longitude, latitude, level, time).
         """
-        for dim in self.dim_order:
-            if dim not in self.data.dims:
-                if dim == "level":
-                    msg = (
-                        f"Meteorology data must contain dimension '{dim}'. "
-                        "For single level data, set 'level' coordinate to constant -1 "
-                        "using `ds = ds.expand_dims({'level': [-1]})`"
-                    )
-                else:
-                    msg = f"Meteorology data must contain dimension '{dim}'."
-                raise ValueError(msg)
+        missing = set(self.dim_order).difference(self.data.dims)
+        if not missing:
+            return
+
+        dim = sorted(missing)[0]
+        if dim == "level":
+            msg = (
+                f"Meteorology data must contain dimension '{dim}'. "
+                "For single level data, set 'level' coordinate to constant -1 "
+                "using `ds = ds.expand_dims({'level': [-1]})`"
+            )
+        else:
+            msg = f"Meteorology data must contain dimension '{dim}'."
+        raise ValueError(msg)
 
     def _validate_longitude(self) -> None:
         """Check longitude bounds.

--- a/tests/unit/test_met.py
+++ b/tests/unit/test_met.py
@@ -1386,3 +1386,19 @@ def test_vertical_coord(met_ecmwf_pl_path: str, coord: str) -> None:
     mds = MetDataset(ds)
     assert np.all(mds.data.coords[coord] == fake_coord)
     assert mds.data.coords[coord].values.dtype == np.float64
+
+
+@pytest.mark.parametrize("copy", [True, False])
+def test_float32_level(met_ecmwf_pl_path: str, copy: bool) -> None:
+    """Confirm that the level coordinate is cast to float64 or an error is raised."""
+    ds = MetDataset(xr.open_dataset(met_ecmwf_pl_path)).data
+
+    ds["level"] = ds["level"].astype(np.float32)
+
+    if copy:
+        mds = MetDataset(ds, copy=copy)
+        assert mds.data["level"].dtype == np.float64
+        return
+
+    with pytest.raises(ValueError, match="Level values must be of type float64"):
+        MetDataset(ds, copy=copy)

--- a/tests/unit/test_met.py
+++ b/tests/unit/test_met.py
@@ -128,7 +128,8 @@ def test_metdataarray_constructor(
     # Cannot instantiate MetDataArray without time or level coord
     # This hacked DataArray only contains latitude and longitude
     insufficient_da = da["latitude"] + da["longitude"]
-    with pytest.raises(ValueError, match="Meteorology data must contain dimension 'level'"):
+    match = r"Meteorology data must contain dimension\(s\): \['level', 'time'\]."
+    with pytest.raises(ValueError, match=match):
         MetDataArray(insufficient_da)
 
 


### PR DESCRIPTION
## Fixes

- Raise an exception in constructing `MetDataset(ds, copy=False)` when `ds["level"]` has float32 dtype. Per interpolation conventions, all coordinate variables must have float64 dtype. (This was previously enforced in longitude and latitude, but was overlooked in the level coordinate.)

## Tests

- [x] QC test passes locally (`make test`)
- [ ] CI tests pass

