### PR TITLE
Fix/gfs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixes
 
-- Update GFS variable names "uswrf" -> "suswrf" and "ulwrf" -> "sulwrf". This seems to provide a fix for a recent change in the GFS grib variable names.
+- Update GFS variable names "uswrf" -> "suswrf" and "ulwrf" -> "sulwrf". This accommodates a breaking change introduced in [eccodes 2.38](https://confluence.ecmwf.int/display/MTG2US/Changes+in+ecCodes+version+2.38.0+compared+to+the+previous+version#ChangesinecCodesversion2.38.0comparedtothepreviousversion-Changedshortnames).
 
 ## v0.54.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.54.2 (unreleased)
+
+### Features
+
+- Add `cache_download` parameter to the `GFSForecast` interface. When set to `True`, downloaded grib data is cached locally. This is consistent with the behavior of the `ERA5ModelLevel` and `HRESModelLevel` interfaces.
+
+### Fixes
+
+- Update GFS variable names "uswrf" -> "suswrf" and "ulwrf" -> "sulwrf". This seems to provide a fix for a recent change in the GFS grib variable names.
+
 ## v0.54.1
 
 ### Features

--- a/pycontrails/datalib/gfs/variables.py
+++ b/pycontrails/datalib/gfs/variables.py
@@ -43,6 +43,8 @@ CloudIceWaterMixingRatio = MetVariable(
 
 
 TOAUpwardShortwaveRadiation = MetVariable(
+    # Note the variable in the GFS Grib file is "uswrf" for the "nominalTop" level
+    # eccodes > 2.38 rewrites to `suswrf` on loading
     short_name="suswrf",
     standard_name="toa_upward_shortwave_flux",
     long_name="Top of atmosphere upward shortwave radiation",

--- a/pycontrails/datalib/gfs/variables.py
+++ b/pycontrails/datalib/gfs/variables.py
@@ -43,7 +43,7 @@ CloudIceWaterMixingRatio = MetVariable(
 
 
 TOAUpwardShortwaveRadiation = MetVariable(
-    short_name="uswrf",
+    short_name="suswrf",
     standard_name="toa_upward_shortwave_flux",
     long_name="Top of atmosphere upward shortwave radiation",
     units="W m**-2",
@@ -56,7 +56,7 @@ TOAUpwardShortwaveRadiation = MetVariable(
 )
 
 TOAUpwardLongwaveRadiation = MetVariable(
-    short_name="ulwrf",
+    short_name="sulwrf",
     standard_name="toa_upward_longwave_flux",
     long_name="Top of atmosphere upward longwave radiation",
     units="W m**-2",

--- a/pycontrails/datalib/gfs/variables.py
+++ b/pycontrails/datalib/gfs/variables.py
@@ -58,6 +58,8 @@ TOAUpwardShortwaveRadiation = MetVariable(
 )
 
 TOAUpwardLongwaveRadiation = MetVariable(
+    # Note the variable in the GFS Grib file is "ulwrf" for the "nominalTop" level
+    # eccodes > 2.38 rewrites to `sulwrf` on loading
     short_name="sulwrf",
     standard_name="toa_upward_longwave_flux",
     long_name="Top of atmosphere upward longwave radiation",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,7 @@ gfs = [
     "boto3>=1.20",
     "cfgrib>=0.9",
     "eccodes>=2.38",
+    "netcdf4>=1.6.1",
     "platformdirs>=3.0",
     "tqdm>=4.61",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ docs = [
 ecmwf = [
     "cdsapi>=0.4",
     "cfgrib>=0.9",
-    "eccodes>=1.4",
+    "eccodes>=2.38",
     "ecmwf-api-client>=1.6",
     "netcdf4>=1.6.1",
     "platformdirs>=3.0",
@@ -109,7 +109,7 @@ gcp = ["google-cloud-storage>=2.1", "platformdirs>=3.0", "tqdm>=4.61"]
 gfs = [
     "boto3>=1.20",
     "cfgrib>=0.9",
-    "eccodes>=1.4",
+    "eccodes>=2.38",
     "platformdirs>=3.0",
     "tqdm>=4.61",
 ]


### PR DESCRIPTION
Closes #253 

### Features

- Add `cache_download` parameter to the `GFSForecast` interface. When set to `True`, downloaded grib data is cached locally. This is consistent with the behavior of the `ERA5ModelLevel` and `HRESModelLevel` interfaces.

### Fixes

- Update GFS variable names "uswrf" -> "suswrf" and "ulwrf" -> "sulwrf". This accommodates a breaking change introduced in [eccodes 2.38](https://confluence.ecmwf.int/display/MTG2US/Changes+in+ecCodes+version+2.38.0+compared+to+the+previous+version#ChangesinecCodesversion2.38.0comparedtothepreviousversion-Changedshortnames).

## Tests

- [x] QC test passes locally (`make test`)
- [ ] CI tests pass

## Reviewer

> Select @ reviewer
