### PR TITLE
maintenance: replace overrides.overrides with typing.override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
 
 - Update GFS variable names "uswrf" -> "suswrf" and "ulwrf" -> "sulwrf". This accommodates a breaking change introduced in [eccodes 2.38](https://confluence.ecmwf.int/display/MTG2US/Changes+in+ecCodes+version+2.38.0+compared+to+the+previous+version#ChangesinecCodesversion2.38.0comparedtothepreviousversion-Changedshortnames).
 
+### Internals
+
+- Remove `overrides` dependency. Require `typing-extensions` for python < 3.12.
+- Upgrade some type hints for more modern python language features.
+
 ## v0.54.1
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.54.2 (unreleased)
+## v0.54.2
 
 ### Features
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -170,7 +170,7 @@ autodoc_typehints = "none"
 
 # autodoc options
 autoclass_content = "class"  # only include docstring from Class (not __init__ method)
-autodoc_inherit_docstrings = False
+autodoc_inherit_docstrings = True
 autodoc_default_options = {
     "members": None,  # means yes/true/on
     "undoc-members": None,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -78,6 +78,7 @@ suppress_warnings = ["myst.header"]
 # Set up mapping for other projects' docs
 intersphinx_mapping = {
     "numpy": ("https://numpy.org/doc/stable/", None),
+    "open3d": ("https://www.open3d.org/docs/release/", None),
     "pandas": ("https://pandas.pydata.org/pandas-docs/dev/", None),
     "pyproj": ("https://pyproj4.github.io/pyproj/stable/", None),
     "python": ("https://docs.python.org/3/", None),

--- a/pycontrails/core/aircraft_performance.py
+++ b/pycontrails/core/aircraft_performance.py
@@ -4,12 +4,17 @@ from __future__ import annotations
 
 import abc
 import dataclasses
+import sys
 import warnings
 from typing import Any, Generic, NoReturn, overload
 
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
+
 import numpy as np
 import numpy.typing as npt
-from overrides import overrides
 
 from pycontrails.core import flight, fuel
 from pycontrails.core.fleet import Fleet
@@ -123,7 +128,7 @@ class AircraftPerformance(Model):
             Flight trajectory with aircraft performance data.
         """
 
-    @overrides
+    @override
     def set_source_met(self, *args: Any, **kwargs: Any) -> None:
         fill_with_isa = self.params["fill_low_altitude_with_isa_temperature"]
         if fill_with_isa and (self.met is None or "air_temperature" not in self.met):

--- a/pycontrails/core/cache.py
+++ b/pycontrails/core/cache.py
@@ -7,14 +7,18 @@ import logging
 import os
 import pathlib
 import shutil
+import sys
 import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
-logger = logging.getLogger(__name__)
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
 
-from overrides import overrides
+logger = logging.getLogger(__name__)
 
 from pycontrails.utils import dependencies
 
@@ -203,20 +207,20 @@ class DiskCacheStore(CacheStore):
         return f"DiskCacheStore: {self.cache_dir}"
 
     @property
-    @overrides
+    @override
     def size(self) -> float:
         disk_path = pathlib.Path(self.cache_dir)
         size = sum(f.stat().st_size for f in disk_path.rglob("*") if f.is_file())
         logger.debug("Disk cache size %s bytes", size)
         return size / 1e6
 
-    @overrides
+    @override
     def listdir(self, path: str = "") -> list[str]:
         path = self.path(path)
         iter_ = pathlib.Path(path).iterdir()
         return sorted(str(f.relative_to(path)) for f in iter_)
 
-    @overrides
+    @override
     def path(self, cache_path: str) -> str:
         if cache_path.startswith(self.cache_dir):
             disk_path = pathlib.Path(cache_path)
@@ -228,7 +232,7 @@ class DiskCacheStore(CacheStore):
 
         return str(disk_path)
 
-    @overrides
+    @override
     def exists(self, cache_path: str) -> bool:
         disk_path = pathlib.Path(self.path(cache_path))
         return disk_path.exists()
@@ -551,7 +555,7 @@ class GCPCacheStore(CacheStore):
         return self._client
 
     @property
-    @overrides
+    @override
     def size(self) -> float:
         # get list of blobs below this path
         blobs = self._bucket.list_blobs(prefix=self.cache_dir)
@@ -559,7 +563,7 @@ class GCPCacheStore(CacheStore):
         logger.debug("GCP cache size %s bytes", size)
         return size / 1e6
 
-    @overrides
+    @override
     def listdir(self, path: str = "") -> list[str]:
         # I don't necessarily think we want to implement this .... it might be
         # very slow if the bucket is large. BUT, it won't be slower than the size
@@ -572,7 +576,7 @@ class GCPCacheStore(CacheStore):
             "list files in the local disk cache."
         )
 
-    @overrides
+    @override
     def path(self, cache_path: str) -> str:
         if cache_path.startswith(self.cache_dir):
             return cache_path
@@ -604,7 +608,7 @@ class GCPCacheStore(CacheStore):
         bucket_path = self.path(cache_path)
         return f"gs://{self.bucket}/{bucket_path}"
 
-    @overrides
+    @override
     def exists(self, cache_path: str) -> bool:
         # see if file is in the mirror disk cache
         if self._disk_cache.exists(cache_path):

--- a/pycontrails/core/fleet.py
+++ b/pycontrails/core/fleet.py
@@ -7,6 +7,11 @@ import warnings
 from collections.abc import Iterable
 from typing import Any, NoReturn
 
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
+
 if sys.version_info >= (3, 12):
     from typing import override
 else:
@@ -159,7 +164,7 @@ class Fleet(Flight):
         broadcast_numeric: bool = True,
         copy: bool = True,
         attrs: dict[str, Any] | None = None,
-    ) -> Fleet:
+    ) -> Self:
         """Instantiate a :class:`Fleet` instance from an iterable of :class:`Flight`.
 
         .. versionchanged:: 0.49.3

--- a/pycontrails/core/fleet.py
+++ b/pycontrails/core/fleet.py
@@ -2,14 +2,19 @@
 
 from __future__ import annotations
 
+import sys
 import warnings
 from collections.abc import Iterable
 from typing import Any, NoReturn
 
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
+
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
-from overrides import overrides
 
 from pycontrails.core.flight import Flight
 from pycontrails.core.fuel import Fuel, JetA
@@ -121,13 +126,13 @@ class Fleet(Flight):
 
         return final_waypoints, fl_attrs
 
-    @overrides
+    @override
     def copy(self, **kwargs: Any) -> Fleet:
         kwargs.setdefault("fuel", self.fuel)
         kwargs.setdefault("fl_attrs", self.fl_attrs)
         return super().copy(**kwargs)
 
-    @overrides
+    @override
     def filter(self, mask: npt.NDArray[np.bool_], copy: bool = True, **kwargs: Any) -> Fleet:
         kwargs.setdefault("fuel", self.fuel)
 
@@ -137,7 +142,7 @@ class Fleet(Flight):
 
         return super().filter(mask, copy=copy, **kwargs)
 
-    @overrides
+    @override
     def sort(self, by: str | list[str]) -> NoReturn:
         msg = (
             "Fleet.sort is not implemented. A Fleet instance must be sorted "
@@ -314,39 +319,39 @@ class Fleet(Flight):
         # use case isn't seen.
         return np.concatenate(tas)
 
-    @overrides
+    @override
     def segment_groundspeed(self, *args: Any, **kwargs: Any) -> npt.NDArray[np.float64]:
         fls = self.to_flight_list(copy=False)
         gs = [fl.segment_groundspeed(*args, **kwargs) for fl in fls]
         return np.concatenate(gs)
 
-    @overrides
+    @override
     def resample_and_fill(self, *args: Any, **kwargs: Any) -> Fleet:
         flights = self.to_flight_list(copy=False)
         flights = [fl.resample_and_fill(*args, **kwargs) for fl in flights]
         return type(self).from_seq(flights, copy=False, broadcast_numeric=False, attrs=self.attrs)
 
-    @overrides
+    @override
     def segment_length(self) -> npt.NDArray[np.float64]:
         return np.where(self.final_waypoints, np.nan, super().segment_length())
 
     @property
-    @overrides
+    @override
     def max_distance_gap(self) -> float:
         return np.nanmax(self.segment_length()).item()
 
-    @overrides
+    @override
     def segment_azimuth(self) -> npt.NDArray[np.float64]:
         return np.where(self.final_waypoints, np.nan, super().segment_azimuth())
 
-    @overrides
+    @override
     def segment_angle(self) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
         sin_a, cos_a = super().segment_angle()
         sin_a[self.final_waypoints] = np.nan
         cos_a[self.final_waypoints] = np.nan
         return sin_a, cos_a
 
-    @overrides
+    @override
     def clean_and_resample(
         self,
         freq: str = "1min",

--- a/pycontrails/core/flight.py
+++ b/pycontrails/core/flight.py
@@ -4,14 +4,20 @@ from __future__ import annotations
 
 import enum
 import logging
+import sys
 import warnings
 from typing import TYPE_CHECKING, Any, NoReturn, TypeVar
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
+
 
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
 import scipy.signal
-from overrides import overrides
 
 from pycontrails.core.fuel import Fuel, JetA
 from pycontrails.core.vector import AttrDict, GeoVectorDataset, VectorDataDict, VectorDataset
@@ -276,19 +282,19 @@ class Flight(GeoVectorDataset):
                     "'drop_duplicated_times=True' or call the 'resample_and_fill' method."
                 )
 
-    @overrides
+    @override
     def copy(self: FlightType, **kwargs: Any) -> FlightType:
         kwargs.setdefault("fuel", self.fuel)
         return super().copy(**kwargs)
 
-    @overrides
+    @override
     def filter(
         self: FlightType, mask: npt.NDArray[np.bool_], copy: bool = True, **kwargs: Any
     ) -> FlightType:
         kwargs.setdefault("fuel", self.fuel)
         return super().filter(mask, copy=copy, **kwargs)
 
-    @overrides
+    @override
     def sort(self, by: str | list[str]) -> NoReturn:
         msg = (
             "Flight.sort is not implemented. A Flight instance is automatically sorted "

--- a/pycontrails/core/flight.py
+++ b/pycontrails/core/flight.py
@@ -1097,7 +1097,7 @@ class Flight(GeoVectorDataset):
 
         Notes
         -----
-        Algorithm is derived from :meth:`traffic.core.flight.Flight.filter`.
+        Algorithm is derived from :meth:`traffic.core.Flight.filter`.
 
         The `traffic
         <https://traffic-viz.github.io/api_reference/traffic.core.flight.html#traffic.core.Flight.filter>`_
@@ -1425,19 +1425,21 @@ class Flight(GeoVectorDataset):
         return {"type": "FeatureCollection", "features": features}
 
     def to_traffic(self) -> traffic.core.Flight:
-        """Convert Flight instance to :class:`traffic.core.Flight` instance.
-
-        See https://traffic-viz.github.io/traffic.core.flight.html#traffic.core.Flight
+        """Convert to :class:`traffic.core.Flight`instance.
 
         Returns
         -------
-        :class:`traffic.core.Flight`
-            `traffic.core.Flight` instance
+        traffic.core.Flight
+            traffic flight instance
 
         Raises
         ------
         ModuleNotFoundError
             `traffic` package not installed
+
+        See Also
+        --------
+        :class:`traffic.core.Flight`
         """
         try:
             import traffic.core
@@ -1983,18 +1985,18 @@ def filter_altitude(
 
     Notes
     -----
-    Algorithm is derived from :meth:`traffic.core.flight.Flight.filter`.
+    Algorithm is derived from :meth:`traffic.core.Flight.filter`.
 
-    The `traffic
+    The `traffic filter algorithm
     <https://traffic-viz.github.io/api_reference/traffic.core.flight.html#traffic.core.Flight.filter>`_
-    algorithm also computes thresholds on sliding windows
+    also computes thresholds on sliding windows
     and replaces unacceptable values with NaNs.
 
     Errors may raised if the ``kernel_size`` is too large.
 
     See Also
     --------
-    :meth:`traffic.core.flight.Flight.filter`
+    :meth:`traffic.core.Flight.filter`
     :func:`scipy.signal.medfilt`
     """
     if not len(altitude_ft):

--- a/pycontrails/core/met.py
+++ b/pycontrails/core/met.py
@@ -1410,8 +1410,9 @@ class MetDataArray(MetBase):
 
         See Also
         --------
-        - :meth:`xr.Dataset.load`
-        - :meth:`xr.DataArray.load`
+        :meth:`xarray.Dataset.load`
+        :meth:`xarray.DataArray.load`
+
         """
         if not self.in_memory:
             self._check_memory("Extracting numpy array from")
@@ -2026,7 +2027,7 @@ class MetDataArray(MetBase):
         See Also
         --------
         :meth:`to_polyhedra`
-        :func:`pycontrails.core.polygons.find_multipolygons`
+        :func:`polygons.find_multipolygons`
 
         Examples
         --------
@@ -2230,7 +2231,7 @@ class MetDataArray(MetBase):
 
         Returns
         -------
-        dict | :class:`o3d.geometry.TriangleMesh`
+        dict | open3d.geometry.TriangleMesh
             Python representation of geojson object or `Open3D Triangle Mesh
             <http://www.open3d.org/docs/release/tutorial/geometry/mesh.html>`_ depending on the
             `return_type` parameter.
@@ -2244,8 +2245,9 @@ class MetDataArray(MetBase):
 
         See Also
         --------
-        :meth:`to_polygons`
-        `skimage.measure.marching_cubes <https://scikit-image.org/docs/dev/api/skimage.measure.html#skimage.measure.marching_cubes>`_
+        :meth:`to_polygon_feature`
+        :func:`skimage.measure.marching_cubes`
+        :class:`open3d.geometry.TriangleMesh`
 
         Notes
         -----

--- a/pycontrails/core/met.py
+++ b/pycontrails/core/met.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import logging
 import pathlib
+import sys
 import typing
 import warnings
 from abc import ABC, abstractmethod
@@ -29,11 +30,15 @@ from typing import (
     overload,
 )
 
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
+
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
 import xarray as xr
-from overrides import overrides
 
 from pycontrails.core import interpolation
 from pycontrails.core import vector as vector_module
@@ -863,13 +868,13 @@ class MetDataset(MetBase):
         return key in self.data
 
     @property
-    @overrides
+    @override
     def shape(self) -> tuple[int, int, int, int]:
         sizes = self.data.sizes
         return sizes["longitude"], sizes["latitude"], sizes["level"], sizes["time"]
 
     @property
-    @overrides
+    @override
     def size(self) -> int:
         return np.prod(self.shape).item()
 
@@ -1015,14 +1020,14 @@ class MetDataset(MetBase):
             cachestore=self.cachestore,
         )
 
-    @overrides
+    @override
     def broadcast_coords(self, name: str) -> xr.DataArray:
         da = xr.ones_like(self.data[next(iter(self.data.keys()))]) * self.data[name]
         da.name = name
 
         return da
 
-    @overrides
+    @override
     def downselect(self, bbox: tuple[float, ...]) -> MetDataset:
         data = downselect(self.data, bbox)
         return MetDataset(data, cachestore=self.cachestore, copy=False)
@@ -1432,12 +1437,12 @@ class MetDataArray(MetBase):
         return np.array_equal(self.data, self.data.astype(bool))
 
     @property
-    @overrides
+    @override
     def size(self) -> int:
         return self.data.size
 
     @property
-    @overrides
+    @override
     def shape(self) -> tuple[int, int, int, int]:
         # https://github.com/python/mypy/issues/1178
         return typing.cast(tuple[int, int, int, int], self.data.shape)
@@ -2380,14 +2385,14 @@ class MetDataArray(MetBase):
             )
         return mesh
 
-    @overrides
+    @override
     def broadcast_coords(self, name: str) -> xr.DataArray:
         da = xr.ones_like(self.data) * self.data[name]
         da.name = name
 
         return da
 
-    @overrides
+    @override
     def downselect(self, bbox: tuple[float, ...]) -> MetDataArray:
         data = downselect(self.data, bbox)
         return MetDataArray(data, cachestore=self.cachestore)

--- a/pycontrails/core/met.py
+++ b/pycontrails/core/met.py
@@ -30,6 +30,11 @@ from typing import (
     overload,
 )
 
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
+
 if sys.version_info >= (3, 12):
     from typing import override
 else:
@@ -983,7 +988,7 @@ class MetDataset(MetBase):
         hash: str,
         cachestore: CacheStore | None = None,
         chunks: dict[str, int] | None = None,
-    ) -> MetDataset:
+    ) -> Self:
         """Load saved intermediate from :attr:`cachestore`.
 
         Parameters
@@ -998,7 +1003,7 @@ class MetDataset(MetBase):
 
         Returns
         -------
-        MetDataset
+        Self
             New MetDataArray with loaded data.
         """
         cachestore = cachestore or DiskCacheStore()
@@ -1184,7 +1189,7 @@ class MetDataset(MetBase):
         latitude: npt.ArrayLike | float,
         level: npt.ArrayLike | float,
         time: npt.ArrayLike | np.datetime64,
-    ) -> MetDataset:
+    ) -> Self:
         r"""Create a :class:`MetDataset` containing a coordinate skeleton from coordinate arrays.
 
         Parameters
@@ -1198,7 +1203,7 @@ class MetDataset(MetBase):
 
         Returns
         -------
-        MetDataset
+        Self
             MetDataset with no variables.
 
         Examples
@@ -1284,7 +1289,7 @@ class MetDataset(MetBase):
         return cls(xr.Dataset({}, coords=coords))
 
     @classmethod
-    def from_zarr(cls, store: Any, **kwargs: Any) -> MetDataset:
+    def from_zarr(cls, store: Any, **kwargs: Any) -> Self:
         """Create a :class:`MetDataset` from a path to a Zarr store.
 
         Parameters
@@ -1296,7 +1301,7 @@ class MetDataset(MetBase):
 
         Returns
         -------
-        MetDataset
+        Self
             MetDataset with data from Zarr store.
         """
         kwargs.setdefault("storage_options", {"read_only": True})
@@ -1832,7 +1837,7 @@ class MetDataArray(MetBase):
         hash: str,
         cachestore: CacheStore | None = None,
         chunks: dict[str, int] | None = None,
-    ) -> MetDataArray:
+    ) -> Self:
         """Load saved intermediate from :attr:`cachestore`.
 
         Parameters

--- a/pycontrails/core/vector.py
+++ b/pycontrails/core/vector.py
@@ -5,15 +5,20 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import sys
 import warnings
 from collections.abc import Generator, Iterable, Iterator, Sequence
 from typing import Any, TypeVar, overload
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
 
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
 import xarray as xr
-from overrides import overrides
 
 from pycontrails.core import coordinates, interpolation
 from pycontrails.core import met as met_module
@@ -1367,7 +1372,7 @@ class GeoVectorDataset(VectorDataset):
         if np.any(latitude > 90.0) or np.any(latitude < -90.0):
             raise ValueError("EPSG:4326 latitude coordinates should lie between [-90, 90].")
 
-    @overrides
+    @override
     def _display_attrs(self) -> dict[str, str]:
         try:
             time0 = pd.Timestamp(np.nanmin(self["time"]))
@@ -1922,7 +1927,7 @@ class GeoVectorDataset(VectorDataset):
     # ------------
 
     @classmethod
-    @overrides
+    @override
     def create_empty(
         cls: type[GeoVectorDatasetType],
         keys: Iterable[str] | None = None,

--- a/pycontrails/core/vector.py
+++ b/pycontrails/core/vector.py
@@ -8,7 +8,12 @@ import logging
 import sys
 import warnings
 from collections.abc import Generator, Iterable, Iterator, Sequence
-from typing import Any, TypeVar, overload
+from typing import Any, overload
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 if sys.version_info >= (3, 12):
     from typing import override
@@ -27,10 +32,6 @@ from pycontrails.utils import dependencies
 from pycontrails.utils import json as json_utils
 
 logger = logging.getLogger(__name__)
-
-#: Vector types
-VectorDatasetType = TypeVar("VectorDatasetType", bound="VectorDataset")
-GeoVectorDatasetType = TypeVar("GeoVectorDatasetType", bound="GeoVectorDataset")
 
 
 class AttrDict(dict[str, Any]):
@@ -579,7 +580,7 @@ class VectorDataset:
         """
         return self.size > 0
 
-    def __add__(self: VectorDatasetType, other: VectorDatasetType | None) -> VectorDatasetType:
+    def __add__(self, other: Self | None) -> Self:
         """Concatenate two compatible instances of VectorDataset.
 
         In this context, compatibility means that both have identical :attr:`data` keys.
@@ -591,12 +592,12 @@ class VectorDataset:
 
         Parameters
         ----------
-        other : VectorDatasetType
+        other : Self | None
             Other values to concatenate
 
         Returns
         -------
-        VectorDatasetType
+        Self
             Concatenated values.
 
         Raises
@@ -615,11 +616,11 @@ class VectorDataset:
 
     @classmethod
     def sum(
-        cls: type[VectorDatasetType],
+        cls,
         vectors: Sequence[VectorDataset],
         infer_attrs: bool = True,
         fill_value: float | None = None,
-    ) -> VectorDatasetType:
+    ) -> Self:
         """Sum a list of :class:`VectorDataset` instances.
 
         Parameters
@@ -697,7 +698,7 @@ class VectorDataset:
             return cls(data, attrs=vectors[0].attrs, copy=False)
         return cls(data, copy=False)
 
-    def __eq__(self: VectorDatasetType, other: object) -> bool:
+    def __eq__(self, other: object) -> bool:
         """Determine if two instances are equal.
 
         NaN values are considered equal in this comparison.
@@ -705,7 +706,7 @@ class VectorDataset:
         Parameters
         ----------
         other : object
-            VectorDatasetType to compare with
+            VectorDataset to compare with
 
         Returns
         -------
@@ -789,8 +790,8 @@ class VectorDataset:
     # Utilities
     # ------------
 
-    def copy(self: VectorDatasetType, **kwargs: Any) -> VectorDatasetType:
-        """Return a copy of this VectorDatasetType class.
+    def copy(self, **kwargs: Any) -> Self:
+        """Return a copy of this instance.
 
         Parameters
         ----------
@@ -799,7 +800,7 @@ class VectorDataset:
 
         Returns
         -------
-        VectorDatasetType
+        Self
             Copy of class
         """
         return type(self)(data=self.data, attrs=self.attrs, copy=True, **kwargs)
@@ -825,9 +826,7 @@ class VectorDataset:
         data = {key: self[key] for key in keys}
         return VectorDataset(data=data, attrs=self.attrs, copy=copy)
 
-    def filter(
-        self: VectorDatasetType, mask: npt.NDArray[np.bool_], copy: bool = True, **kwargs: Any
-    ) -> VectorDatasetType:
+    def filter(self, mask: npt.NDArray[np.bool_], copy: bool = True, **kwargs: Any) -> Self:
         """Filter :attr:`data` according to a boolean array ``mask``.
 
         Entries corresponding to ``mask == True`` are kept.
@@ -845,7 +844,7 @@ class VectorDataset:
 
         Returns
         -------
-        VectorDatasetType
+        Self
             Containing filtered data
 
         Raises
@@ -860,7 +859,7 @@ class VectorDataset:
         data = {key: value[mask] for key, value in self.data.items()}
         return type(self)(data=data, attrs=self.attrs, copy=copy, **kwargs)
 
-    def sort(self: VectorDatasetType, by: str | list[str]) -> VectorDatasetType:
+    def sort(self, by: str | list[str]) -> Self:
         """Sort data by key(s).
 
         This method always creates a copy of the data by calling
@@ -873,7 +872,7 @@ class VectorDataset:
 
         Returns
         -------
-        VectorDatasetType
+        Self
             Instance with sorted data.
         """
         return type(self)(data=self.dataframe.sort_values(by=by), attrs=self.attrs, copy=False)
@@ -1114,12 +1113,12 @@ class VectorDataset:
 
     @classmethod
     def create_empty(
-        cls: type[VectorDatasetType],
+        cls,
         keys: Iterable[str],
         attrs: dict[str, Any] | None = None,
         **attrs_kwargs: Any,
-    ) -> VectorDatasetType:
-        """Create instance with variables defined by `keys` and size 0.
+    ) -> Self:
+        """Create instance with variables defined by ``keys`` and size 0.
 
         If instance requires additional variables to be defined, these keys will automatically
         be attached to returned instance.
@@ -1135,15 +1134,13 @@ class VectorDataset:
 
         Returns
         -------
-        VectorDatasetType
+        Self
             Empty VectorDataset instance.
         """
         return cls(data=_empty_vector_dict(keys or set()), attrs=attrs, copy=False, **attrs_kwargs)
 
     @classmethod
-    def from_dict(
-        cls: type[VectorDatasetType], obj: dict[str, Any], copy: bool = True, **obj_kwargs: Any
-    ) -> VectorDatasetType:
+    def from_dict(cls, obj: dict[str, Any], copy: bool = True, **obj_kwargs: Any) -> Self:
         """Create instance from dict representation containing data and attrs.
 
         Parameters
@@ -1158,7 +1155,7 @@ class VectorDataset:
 
         Returns
         -------
-        VectorDatasetType
+        Self
             VectorDataset instance.
 
         See Also
@@ -1176,9 +1173,7 @@ class VectorDataset:
 
         return cls(data=data, attrs=attrs, copy=copy)
 
-    def generate_splits(
-        self: VectorDatasetType, n_splits: int, copy: bool = True
-    ) -> Generator[VectorDatasetType, None, None]:
+    def generate_splits(self, n_splits: int, copy: bool = True) -> Generator[Self, None, None]:
         """Split instance into ``n_split`` sub-vectors.
 
         Parameters
@@ -1191,7 +1186,7 @@ class VectorDataset:
 
         Returns
         -------
-        Generator[VectorDatasetType, None, None]
+        Generator[Self, None, None]
             Generator of split vectors.
 
         See Also
@@ -1929,11 +1924,11 @@ class GeoVectorDataset(VectorDataset):
     @classmethod
     @override
     def create_empty(
-        cls: type[GeoVectorDatasetType],
+        cls,
         keys: Iterable[str] | None = None,
         attrs: dict[str, Any] | None = None,
         **attrs_kwargs: Any,
-    ) -> GeoVectorDatasetType:
+    ) -> Self:
         keys = *cls.required_keys, "altitude", *(keys or ())
         return super().create_empty(keys, attrs, **attrs_kwargs)
 

--- a/pycontrails/datalib/ecmwf/arco_era5.py
+++ b/pycontrails/datalib/ecmwf/arco_era5.py
@@ -19,11 +19,16 @@ from __future__ import annotations
 
 import datetime
 import hashlib
+import sys
 from typing import Any
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
 
 import numpy.typing as npt
 import xarray as xr
-from overrides import overrides
 
 from pycontrails.core import cache, met_var
 from pycontrails.core.met import MetDataset
@@ -274,7 +279,7 @@ class ERA5ARCO(ecmwf_common.ECMWFAPI):
         """
         return ecmwf_variables.SURFACE_VARIABLES
 
-    @overrides
+    @override
     def download_dataset(self, times: list[datetime.datetime]) -> None:
         if not times:
             return
@@ -286,7 +291,7 @@ class ERA5ARCO(ecmwf_common.ECMWFAPI):
 
         self.cache_dataset(ds)
 
-    @overrides
+    @override
     def create_cachepath(self, t: datetime.datetime) -> str:
         if self.cachestore is None:
             msg = "Attribute self.cachestore must be defined to create cache path"
@@ -302,7 +307,7 @@ class ERA5ARCO(ecmwf_common.ECMWFAPI):
 
         return self.cachestore.path(cache_path)
 
-    @overrides
+    @override
     def open_metdataset(
         self,
         dataset: xr.Dataset | None = None,
@@ -331,7 +336,7 @@ class ERA5ARCO(ecmwf_common.ECMWFAPI):
         self.set_metadata(mds)
         return mds
 
-    @overrides
+    @override
     def set_metadata(self, ds: xr.Dataset | MetDataset) -> None:
         ds.attrs.update(
             provider="ECMWF",

--- a/pycontrails/datalib/ecmwf/common.py
+++ b/pycontrails/datalib/ecmwf/common.py
@@ -4,14 +4,19 @@ from __future__ import annotations
 
 import logging
 import os
+import sys
 from typing import Any
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
 
 LOG = logging.getLogger(__name__)
 
 import numpy as np
 import pandas as pd
 import xarray as xr
-from overrides import overrides
 
 from pycontrails.core import met
 from pycontrails.datalib._met_utils import metsource
@@ -88,7 +93,7 @@ class ECMWFAPI(metsource.MetDataSource):
         kwargs.setdefault("cachestore", self.cachestore)
         return met.MetDataset(ds, **kwargs)
 
-    @overrides
+    @override
     def cache_dataset(self, dataset: xr.Dataset) -> None:
         if self.cachestore is None:
             LOG.debug("Cache is turned off, skipping")

--- a/pycontrails/datalib/ecmwf/era5.py
+++ b/pycontrails/datalib/ecmwf/era5.py
@@ -7,16 +7,21 @@ import hashlib
 import logging
 import os
 import pathlib
+import sys
 import warnings
 from contextlib import ExitStack
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
+
 LOG = logging.getLogger(__name__)
 
 import pandas as pd
 import xarray as xr
-from overrides import overrides
 
 import pycontrails
 from pycontrails.core import cache
@@ -347,7 +352,7 @@ class ERA5(ECMWFAPI):
         # return cache path
         return self.cachestore.path(f"{datestr}-{suffix}.nc")
 
-    @overrides
+    @override
     def download_dataset(self, times: list[datetime]) -> None:
         download_times: dict[datetime, list[datetime]] = collections.defaultdict(list)
         for t in times:
@@ -359,7 +364,7 @@ class ERA5(ECMWFAPI):
         for times_for_day in download_times.values():
             self._download_file(times_for_day)
 
-    @overrides
+    @override
     def open_metdataset(
         self,
         dataset: xr.Dataset | None = None,
@@ -399,7 +404,7 @@ class ERA5(ECMWFAPI):
         self.set_metadata(mds)
         return mds
 
-    @overrides
+    @override
     def set_metadata(self, ds: xr.Dataset | MetDataset) -> None:
         if self.product_type == "reanalysis":
             product = "reanalysis"

--- a/pycontrails/datalib/ecmwf/era5_model_level.py
+++ b/pycontrails/datalib/ecmwf/era5_model_level.py
@@ -25,12 +25,16 @@ import contextlib
 import hashlib
 import logging
 import os
+import sys
 import threading
 import warnings
 from datetime import datetime
 from typing import Any
 
-from overrides import overrides
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
 
 LOG = logging.getLogger(__name__)
 
@@ -245,7 +249,7 @@ class ERA5ModelLevel(ECMWFAPI):
         """
         return "reanalysis-era5-complete"
 
-    @overrides
+    @override
     def create_cachepath(self, t: datetime | pd.Timestamp) -> str:
         """Return cachepath to local ERA5 data file based on datetime.
 
@@ -277,7 +281,7 @@ class ERA5ModelLevel(ECMWFAPI):
 
         return self.cachestore.path(cache_path)
 
-    @overrides
+    @override
     def download_dataset(self, times: list[datetime]) -> None:
         # group data to request by month (nominal) or by day (ensemble)
         requests: dict[datetime, list[datetime]] = collections.defaultdict(list)
@@ -294,7 +298,7 @@ class ERA5ModelLevel(ECMWFAPI):
         for times_in_request in requests.values():
             self._download_convert_cache_handler(times_in_request)
 
-    @overrides
+    @override
     def open_metdataset(
         self,
         dataset: xr.Dataset | None = None,
@@ -320,7 +324,7 @@ class ERA5ModelLevel(ECMWFAPI):
         self.set_metadata(mds)
         return mds
 
-    @overrides
+    @override
     def set_metadata(self, ds: xr.Dataset | MetDataset) -> None:
         if self.product_type == "reanalysis":
             product = "reanalysis"

--- a/pycontrails/datalib/ecmwf/hres.py
+++ b/pycontrails/datalib/ecmwf/hres.py
@@ -5,16 +5,21 @@ from __future__ import annotations
 import hashlib
 import logging
 import pathlib
+import sys
 from contextlib import ExitStack
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
 
 LOG = logging.getLogger(__name__)
 
 import numpy as np
 import pandas as pd
 import xarray as xr
-from overrides import overrides
 
 import pycontrails
 from pycontrails.core import cache
@@ -556,7 +561,7 @@ class HRES(ECMWFAPI):
             f"\n\tgrid={request['grid']},\n\tlevtype={request['levtype']}{levelist}"
         )
 
-    @overrides
+    @override
     def create_cachepath(self, t: datetime) -> str:
         if self.cachestore is None:
             raise ValueError("self.cachestore attribute must be defined to create cache path")
@@ -574,7 +579,7 @@ class HRES(ECMWFAPI):
         # return cache path
         return self.cachestore.path(f"{datestr}-{step}-{suffix}.nc")
 
-    @overrides
+    @override
     def download_dataset(self, times: list[datetime]) -> None:
         """Download data from data source for input times.
 
@@ -595,7 +600,7 @@ class HRES(ECMWFAPI):
         elif len(steps) > 0:
             self._download_file(steps)
 
-    @overrides
+    @override
     def open_metdataset(
         self,
         dataset: xr.Dataset | None = None,
@@ -635,7 +640,7 @@ class HRES(ECMWFAPI):
         self.set_metadata(mds)
         return mds
 
-    @overrides
+    @override
     def set_metadata(self, ds: xr.Dataset | MetDataset) -> None:
         if self.stream == "oper":
             product = "forecast"

--- a/pycontrails/datalib/ecmwf/hres.py
+++ b/pycontrails/datalib/ecmwf/hres.py
@@ -331,9 +331,9 @@ class HRES(ECMWFAPI):
             f" {getattr(self, 'steps', '')}"
         )
 
-    @classmethod
+    @staticmethod
     def create_synoptic_time_ranges(
-        self, timesteps: list[pd.Timestamp]
+        timesteps: list[pd.Timestamp],
     ) -> list[tuple[pd.Timestamp, pd.Timestamp]]:
         """Create synoptic time bounds encompassing date range.
 

--- a/pycontrails/datalib/ecmwf/hres_model_level.py
+++ b/pycontrails/datalib/ecmwf/hres_model_level.py
@@ -13,15 +13,20 @@ from __future__ import annotations
 import contextlib
 import hashlib
 import logging
+import sys
 import warnings
 from datetime import datetime, timedelta
 from typing import Any
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
 
 LOG = logging.getLogger(__name__)
 
 import pandas as pd
 import xarray as xr
-from overrides import overrides
 
 import pycontrails
 from pycontrails.core import cache
@@ -283,7 +288,7 @@ class HRESModelLevel(ECMWFAPI):
         """
         return []
 
-    @overrides
+    @override
     def create_cachepath(self, t: datetime | pd.Timestamp) -> str:
         """Return cachepath to local HRES data file based on datetime.
 
@@ -316,13 +321,13 @@ class HRESModelLevel(ECMWFAPI):
 
         return self.cachestore.path(cache_path)
 
-    @overrides
+    @override
     def download_dataset(self, times: list[datetime]) -> None:
         # will always submit a single MARS request since each forecast is a separate file on tape
         LOG.debug(f"Retrieving ERA5 data for times {times} from forecast {self.forecast_time}")
         self._download_convert_cache_handler(times)
 
-    @overrides
+    @override
     def open_metdataset(
         self,
         dataset: xr.Dataset | None = None,
@@ -348,7 +353,7 @@ class HRESModelLevel(ECMWFAPI):
         self.set_metadata(mds)
         return mds
 
-    @overrides
+    @override
     def set_metadata(self, ds: xr.Dataset | MetDataset) -> None:
         ds.attrs.update(
             provider="ECMWF", dataset="HRES", product="forecast", radiation_accumulated=True

--- a/pycontrails/datalib/ecmwf/ifs.py
+++ b/pycontrails/datalib/ecmwf/ifs.py
@@ -4,16 +4,21 @@ from __future__ import annotations
 
 import logging
 import pathlib
+import sys
 import warnings
 from datetime import datetime
 from typing import Any
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
 
 LOG = logging.getLogger(__name__)
 
 import numpy as np
 import pandas as pd
 import xarray as xr
-from overrides import overrides
 
 from pycontrails.core import met
 from pycontrails.datalib._met_utils import metsource
@@ -119,7 +124,7 @@ class IFS(metsource.MetDataSource):
         """
         return None
 
-    @overrides
+    @override
     def open_metdataset(
         self,
         dataset: xr.Dataset | None = None,
@@ -190,7 +195,7 @@ class IFS(metsource.MetDataSource):
         self.set_metadata(ds)
         return met.MetDataset(ds, **kwargs)
 
-    @overrides
+    @override
     def set_metadata(self, ds: xr.Dataset | met.MetDataset) -> None:
         ds.attrs.update(
             provider="ECMWF",
@@ -198,15 +203,15 @@ class IFS(metsource.MetDataSource):
             product="forecast",
         )
 
-    @overrides
+    @override
     def download_dataset(self, times: list[datetime]) -> None:
         raise NotImplementedError("IFS download is not supported")
 
-    @overrides
+    @override
     def cache_dataset(self, dataset: xr.Dataset) -> None:
         raise NotImplementedError("IFS dataset caching not supported")
 
-    @overrides
+    @override
     def create_cachepath(self, t: datetime) -> str:
         raise NotImplementedError("IFS download is not supported")
 

--- a/pycontrails/datalib/gfs/gfs.py
+++ b/pycontrails/datalib/gfs/gfs.py
@@ -13,15 +13,20 @@ import contextlib
 import hashlib
 import logging
 import pathlib
+import sys
 import warnings
 from collections.abc import Callable
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
+
 import numpy as np
 import pandas as pd
 import xarray as xr
-from overrides import overrides
 
 import pycontrails
 from pycontrails.core import cache, met
@@ -355,7 +360,7 @@ class GFSForecast(metsource.MetDataSource):
         forecast_hour = str(self.forecast_time.hour).zfill(2)
         return f"gfs.t{forecast_hour}z.pgrb2.{self._grid_string}.f{step_hour}"
 
-    @overrides
+    @override
     def create_cachepath(self, t: datetime) -> str:
         if self.cachestore is None:
             raise ValueError("self.cachestore attribute must be defined to create cache path")
@@ -372,7 +377,7 @@ class GFSForecast(metsource.MetDataSource):
         # return cache path
         return self.cachestore.path(f"{datestr}-{step}-{suffix}.nc")
 
-    @overrides
+    @override
     def download_dataset(self, times: list[datetime]) -> None:
         # get step relative to forecast forecast_time
         logger.debug(
@@ -383,7 +388,7 @@ class GFSForecast(metsource.MetDataSource):
         for t in times:
             self._download_file(t)
 
-    @overrides
+    @override
     def cache_dataset(self, dataset: xr.Dataset) -> None:
         # if self.cachestore is None:
         #     LOG.debug("Cache is turned off, skipping")
@@ -391,7 +396,7 @@ class GFSForecast(metsource.MetDataSource):
 
         raise NotImplementedError("GFS caching only implemented with download")
 
-    @overrides
+    @override
     def open_metdataset(
         self,
         dataset: xr.Dataset | None = None,
@@ -435,7 +440,7 @@ class GFSForecast(metsource.MetDataSource):
         # run the same GFS-specific processing on the dataset
         return self._process_dataset(ds, **kwargs)
 
-    @overrides
+    @override
     def set_metadata(self, ds: xr.Dataset | met.MetDataset) -> None:
         ds.attrs.update(
             provider="NCEP",

--- a/pycontrails/models/cocip/cocip.py
+++ b/pycontrails/models/cocip/cocip.py
@@ -3,15 +3,20 @@
 from __future__ import annotations
 
 import logging
+import sys
 import warnings
 from collections.abc import Sequence
 from typing import Any, Literal, NoReturn, overload
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
 
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
 import xarray as xr
-from overrides import overrides
 
 from pycontrails.core import met_var
 from pycontrails.core.aircraft_performance import AircraftPerformance
@@ -1218,7 +1223,7 @@ class Cocip(Model):
 
         return self._downwash_contrail.filter(filt)
 
-    @overrides
+    @override
     def _cleanup_indices(self) -> None:
         """Cleanup interpolation artifacts."""
 

--- a/pycontrails/models/humidity_scaling/humidity_scaling.py
+++ b/pycontrails/models/humidity_scaling/humidity_scaling.py
@@ -7,14 +7,19 @@ import contextlib
 import dataclasses
 import functools
 import pathlib
+import sys
 import warnings
 from typing import Any, NoReturn, overload
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
 
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
 import xarray as xr
-from overrides import overrides
 
 from pycontrails.core import models
 from pycontrails.core.met import MetDataArray, MetDataset
@@ -202,7 +207,7 @@ class ConstantHumidityScaling(HumidityScaling):
     default_params = ConstantHumidityScalingParams
     scaler_specific_keys = ("rhi_adj",)
 
-    @overrides
+    @override
     def scale(
         self,
         specific_humidity: ArrayLike,
@@ -254,7 +259,7 @@ class ExponentialBoostHumidityScaling(HumidityScaling):
     default_params = ExponentialBoostHumidityScalingParams
     scaler_specific_keys = "rhi_adj", "rhi_boost_exponent", "clip_upper"
 
-    @overrides
+    @override
     def scale(
         self,
         specific_humidity: ArrayLike,
@@ -408,7 +413,7 @@ class ExponentialBoostLatitudeCorrectionHumidityScaling(HumidityScaling):
         q_method = self.params["interpolation_q_method"]
         return {**super()._scale_kwargs(), "q_method": q_method}
 
-    @overrides
+    @override
     def scale(
         self,
         specific_humidity: ArrayLike,
@@ -557,7 +562,7 @@ class HumidityScalingByLevel(HumidityScaling):
         "stratosphere_threshold",
     )
 
-    @overrides
+    @override
     def scale(
         self,
         specific_humidity: ArrayLike,
@@ -825,7 +830,7 @@ class HistogramMatching(HumidityScaling):
             warnings.warn(msg, DeprecationWarning)
         super().__init__(met, params, **params_kwargs)
 
-    @overrides
+    @override
     def scale(
         self,
         specific_humidity: ArrayLike,
@@ -976,7 +981,7 @@ class HistogramMatchingWithEckel(HumidityScaling):
 
         return self.source
 
-    @overrides
+    @override
     def scale(  # type: ignore[override]
         self,
         specific_humidity: npt.NDArray[np.float64],

--- a/pycontrails/models/ps_model/ps_model.py
+++ b/pycontrails/models/ps_model/ps_model.py
@@ -5,13 +5,18 @@ from __future__ import annotations
 import dataclasses
 import functools
 import pathlib
+import sys
 from collections.abc import Mapping
 from typing import Any, NoReturn, overload
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
 
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
-from overrides import overrides
 
 from pycontrails.core import flight
 from pycontrails.core.aircraft_performance import (
@@ -125,7 +130,7 @@ class PSFlight(AircraftPerformance):
     @overload
     def eval(self, source: None = ..., **params: Any) -> NoReturn: ...
 
-    @overrides
+    @override
     def eval(self, source: Flight | None = None, **params: Any) -> Flight:
         self.update_params(params)
         self.set_source(source)
@@ -217,7 +222,7 @@ class PSFlight(AircraftPerformance):
 
         return fl
 
-    @overrides
+    @override
     def calculate_aircraft_performance(
         self,
         *,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,9 +38,9 @@ readme = { file = "README.md", content-type = "text/markdown" }
 dependencies = [
     "dask>=2022.3",
     "numpy>=1.22",
-    "overrides>=6.1",
     "pandas>=2.2",
     "scipy>=1.10",
+    "typing-extensions>=4.5; python_version < '3.12'",
     "xarray>=2022.3",
 ]
 dynamic = ["version"]
@@ -264,7 +264,6 @@ lint.ignore = [
 # https://docs.astral.sh/ruff/settings/#pydocstyle
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"
-ignore-decorators = ["overrides.overrides"]
 
 # https://docs.astral.sh/ruff/settings/#flake8-pytest-style
 [tool.ruff.lint.flake8-pytest-style]

--- a/tests/unit/test_humidity_scaling.py
+++ b/tests/unit/test_humidity_scaling.py
@@ -3,12 +3,17 @@
 from __future__ import annotations
 
 import json
+import sys
 from typing import Any
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
 
 import numpy as np
 import pandas as pd
 import pytest
-from overrides import overrides
 
 from pycontrails import GeoVectorDataset, MetDataArray, MetDataset, VectorDataset
 from pycontrails.core import models
@@ -68,7 +73,7 @@ class DefaultHumidityScaling(hs.HumidityScaling):
     long_name = "No humidity scaling"
     formula = "rhi -> rhi"
 
-    @overrides
+    @override
     def scale(
         self,
         specific_humidity: ArrayLike,


### PR DESCRIPTION
### Internals

- Remove `overrides` dependency. Require `typing-extensions` for python < 3.12.
- Upgrade some type hints for more modern python language features.

## Tests

- [x] QC test passes locally (`make test`)
- [x] CI tests pass

