### PR TITLE
Feature/test 313

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -41,7 +41,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.13'
           cache: 'pip'
           cache-dependency-path: pyproject.toml
 

--- a/.github/workflows/doctest.yaml
+++ b/.github/workflows/doctest.yaml
@@ -41,7 +41,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.13'
           cache: 'pip'
           cache-dependency-path: pyproject.toml
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -123,6 +123,13 @@ jobs:
       - build-sdist
       - check-main-test-status
     runs-on: ubuntu-latest
+
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pycontrails
+    permissions:
+      id-token: write
+
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v4
@@ -138,8 +145,3 @@ jobs:
 
       - name: Publish distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
-          verbose: true
-          verify-metadata: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Check main test status
         run: make main-test-status
 
-  build_wheels:
+  build-wheels:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -65,7 +65,7 @@ jobs:
           name: wheels-${{ matrix.os }}-artifact
           path: ./wheelhouse/*.whl
 
-  build_sdist:
+  build-sdist:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
@@ -82,8 +82,10 @@ jobs:
           name: sdist-artifact
           path: dist/*.tar.gz
 
-  upload_pypi_test:
-    needs: [build_wheels, build_sdist]
+  publish-to-testpypi:
+    needs:
+      - build-wheels
+      - build-sdist
     runs-on: ubuntu-latest
     steps:
       - name: Download artifacts
@@ -107,9 +109,12 @@ jobs:
           verbose: true
           verify-metadata: true
 
-  upload_pypi:
+  publish-to-pypi:
     if: ${{ github.event_name == 'release'}}
-    needs: [build_wheels, build_sdist, check-main-test-status]
+    needs:
+      - build-wheels
+      - build-sdist
+      - check-main-test-status
     runs-on: ubuntu-latest
     steps:
       - name: Download artifacts

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -82,11 +82,21 @@ jobs:
           name: sdist-artifact
           path: dist/*.tar.gz
 
+  # Publish using PyPI trusted publishing
+  # https://docs.pypi.org/trusted-publishers/using-a-publisher/
+  # https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
   publish-to-testpypi:
     needs:
       - build-wheels
       - build-sdist
     runs-on: ubuntu-latest
+
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/pycontrails
+    permissions:
+      id-token: write
+
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v4
@@ -103,11 +113,8 @@ jobs:
       - name: Publish distribution 📦 to Test PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
           verbose: true
-          verify-metadata: true
 
   publish-to-pypi:
     if: ${{ github.event_name == 'release'}}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,7 +46,7 @@ jobs:
           CIBW_SKIP: '*-win32 *-manylinux_i686 *-musllinux*'
           CIBW_BUILD_VERBOSITY: 3
           CIBW_ARCHS_MACOS: x86_64 arm64
-          CIBW_TEST_SKIP: '*-macosx_arm64 cp313-*'
+          CIBW_TEST_SKIP: '*-macosx_arm64'
           # Completely isolate tests to prevent cibuildwheel from importing the
           # source instead of the wheel. This happens when tests/__init__.py is read.
           CIBW_TEST_EXTRAS: "complete,dev"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,8 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        # TODO(Fall 2024): Add 3.13 once all dependencies are available
-        pyversion: ['3.10', '3.11', '3.12']
+        pyversion: ['3.10', '3.11', '3.12', '3.13']
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Improve computation of mach limits to accept vectorized input/output.
 - Test against python 3.13 in the GitHub Actions CI. Use python 3.13 in the docs and doctest workflows.
+- Publish to PyPI using [trusted publishing](https://docs.pypi.org/trusted-publishers/using-a-publisher/).
 
 ## v0.54.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,15 @@
 # Changelog
 
-## v0.54.3
+## v0.54.3 (unreleased)
 
 ### Features
 
-- Creates new method `ps_nominal_optimize_mach` which computes the optimal mach number given a set of operating conditions.
+- Create new function `ps_nominal_optimize_mach` which computes the optimal mach number given a set of operating conditions.
 
 ### Internals
 
-- Improves computation of mach limits to accept vectorized input/output.
+- Improve computation of mach limits to accept vectorized input/output.
+- Test against python 3.13 in the GitHub Actions CI. Use python 3.13 in the docs and doctest workflows.
 
 ## v0.54.2
 

--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,8 @@ pip-install:
 	python -m pip install -U pip wheel
 	python -m pip install -e ".[complete]"
 
-	# these still must be installed manually for Python < 3.10
-	# -pip install -e ".[open3d]"
+	# open3d wheels not available for latest python versions; install manually
+	# pip install -e ".[open3d]"
 
 # development installation
 dev-install: pip-install

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -27,8 +27,7 @@ With Python 3.10 or later, install the latest release from PyPI using ``pip``:
     # install with all optional dependencies
     $ pip install "pycontrails[complete]"
 
-Wheels are currently built for python 3.10 - 3.13 on Linux, macOS, and Windows. The python 3.13
-wheels are not yet tested in CI/CD and not all runtime dependencies are available for python 3.13.
+Wheels are currently built and tested for python 3.10 - 3.13 on Linux, macOS, and Windows.
 
 Install the latest development version directly from GitHub:
 


### PR DESCRIPTION
### Internals

- Test against python 3.13 in the GitHub Actions CI. Use python 3.13 in the docs and doctest workflows.
- Publish to PyPI using [trusted publishing](https://docs.pypi.org/trusted-publishers/using-a-publisher/).

## Tests

- [x] QC test passes locally (`make test`)
- [x] CI tests pass

## Reviewer

@mlshapiro At some point in the past year, PyPI updated their recommendations for publishing. This moves us away from the previous token-based approach to publishing via OIDC with github as the trusted third-party. (I already set this up in PyPI.)
