### PR TITLE
Extend ACCF relative humidity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 - Update the `ACCFParams.forecast_step` to None, which allows CLIMaCCF to automatically determine the forecast step based on the `met` data.
 - Update the `ACCF` NOx parameter for the latest CLIMaCCF version.
 - Ensure a custom "horizontal_resolution" param passed into `ACCF` is not overwritten.
+- Remove duplicated variable in `ACCF.met_variables`.
+- Allow the `ACCF` model to accept relative humidity as a percentage or as a proportion.
+- Include `ecmwf.RelativeHumidity` in `ACCF.met_variables` so that `ERA5(..., variables=ACCF.met_variables)` no longer raises an error.
 
 ### Internals
 

--- a/docs/integrations/ACCF.ipynb
+++ b/docs/integrations/ACCF.ipynb
@@ -78,22 +78,14 @@
     "# pressure level data\n",
     "era5_pl = ERA5(\n",
     "    time=time_bounds,\n",
-    "    variables=[\n",
-    "        \"air_temperature\",\n",
-    "        \"specific_humidity\",\n",
-    "        \"potential_vorticity\",\n",
-    "        \"geopotential\",\n",
-    "        \"relative_humidity\",\n",
-    "        \"northward_wind\",\n",
-    "        \"eastward_wind\",\n",
-    "    ],\n",
+    "    variables=ACCF.met_variables,\n",
     "    pressure_levels=pressure_levels,\n",
     ")\n",
     "\n",
     "# single level data (radiation)\n",
     "era5_sl = ERA5(\n",
     "    time=time_bounds,\n",
-    "    variables=[\"surface_solar_downward_radiation\", \"top_net_thermal_radiation\"],\n",
+    "    variables=ACCF.sur_variables,\n",
     ")\n",
     "\n",
     "pl = era5_pl.open_metdataset()\n",
