### PR TITLE
Remove duplicate of potential vorticity parameter

### DIFF
--- a/pycontrails/models/accf.py
+++ b/pycontrails/models/accf.py
@@ -154,7 +154,6 @@ class ACCF(Model):
         RelativeHumidity,
         NorthwardWind,
         EastwardWind,
-        ecmwf.PotentialVorticity,
     )
     sur_variables = (ecmwf.SurfaceSolarDownwardRadiation, ecmwf.TopNetThermalRadiation)
     default_params = ACCFParams


### PR DESCRIPTION
ACCF.met_variables included the same parameter twice: pv (potential_vorticity)
