### PR TITLE
Feature/ps grid mach optimize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.54.3
+
+### Features
+
+- Creates new method `ps_nominal_optimize_mach` which computes the optimal mach number given a set of operating conditions.
+
+### Internals
+
+- Improves computation of mach limits to accept vectorized input/output.
+
 ## v0.54.2
 
 ### Features

--- a/pycontrails/models/ps_model/__init__.py
+++ b/pycontrails/models/ps_model/__init__.py
@@ -14,5 +14,5 @@ __all__ = [
     "PSGrid",
     "load_aircraft_engine_params",
     "ps_nominal_grid",
-    "ps_nominal_optimize_mach"
+    "ps_nominal_optimize_mach",
 ]

--- a/pycontrails/models/ps_model/__init__.py
+++ b/pycontrails/models/ps_model/__init__.py
@@ -4,7 +4,7 @@ from pycontrails.models.ps_model.ps_aircraft_params import (
     PSAircraftEngineParams,
     load_aircraft_engine_params,
 )
-from pycontrails.models.ps_model.ps_grid import PSGrid, ps_nominal_grid
+from pycontrails.models.ps_model.ps_grid import PSGrid, ps_nominal_grid, ps_nominal_optimize_mach
 from pycontrails.models.ps_model.ps_model import PSFlight, PSFlightParams
 
 __all__ = [
@@ -14,4 +14,5 @@ __all__ = [
     "PSGrid",
     "load_aircraft_engine_params",
     "ps_nominal_grid",
+    "ps_nominal_optimize_mach"
 ]

--- a/pycontrails/models/ps_model/ps_grid.py
+++ b/pycontrails/models/ps_model/ps_grid.py
@@ -621,14 +621,7 @@ def ps_nominal_optimize_mach(
         if sin_a is None or cos_a is None:
             msg = "Segment angles must be provide if wind data is specified"
             raise ValueError(msg)
-        headwind = np.sqrt((northward_wind * cos_a) ** 2 + (eastward_wind * sin_a) ** 2)
-        # There's probably a better way to do this?
-        # Compute angle between wind and segment angle and set to (-pi, pi]
-        dth = np.arctan2(cos_a, sin_a) - np.arctan2(eastward_wind, northward_wind)
-        dth = ((dth + np.pi) % (2 * np.pi)) - np.pi
-        # Flip sign of wind if more than pi/2 part
-        sign = 2 * (np.abs(dth) > np.pi / 2) - 1
-        headwind *= sign
+        headwind = -(northward_wind * cos_a + eastward_wind * sin_a)
     else:
         headwind = 0.0  # type: ignore
 

--- a/tests/unit/test_ps_model.py
+++ b/tests/unit/test_ps_model.py
@@ -489,7 +489,7 @@ def test_ps_optimal_mach():
     )
 
     np.testing.assert_array_almost_equal(
-        mach_opt, [0.645, 0.703, 0.77 , 0.804, 0.81 , 0.807, 0.795], decimal=3
+        mach_opt, [0.645, 0.703, 0.77, 0.804, 0.81, 0.807, 0.795], decimal=3
     )
 
 

--- a/tests/unit/test_ps_model.py
+++ b/tests/unit/test_ps_model.py
@@ -489,7 +489,7 @@ def test_ps_optimal_mach():
     )
 
     np.testing.assert_array_almost_equal(
-        mach_opt, [0.645, 0.703, 0.77, 0.804, 0.81, 0.807, 0.795], decimal=3
+        mach_opt["mach_number"].values, [0.645, 0.703, 0.77, 0.804, 0.81, 0.807, 0.795], decimal=3
     )
 
 


### PR DESCRIPTION
## Changes

> Improves computation of mach limits to accept vectorized input/output
> Creates new method `ps_nominal_optimize_mach` which computes the optimal mach number given a set of operating conditions

#### Internals

All functions now use the `newton` optimization method similar to `ps_nominal_grid`.

## Tests

- [ ] QC test passes locally (`make test`)
- [ ] CI tests pass