@@ -347,7 +339,7 @@
     {
      "data": {
       "text/html": [
-       "<b>Flight</b> [27 keys x 10000 length, 6 attributes]<br/ ><br/><table><tr style=\"border-bottom:1px solid silver\"><th colspan=\"2\">Attributes</th></tr><tr><td>time</td><td>[2022-01-01 12:00:00, 2022-01-01 13:30:00]</td></tr><tr><td>longitude</td><td>[45.0, 59.0]</td></tr><tr><td>latitude</td><td>[45.0, 53.0]</td></tr><tr><td>altitude</td><td>[11037.0, 11037.0]</td></tr><tr><td>aircraft_type</td><td>B737</td></tr><tr><td>flight_id</td><td>17</td></tr><tr><td>met_source_provider</td><td>ECMWF</td></tr><tr><td>met_source_dataset</td><td>ERA5</td></tr><tr><td>met_source_product</td><td>reanalysis</td></tr><tr><td>pycontrails_version</td><td>0.54.3.dev22</td></tr></table><div>\n",
+       "<b>Flight</b> [27 keys x 10000 length, 6 attributes]<br/ ><br/><table><tr style=\"border-bottom:1px solid silver\"><th colspan=\"2\">Attributes</th></tr><tr><td>time</td><td>[2022-01-01 12:00:00, 2022-01-01 13:30:00]</td></tr><tr><td>longitude</td><td>[45.0, 59.0]</td></tr><tr><td>latitude</td><td>[45.0, 53.0]</td></tr><tr><td>altitude</td><td>[11037.0, 11037.0]</td></tr><tr><td>aircraft_type</td><td>B737</td></tr><tr><td>flight_id</td><td>17</td></tr><tr><td>met_source_provider</td><td>ECMWF</td></tr><tr><td>met_source_dataset</td><td>ERA5</td></tr><tr><td>met_source_product</td><td>reanalysis</td></tr><tr><td>pycontrails_version</td><td>0.54.3.dev31</td></tr></table><div>\n",
        "<style scoped>\n",
        "    .dataframe tbody tr th:only-of-type {\n",
        "        vertical-align: middle;\n",
@@ -671,7 +663,7 @@
        "\tmet_source_provider ECMWF\n",
        "\tmet_source_dataset  ERA5\n",
        "\tmet_source_product  reanalysis\n",
-       "\tpycontrails_version 0.54.3.dev22"
+       "\tpycontrails_version 0.54.3.dev31"
       ]
      },
      "execution_count": 8,

--- a/docs/notebooks/ECMWF.ipynb
+++ b/docs/notebooks/ECMWF.ipynb
@@ -17,7 +17,7 @@
     "Support provided for:\n",
     "\n",
     "- [ERA5](https://www.ecmwf.int/en/forecasts/dataset/ecmwf-reanalysis-v5) via the [Copernicus Data Store (CDS-Beta)](https://cds-beta.climate.copernicus.eu/) using [cdsapi](https://github.com/ecmwf/cdsapi) or user provided files\n",
-    "- [HRES](https://confluence.ecmwf.int/display/FUG/Section+2.1.1.2+Rationale+for+High+Resolution) and [ENS](https://confluence.ecmwf.int/display/FUG/Cy49r1+Section+5+Forecast+Ensemble+%28ENS%29+-+Rationale+and+Construction) via [MARS](https://confluence.ecmwf.int/display/UDOC/MARS+user+documentation) using [ecmwf-api-client](https://github.com/ecmwf/ecmwf-api-client) or user provided files.\n",
+    "- [HRES](https://confluence.ecmwf.int/display/FUG/Section+2.1.1.2+Rationale+for+High+Resolution) and [ENS](https://confluence.ecmwf.int/display/FUG/Section+2.1.2.1+Medium+Range+Ensemble+forecasts) via [MARS](https://confluence.ecmwf.int/display/UDOC/MARS+user+documentation) using [ecmwf-api-client](https://github.com/ecmwf/ecmwf-api-client) or user provided files.\n",
     "\n",
     "For both ERA5 and HRES, we provide interfaces for accessing \"pressure-level data\" (fields pre-interpolated to a fixed set of pressure levels) or \"model-level data\" (fields retrieved on the native vertical grid and [interpolated after retrieval to an arbitrary set of pressure levels](model-levels.ipynb)). We recommend using model-level data when possible, as the resolution of pressure-level data is coarse relative to the vertical scale of ice-supersaturated regions.\n",
     "\n",
@@ -3258,7 +3258,7 @@
     "### Reference\n",
     "\n",
     "- [HRES](https://confluence.ecmwf.int/display/FUG/Section+2.1.1.2+Rationale+for+High+Resolution) High resolution forecast\n",
-    "- [ENS](https://confluence.ecmwf.int/display/FUG/Cy49r1+Section+5+Forecast+Ensemble+%28ENS%29+-+Rationale+and+Construction) Ensemble forecast"
+    "- [ENS](https://confluence.ecmwf.int/display/FUG/Section+2.1.2.1+Medium+Range+Ensemble+forecasts) Ensemble forecast"
    ]
   },
   {

--- a/docs/notebooks/ECMWF.ipynb
+++ b/docs/notebooks/ECMWF.ipynb
@@ -17,7 +17,7 @@
     "Support provided for:\n",
     "\n",
     "- [ERA5](https://www.ecmwf.int/en/forecasts/dataset/ecmwf-reanalysis-v5) via the [Copernicus Data Store (CDS-Beta)](https://cds-beta.climate.copernicus.eu/) using [cdsapi](https://github.com/ecmwf/cdsapi) or user provided files\n",
-    "- [HRES](https://confluence.ecmwf.int/display/FUG/Section+2.1.1.2+Rationale+for+High+Resolution) and [ENS](https://confluence.ecmwf.int/display/FUG/Section+2.1.2.1+Medium+Range+Ensemble+forecasts) via [MARS](https://confluence.ecmwf.int/display/UDOC/MARS+user+documentation) using [ecmwf-api-client](https://github.com/ecmwf/ecmwf-api-client) or user provided files.\n",
+    "- [HRES](https://confluence.ecmwf.int/display/FUG/Section+2.1.1.2+Rationale+for+High+Resolution) and [ENS](https://confluence.ecmwf.int/display/FUG/Cy49r1+Section+5+Forecast+Ensemble+%28ENS%29+-+Rationale+and+Construction) via [MARS](https://confluence.ecmwf.int/display/UDOC/MARS+user+documentation) using [ecmwf-api-client](https://github.com/ecmwf/ecmwf-api-client) or user provided files.\n",
     "\n",
     "For both ERA5 and HRES, we provide interfaces for accessing \"pressure-level data\" (fields pre-interpolated to a fixed set of pressure levels) or \"model-level data\" (fields retrieved on the native vertical grid and [interpolated after retrieval to an arbitrary set of pressure levels](model-levels.ipynb)). We recommend using model-level data when possible, as the resolution of pressure-level data is coarse relative to the vertical scale of ice-supersaturated regions.\n",
     "\n",
@@ -3258,7 +3258,7 @@
     "### Reference\n",
     "\n",
     "- [HRES](https://confluence.ecmwf.int/display/FUG/Section+2.1.1.2+Rationale+for+High+Resolution) High resolution forecast\n",
-    "- [ENS](https://confluence.ecmwf.int/display/FUG/Section+2.1.2.1+Medium+Range+Ensemble+forecasts) Ensemble forecast"
+    "- [ENS](https://confluence.ecmwf.int/display/FUG/Cy49r1+Section+5+Forecast+Ensemble+%28ENS%29+-+Rationale+and+Construction) Ensemble forecast"
    ]
   },
   {

--- a/pycontrails/datalib/ecmwf/variables.py
+++ b/pycontrails/datalib/ecmwf/variables.py
@@ -107,6 +107,7 @@ RelativeHumidity = MetVariable(
     long_name=met_var.RelativeHumidity.long_name,
     units="%",
     level_type=met_var.RelativeHumidity.level_type,
+    grib1_id=met_var.RelativeHumidity.grib1_id,
     ecmwf_id=met_var.RelativeHumidity.ecmwf_id,
     grib2_id=met_var.RelativeHumidity.grib2_id,
     description=(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -237,9 +237,11 @@ ignore-path = [
 # https://docs.astral.sh/ruff/settings/#select
 # https://www.pydocstyle.org/en/6.3.0/error_codes.html
 [tool.ruff]
-lint.select = ["B", "D", "E", "F", "I", "NPY", "PL", "PT", "SIM", "UP"]
 line-length = 100
-lint.ignore = [
+
+[tool.ruff.lint]
+select = ["B", "D", "E", "F", "I", "NPY", "PL", "PT", "SIM", "UP"]
+ignore = [
     "B028",
     "E402",
     "D105",


### PR DESCRIPTION
#### Fixes

- Allow the `ACCF` model to accept relative humidity as a percentage or as a proportion.
- Include `ecmwf.RelativeHumidity` in `ACCF.met_variables` so that `ERA5(..., variables=ACCF.met_variables)` no longer raises an error.

## Tests

- [x] QC test passes locally (`make test`)
- [x] CI tests pass

## Reviewer

@jsmretschnig let me know if this fixes the issue you identified in #264 
