### PR TITLE
preserve fuel in Flight.resample_and_fill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Create new function `ps_nominal_optimize_mach` which computes the optimal mach number given a set of operating conditions.
 
+### Fixes
+
+- Ensure the fuel type is preserved when calling `Flight.resample_and_fill`.
+
 ### Internals
 
 - Improve computation of mach limits to accept vectorized input/output.

--- a/pycontrails/core/flight.py
+++ b/pycontrails/core/flight.py
@@ -961,7 +961,7 @@ class Flight(GeoVectorDataset):
                 msg = f"{msg} Pass 'keep_original_index=True' to keep the original index."
             warnings.warn(msg)
 
-        return Flight(data=df, attrs=self.attrs)
+        return Flight(data=df, attrs=self.attrs, fuel=self.fuel)
 
     def clean_and_resample(
         self,

--- a/tests/unit/test_flight.py
+++ b/tests/unit/test_flight.py
@@ -1219,23 +1219,26 @@ def test_flight_slots(flight_fake: Flight) -> None:
         flight_fake.foo = "bar"
 
 
-@pytest.mark.parametrize("method", ["copy", "filter"])
+@pytest.mark.parametrize("method", ["copy", "filter", "resample"])
 def test_method_preserves_fuel(flight_fake: Flight, method: str) -> None:
-    """Ensure fuel is preserved for the copy and filter methods."""
+    """Ensure fuel is preserved for the copy, filter, and resample_and_fill methods."""
 
     flight_fake.fuel = SAFBlend(15.0)
 
     if method == "copy":
         out = flight_fake.copy()
-    else:
-        assert method == "filter"
+    elif method == "filter":
         mask = np.ones(len(flight_fake), dtype=bool)
         mask[::3] = False
         out = flight_fake.filter(mask)
+    else:
+        assert method == "resample"
+        out = flight_fake.resample_and_fill("50s")
 
     assert isinstance(out, Flight)
     assert hasattr(out, "fuel")
     assert out.fuel is flight_fake.fuel
+    assert out.fuel == SAFBlend(15.0)
 
 
 def test_resample_and_fill_short_flight() -> None:


### PR DESCRIPTION
#### Fixes

- Ensure the fuel type is preserved when calling `Flight.resample_and_fill`.

## Tests

- [x] QC test passes locally (`make test`)
- [ ] CI tests pass

