### PR TITLE
fix ACCF parameters

### DIFF
--- a/pycontrails/models/accf.py
+++ b/pycontrails/models/accf.py
@@ -88,7 +88,7 @@ class ACCFParams(ModelParams):
     h2o_scaling: float = 1.0
     o3_scaling: float = 1.0
 
-    forecast_step: float = 6.0
+    forecast_step: float = None
 
     sep_ri_rw: bool = False
 
@@ -340,7 +340,7 @@ def _get_accf_config(params: dict[str, Any]) -> dict[str, Any]:
         "horizontal_resolution": params["horizontal_resolution"],
         "forecast_step": params["forecast_step"],
         "NOx_aCCF": True,
-        "NOx&inverse_EIs": params["nox_ei"],
+        "NOx_EI&F_km": params["nox_ei"],
         "output_format": "netCDF",
         "mean": False,
         "std": False,
@@ -361,6 +361,7 @@ def _get_accf_config(params: dict[str, Any]) -> dict[str, Any]:
             "H2O": params["h2o_scaling"],
             "O3": params["o3_scaling"],
         },
+        "unit_K/kg(fuel)": False,
         "PCFA": params["pfca"],
         "PCFA-ISSR": {
             "rhi_threshold": params["issr_rhi_threshold"],


### PR DESCRIPTION
- The forecast_step is now automatically determined by CLIMaCCF. It is used to convert the top net thermal radiation (TTR) to the outgoing longwave radiation (OLR). If specified, it should be 1.0 hour for ERA5 reanalysis and 3.0 hours for ERA5 ensemble as stated here https://codes.ecmwf.int/grib/param-db/179 and here https://confluence.ecmwf.int/display/CKB/ERA5%3A+data+documentation#ERA5:datadocumentation-Meanrates/fluxesandaccumulations
- The NOx parameter now aligns with CLIMaCCF
- CLIMaCCF returns the ACCFs in their original unit, i.e. K/kg[NO2] for CH4, O3 and NOx, K/kg[fuel] for H2O, CO2 and the merged aCCF, and K/km for contrails. The parameter now represents the default behavior. HOWEVER: the Jupyter notebook still assumes K/kg[fuel]. I would like to implement the following to fix the Jupyter notebook:

`ac = ACCF(pl, sl, {"unit_K_per_kg_fuel": True})`

Any support would be appreciated :) @zebengberg

Acknowledgements also go to Abolfazl Simorgh (asimorgh@pa.uc3m.es) and Simone Dietmüller (Simone.Dietmueller@dlr.de).
