### PR TITLE
Feature/update resample and fill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Use native python types (as opposed to `numpy` scalars) in the `PSAircraftEngineParams` dataclass.
 - Ensure the `PSGrid` model maintains the precision of the `source`. Previously, float32 precision was lost per [NEP 50](https://numpy.org/neps/nep-0050-scalar-promotion.html).
 - Fix `Fleet.resample_and_fill` when the the "flight_id" field is included on `Fleet.data` (as opposed to `Fleet.fl_attrs`). Previously, this would raise a ValueError.
+- Use the supplied `nominal_rocd` parameter in `Flight.resample_and_fill` rather than `constants.nominal_rocd` (the default value of this parameter).
 
 ### Internals
 
@@ -37,6 +38,7 @@
 - Add the `RUF` ruleset for linting and formatting the codebase.
 - Update type hints for `numpy` 2.2 compatibility. Additional changes may be required after the next iteration of the `numpy` 2.2 series.
 - Relax the tolerance passed into `scipy.optimize.newton` in `ps_nominal_grid` to avoid some convergence warnings. (These warnings were more distracting than informative.)
+- Remove the `_verify_altitude` check in `Flight.resample_and_fill`. This was often triggered by a flight with corrupt waypoints (ie, independent from the logic in `Flight.resample_and_fill`).
 
 ## v0.54.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## v0.54.4 (unreleased)
 
+### Features
+
+- Improve the `_altitude_interpolation` function used within `Flight.resample_and_fill` and ensure that it is consistent with the [existing GAIA publication](https://acp.copernicus.org/articles/24/725/2024/) The function `_altitude_interpolation` now accounts for various scenarios. For example:
+
+  1. Flight will automatically climb to an assumed cruise altitude if the first and next known waypoints are at very low altitudes with a large time gap.
+  1. If there are large time gaps between known waypoints with a small altitude difference, then the flight will climb at the mid-point of the segment.
+  1. If there are large time gaps and positive altitude difference, then the flight will climb at the start of its interpolation until the known cruising altitude and start its cruise phase.
+  1. If there are large time gaps and negative altitude difference, then the flight will continue cruising and only starts to descend towards the end of the interpolation.
+  1. If there is a shallow climb (ROCD < 500 ft/min), then always assume that the flight will climb at the next time step.
+  1. If there is a shallow descent (-250 < ROCD < 0 ft/min), then always assume that the flight will descend at the final time step.
+
+  Conditions (3) to (6) is based on the logic that the aircraft will generally prefer to climb to a higher altitude as early as possible, and descend to a lower altitude as late as possible, because a higher altitude can reduce drag and fuel consumption.
+
+### Breaking changes
+
+- Remove the optional input parameter `climb_descend_at_end` in `Flight.resample_and_fill`. See the description of the new `_altitude_interpolation` function for the rationale behind this change.
+
 ### Fixes
 
 - Fix the `ERA5` interface when making a pressure-level request with a single pressure level. This change accommodates CDS-Beta server behavior. Previously, a ValueError was raised in this case.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### Breaking changes
 
 - Remove the optional input parameter `climb_descend_at_end` in `Flight.resample_and_fill`. See the description of the new `_altitude_interpolation` function for the rationale behind this change.
+- Remove the `copy` argument from `Fleet.from_seq`. This was argument is redundant and not used effectively in the implementation. The `Fleet.from_seq` method always returns a copy of the input sequence.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - By default, don't interpolate air temperature when running the `DryAdvection` model in a point-wise manner (no wind-shear simulation).
 - Use native python types (as opposed to `numpy` scalars) in the `PSAircraftEngineParams` dataclass.
 - Ensure the `PSGrid` model maintains the precision of the `source`. Previously, float32 precision was lost per [NEP 50](https://numpy.org/neps/nep-0050-scalar-promotion.html).
+- Fix `Fleet.resample_and_fill` when the the "flight_id" field is included on `Fleet.data` (as opposed to `Fleet.fl_attrs`). Previously, this would raise a ValueError.
 
 ### Internals
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@
 - Change the order of advected points returned by `DryAdvection` to be consistent with the input order at each time step.
 - Add the `RUF` ruleset for linting and formatting the codebase.
 - Update type hints for `numpy` 2.2 compatibility. Additional changes may be required after the next iteration of the `numpy` 2.2 series.
-- Relax the tolerance passed into `scipy.optimize.newton` in `ps_nominal_grid` to avoid more convergence warnings. These warnings were more distracting than informative.
+- Relax the tolerance passed into `scipy.optimize.newton` in `ps_nominal_grid` to avoid some convergence warnings. (These warnings were more distracting than informative.)
 
 ## v0.54.3
 

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-Copyright (c) 2021-2023 Breakthrough Energy
+Copyright (c) 2021-present Breakthrough Energy
 
 
 Attribution

--- a/pycontrails/__init__.py
+++ b/pycontrails/__init__.py
@@ -1,7 +1,7 @@
 """
 ``pycontrails`` public API.
 
-Copyright 2021-2023 Breakthrough Energy
+Copyright 2021-present Breakthrough Energy
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pycontrails/core/fleet.py
+++ b/pycontrails/core/fleet.py
@@ -373,7 +373,6 @@ class Fleet(Flight):
         force_filter: bool = False,
         drop: bool = True,
         keep_original_index: bool = False,
-        climb_descend_at_end: bool = False,
     ) -> NoReturn:
         msg = "Only implemented for Flight instances"
         raise NotImplementedError(msg)

--- a/pycontrails/core/fleet.py
+++ b/pycontrails/core/fleet.py
@@ -132,13 +132,13 @@ class Fleet(Flight):
         return final_waypoints, fl_attrs
 
     @override
-    def copy(self, **kwargs: Any) -> Fleet:
+    def copy(self, **kwargs: Any) -> Self:
         kwargs.setdefault("fuel", self.fuel)
         kwargs.setdefault("fl_attrs", self.fl_attrs)
         return super().copy(**kwargs)
 
     @override
-    def filter(self, mask: npt.NDArray[np.bool_], copy: bool = True, **kwargs: Any) -> Fleet:
+    def filter(self, mask: npt.NDArray[np.bool_], copy: bool = True, **kwargs: Any) -> Self:
         kwargs.setdefault("fuel", self.fuel)
 
         flight_ids = set(np.unique(self["flight_id"][mask]))
@@ -331,7 +331,7 @@ class Fleet(Flight):
         return np.concatenate(gs)
 
     @override
-    def resample_and_fill(self, *args: Any, **kwargs: Any) -> Fleet:
+    def resample_and_fill(self, *args: Any, **kwargs: Any) -> Self:
         flights = self.to_flight_list(copy=False)
 
         # We need to ensure that each flight has an flight_id attrs field
@@ -377,7 +377,7 @@ class Fleet(Flight):
         drop: bool = True,
         keep_original_index: bool = False,
         climb_descend_at_end: bool = False,
-    ) -> Flight:
+    ) -> NoReturn:
         msg = "Only implemented for Flight instances"
         raise NotImplementedError(msg)
 

--- a/pycontrails/core/fleet.py
+++ b/pycontrails/core/fleet.py
@@ -333,6 +333,14 @@ class Fleet(Flight):
     @override
     def resample_and_fill(self, *args: Any, **kwargs: Any) -> Fleet:
         flights = self.to_flight_list(copy=False)
+
+        # We need to ensure that each flight has an flight_id attrs field
+        # When we call fl.resample_and_fill, any flight_id data field
+        # will be lost, so the call to Fleet.from_seq will fail.
+        for fl in flights:
+            if "flight_id" not in fl.attrs:
+                fl.attrs["flight_id"] = _extract_flight_id(fl)
+
         flights = [fl.resample_and_fill(*args, **kwargs) for fl in flights]
         return type(self).from_seq(flights, copy=False, broadcast_numeric=False, attrs=self.attrs)
 

--- a/pycontrails/core/flight.py
+++ b/pycontrails/core/flight.py
@@ -1887,7 +1887,7 @@ def _verify_altitude(
     dalt = np.diff(altitude)
     dt = freq / np.timedelta64(1, "s")
     rocd = np.abs(dalt / dt)
-    if np.any(rocd > 3.0 * nominal_rocd):
+    if np.any(rocd > 2.5 * nominal_rocd):
         warnings.warn(
             "Rate of climb/descent values greater than nominal "
             f"({nominal_rocd} m/s) after altitude interpolation"

--- a/pycontrails/core/flight.py
+++ b/pycontrails/core/flight.py
@@ -1784,9 +1784,9 @@ def _altitude_interpolation(
 
         # (1): Unrealistic scenario
         is_unrealistic = (
-            (alt_ft_start < minimum_cruise_altitude_ft) and
-            (alt_ft_end < minimum_cruise_altitude_ft) and
-            (dt_next > 60)
+            (alt_ft_start < minimum_cruise_altitude_ft)
+            and (alt_ft_end < minimum_cruise_altitude_ft)
+            and (dt_next > 60)
         )
 
         # If unrealistic, assume flight will climb to cruise altitudes (0.8 * max_altitude_ft),
@@ -1814,9 +1814,11 @@ def _altitude_interpolation(
 
         # (3): If cruise over 2 h with small altitude change, set change to mid-point
         is_long_segment_small_altitude_change = (
-            (rocd_next < 500) and (rocd_next > -500) and (dt_next > 120) and
-            (alt_ft_start > minimum_cruise_altitude_ft) and
-            (alt_ft_end > minimum_cruise_altitude_ft)
+            (rocd_next < 500)
+            and (rocd_next > -500)
+            and (dt_next > 120)
+            and (alt_ft_start > minimum_cruise_altitude_ft)
+            and (alt_ft_end > minimum_cruise_altitude_ft)
         )
 
         if is_long_segment_small_altitude_change:

--- a/pycontrails/core/flight.py
+++ b/pycontrails/core/flight.py
@@ -945,7 +945,7 @@ class Flight(GeoVectorDataset):
         time = df.index.to_numpy()
         if np.any(np.isnan(altitude)):
             df_freq = pd.Timedelta(freq).to_numpy()
-            new_alt = _altitude_interpolation(altitude, time, nominal_rocd=nominal_rocd)
+            new_alt = _altitude_interpolation(altitude, time)
             _verify_altitude(new_alt, nominal_rocd, df_freq)
             df["altitude"] = new_alt
 
@@ -1702,7 +1702,6 @@ def _sg_filter(
 def _altitude_interpolation(
     altitude: npt.NDArray[np.floating],
     time: npt.NDArray[np.datetime64],
-    nominal_rocd: float = constants.nominal_rocd,
     minimum_cruise_altitude_ft: float = 20000.0,
     assumed_cruise_altitude_ft: float = 30000.0,
 ) -> npt.NDArray[np.floating]:
@@ -1749,7 +1748,7 @@ def _altitude_interpolation(
     """
     # Work in units of feet
     alt_ft = units.m_to_ft(altitude)
-    nominal_rocd_ft_min = units.m_to_ft(nominal_rocd) * 60
+    nominal_rocd_ft_min = units.m_to_ft(constants.nominal_rocd) * 60
 
     # Determine nan state of altitude
     isna = np.isnan(alt_ft)

--- a/pycontrails/core/flight.py
+++ b/pycontrails/core/flight.py
@@ -937,8 +937,7 @@ class Flight(GeoVectorDataset):
 
         if shift is not None:
             # We need to translate back to the original chart here
-            df["longitude"] += shift
-            df["longitude"] = ((df["longitude"] + 180.0) % 360.0) - 180.0
+            df["longitude"] = ((df["longitude"] + shift + 180.0) % 360.0) - 180.0
 
         # STEP 6: Interpolate nan values in altitude
         altitude = df["altitude"].to_numpy()

--- a/pycontrails/core/flight.py
+++ b/pycontrails/core/flight.py
@@ -1866,34 +1866,6 @@ def _altitude_interpolation(
     return units.ft_to_m(out_alt_ft.to_numpy())
 
 
-def _verify_altitude(
-    altitude: npt.NDArray[np.floating], nominal_rocd: float, freq: np.timedelta64
-) -> None:
-    """Confirm that the time derivative of ``altitude`` does not exceed twice ``nominal_rocd``.
-
-    Parameters
-    ----------
-    altitude : npt.NDArray[np.floating]
-        Array of filled altitude values containing nan values.
-    nominal_rocd : float
-        Nominal rate of climb/descent, in m/s
-    freq : np.timedelta64
-        Frequency of time index associated to `altitude`.
-    """
-    dalt = np.diff(altitude)
-    dt = freq / np.timedelta64(1, "s")
-    rocd = np.abs(dalt / dt)
-    if np.any(rocd > 2.5 * nominal_rocd):
-        warnings.warn(
-            "Rate of climb/descent values greater than nominal "
-            f"({nominal_rocd} m/s) after altitude interpolation"
-        )
-    if np.any(np.isnan(altitude)):
-        warnings.warn(
-            f"Found nan values altitude after ({nominal_rocd} m/s) after altitude interpolation"
-        )
-
-
 def filter_altitude(
     time: npt.NDArray[np.datetime64],
     altitude_ft: npt.NDArray[np.floating],

--- a/pycontrails/core/flight.py
+++ b/pycontrails/core/flight.py
@@ -973,7 +973,6 @@ class Flight(GeoVectorDataset):
         force_filter: bool = False,
         drop: bool = True,
         keep_original_index: bool = False,
-        climb_descend_at_end: bool = False,
     ) -> Self:
         """Resample and (possibly) filter a flight trajectory.
 
@@ -1015,9 +1014,6 @@ class Flight(GeoVectorDataset):
             Keep the original index of the :class:`Flight` in addition to the new
             resampled index. Defaults to ``False``.
             .. versionadded:: 0.45.2
-        climb_or_descend_at_end : bool
-            If true, the climb or descent will be placed at the end of each segment
-            rather than the start. Default is false (climb or descent immediately).
 
         Returns
         -------

--- a/pycontrails/core/flight.py
+++ b/pycontrails/core/flight.py
@@ -8,15 +8,15 @@ import sys
 import warnings
 from typing import TYPE_CHECKING, Any, NoReturn
 
-if sys.version_info >= (3, 11):
-    from typing import Self
-else:
-    from typing_extensions import Self
-
 if sys.version_info >= (3, 12):
     from typing import override
 else:
     from typing_extensions import override
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 
 import numpy as np
@@ -766,7 +766,7 @@ class Flight(GeoVectorDataset):
     # Filter/Resample
     # ------------
 
-    def filter_by_first(self) -> Flight:
+    def filter_by_first(self) -> Self:
         """Keep first row of group of waypoints with identical coordinates.
 
         Chaining this method with `resample_and_fill` often gives a cleaner trajectory
@@ -796,7 +796,7 @@ class Flight(GeoVectorDataset):
         1       50.0       0.0       0.0 2020-01-01 02:00:00
         """
         df = self.dataframe.groupby(["longitude", "latitude"], sort=False).first().reset_index()
-        return Flight(data=df, attrs=self.attrs)
+        return type(self)(data=df, attrs=self.attrs, fuel=self.fuel)
 
     def resample_and_fill(
         self,
@@ -806,7 +806,7 @@ class Flight(GeoVectorDataset):
         nominal_rocd: float = constants.nominal_rocd,
         drop: bool = True,
         keep_original_index: bool = False,
-    ) -> Flight:
+    ) -> Self:
         """Resample and fill flight trajectory with geodesics and linear interpolation.
 
         Waypoints are resampled according to the frequency ``freq``. Values for :attr:`data`
@@ -961,7 +961,7 @@ class Flight(GeoVectorDataset):
                 msg = f"{msg} Pass 'keep_original_index=True' to keep the original index."
             warnings.warn(msg)
 
-        return Flight(data=df, attrs=self.attrs, fuel=self.fuel)
+        return type(self)(data=df, attrs=self.attrs, fuel=self.fuel)
 
     def clean_and_resample(
         self,
@@ -975,7 +975,7 @@ class Flight(GeoVectorDataset):
         drop: bool = True,
         keep_original_index: bool = False,
         climb_descend_at_end: bool = False,
-    ) -> Flight:
+    ) -> Self:
         """Resample and (possibly) filter a flight trajectory.
 
         Waypoints are resampled according to the frequency ``freq``. If the original
@@ -1071,7 +1071,7 @@ class Flight(GeoVectorDataset):
         self,
         kernel_size: int = 17,
         cruise_threshold: float = 120.0,
-    ) -> Flight:
+    ) -> Self:
         """
         Filter noisy altitude on a single flight.
 

--- a/pycontrails/core/flight.py
+++ b/pycontrails/core/flight.py
@@ -2109,7 +2109,7 @@ def segment_phase(
 def segment_rocd(
     segment_duration: npt.NDArray[np.floating],
     altitude_ft: npt.NDArray[np.floating],
-    air_temperature: None | npt.NDArray[np.floating] = None,
+    air_temperature: npt.NDArray[np.floating] | None = None,
 ) -> npt.NDArray[np.floating]:
     """Calculate the rate of climb and descent (ROCD).
 
@@ -2117,11 +2117,11 @@ def segment_rocd(
     ----------
     segment_duration: npt.NDArray[np.floating]
         Time difference between waypoints, [:math:`s`].
-        Expected to have numeric `dtype`, not `"timedelta64"`.
+        Expected to have numeric ``dtype``, not ``np.timedelta64``.
         See output from :func:`segment_duration`.
     altitude_ft: npt.NDArray[np.floating]
         Altitude of each waypoint, [:math:`ft`]
-    air_temperature: None | npt.NDArray[np.floating]
+    air_temperature: npt.NDArray[np.floating] | None
         Air temperature of each flight waypoint, [:math:`K`]
 
     Returns
@@ -2131,7 +2131,7 @@ def segment_rocd(
 
     Notes
     -----
-    The hydrostatic equation will be used to estimate the ROCD if `air_temperature` is provided.
+    The hydrostatic equation will be used to estimate the ROCD if ``air_temperature`` is provided.
     This will improve the accuracy of the estimated ROCD with a temperature correction. The
     estimated ROCD with the temperature correction are expected to differ by up to +-5% compared to
     those without the correction. These differences are important when the ROCD estimates are used
@@ -2139,7 +2139,7 @@ def segment_rocd(
 
     See Also
     --------
-    :func:`segment_duration`
+    segment_duration
     """
     dt_min = segment_duration / 60.0
 

--- a/pycontrails/core/flight.py
+++ b/pycontrails/core/flight.py
@@ -1776,9 +1776,6 @@ def _altitude_interpolation(
         # Time to next waypoint
         dt_next = (time_end - time_start) / np.timedelta64(1, "m")
 
-        # Rate of climb and descent to next waypoint, in ft/min
-        rocd_next = (alt_ft_end - alt_ft_start) / dt_next
-
         # (1): Unrealistic scenario: first and next known waypoints are at very
         # low altitudes with a large time gap.
         is_unrealistic = (
@@ -1809,6 +1806,9 @@ def _altitude_interpolation(
         # (2): If both altitudes are the same, then skip entire operations below
         if alt_ft_start == alt_ft_end:
             continue
+
+        # Rate of climb and descent to next waypoint, in ft/min
+        rocd_next = (alt_ft_end - alt_ft_start) / dt_next
 
         # (3): If cruise over 2 h with small altitude change, set change to mid-point
         is_long_segment_small_altitude_change = (

--- a/pycontrails/core/flight.py
+++ b/pycontrails/core/flight.py
@@ -1855,7 +1855,7 @@ def _altitude_interpolation(
             idx_descent_start = np.where(
                 -250.0 < rocd_next < 0.0,
                 np.searchsorted(time, t_descent_start) - 1,
-                np.searchsorted(time, t_descent_start)
+                np.searchsorted(time, t_descent_start),
             )
 
             #: [Safeguard for very small `dt_next`] Ensure descent can be performed within the

--- a/pycontrails/core/flight.py
+++ b/pycontrails/core/flight.py
@@ -1722,9 +1722,11 @@ def _altitude_interpolation(
     nominal_rocd : float
         Nominal rate of climb/descent, [:math:`m s^{-1}`]
     minimum_cruise_altitude_ft : float
-        Minimium cruising altitude for a given aircraft type, [:math:`ft`]
+        Minimium cruising altitude for a given aircraft type, [:math:`ft`].
+        By default, this is 20000.0 ft.
     assumed_cruise_altitude_ft : float
-        Assumed cruising altitude for a given aircraft type, [:math:`ft`]
+        Assumed cruising altitude for a given aircraft type, [:math:`ft`].
+        By default, this is 30000.0 ft.
 
     Returns
     -------
@@ -1733,11 +1735,11 @@ def _altitude_interpolation(
 
     Notes
     -----
-    Default values for `minimum_cruise_altitude_ft` and `assumed_cruise_altitude_ft` should be
+    Default values for ``minimum_cruise_altitude_ft`` and ``assumed_cruise_altitude_ft`` should be
     provided if aircraft-specific parameters are available to improve the output quality.
 
-    We can assume `minimum_cruise_altitude_ft` as 0.5 times the aircraft service ceiling, and
-    `assumed_cruise_altitude_ft` as 0.8 times the aircraft service ceiling.
+    We can assume ``minimum_cruise_altitude_ft`` as 0.5 times the aircraft service ceiling, and
+    ``assumed_cruise_altitude_ft`` as 0.8 times the aircraft service ceiling.
 
     Assume that aircraft will generally prefer to climb to a higher altitude as early as possible,
     and descent to a lower altitude as late as possible, because a higher altitude can reduce

--- a/pycontrails/core/flight.py
+++ b/pycontrails/core/flight.py
@@ -1874,7 +1874,7 @@ def _verify_altitude(
     dalt = np.diff(altitude)
     dt = freq / np.timedelta64(1, "s")
     rocd = np.abs(dalt / dt)
-    if np.any(rocd > 2.0 * nominal_rocd):
+    if np.any(rocd > 2.5 * nominal_rocd):
         warnings.warn(
             "Rate of climb/descent values greater than nominal "
             f"({nominal_rocd} m/s) after altitude interpolation"

--- a/pycontrails/core/flight.py
+++ b/pycontrails/core/flight.py
@@ -1694,6 +1694,7 @@ def _sg_filter(
 def _altitude_interpolation(
     altitude: npt.NDArray[np.floating],
     time: npt.NDArray[np.datetime64],
+    nominal_rocd: float,
     minimum_cruise_altitude_ft: float = 20000.0,
     assumed_cruise_altitude_ft: float = 30000.0,
 ) -> npt.NDArray[np.floating]:
@@ -1742,7 +1743,7 @@ def _altitude_interpolation(
     """
     # Work in units of feet
     alt_ft = units.m_to_ft(altitude)
-    nominal_rocd_ft_min = units.m_to_ft(constants.nominal_rocd) * 60.0
+    nominal_rocd_ft_min = units.m_to_ft(nominal_rocd) * 60.0
 
     # Determine nan state of altitude
     isna = np.isnan(alt_ft)

--- a/pycontrails/core/flight.py
+++ b/pycontrails/core/flight.py
@@ -943,10 +943,7 @@ class Flight(GeoVectorDataset):
         altitude = df["altitude"].to_numpy()
         time = df.index.to_numpy()
         if np.any(np.isnan(altitude)):
-            df_freq = pd.Timedelta(freq).to_numpy()
-            new_alt = _altitude_interpolation(altitude, time)
-            _verify_altitude(new_alt, nominal_rocd, df_freq)
-            df["altitude"] = new_alt
+            df["altitude"] = _altitude_interpolation(altitude, time, nominal_rocd)
 
         # Remove original index if requested
         if not keep_original_index:

--- a/pycontrails/core/flight.py
+++ b/pycontrails/core/flight.py
@@ -1874,7 +1874,7 @@ def _altitude_interpolation(
 def _verify_altitude(
     altitude: npt.NDArray[np.floating], nominal_rocd: float, freq: np.timedelta64
 ) -> None:
-    """Confirm that the time derivative of `altitude` does not exceed twice `nominal_rocd`.
+    """Confirm that the time derivative of ``altitude`` does not exceed twice ``nominal_rocd``.
 
     Parameters
     ----------
@@ -1888,7 +1888,7 @@ def _verify_altitude(
     dalt = np.diff(altitude)
     dt = freq / np.timedelta64(1, "s")
     rocd = np.abs(dalt / dt)
-    if np.any(rocd > 2.5 * nominal_rocd):
+    if np.any(rocd > 3.0 * nominal_rocd):
         warnings.warn(
             "Rate of climb/descent values greater than nominal "
             f"({nominal_rocd} m/s) after altitude interpolation"

--- a/pycontrails/core/flight.py
+++ b/pycontrails/core/flight.py
@@ -1037,7 +1037,6 @@ class Flight(GeoVectorDataset):
                 nominal_rocd,
                 drop,
                 keep_original_index,
-                climb_descend_at_end,
             )
 
         # If the flight has large gap(s), then call resample and fill, then filter altitude
@@ -1053,7 +1052,6 @@ class Flight(GeoVectorDataset):
                     nominal_rocd,
                     drop,
                     keep_original_index,
-                    climb_descend_at_end,
                 )
             clean_flight = clean_flight.filter_altitude(kernel_size, cruise_threshold)
         else:
@@ -1067,7 +1065,6 @@ class Flight(GeoVectorDataset):
             nominal_rocd,
             drop,
             keep_original_index,
-            climb_descend_at_end,
         )
 
     def filter_altitude(

--- a/pycontrails/models/cocip/cocip.py
+++ b/pycontrails/models/cocip/cocip.py
@@ -660,7 +660,7 @@ class Cocip(Model):
             attrs = self.source.attrs
             attrs.pop("fl_attrs", None)
             attrs.pop("data_keys", None)
-            self.source = Fleet.from_seq(fls, broadcast_numeric=False, copy=False, attrs=attrs)
+            self.source = Fleet.from_seq(fls, broadcast_numeric=False, attrs=attrs)
 
         # Single flight
         else:

--- a/tests/unit/test_cocip.py
+++ b/tests/unit/test_cocip.py
@@ -1071,7 +1071,7 @@ def fleet(met: MetDataset) -> Fleet:
         )
         fls.append(fl)
 
-    return Fleet.from_seq(fls, copy=False, broadcast_numeric=False)
+    return Fleet.from_seq(fls, broadcast_numeric=False)
 
 
 @pytest.mark.filterwarnings("ignore:.*the contrail has no intersection with the met")

--- a/tests/unit/test_cocip.py
+++ b/tests/unit/test_cocip.py
@@ -1334,6 +1334,8 @@ def test_cocip_fleet(fl: Flight, met: MetDataset, rad: MetDataset):
     initial_keys = set(fl)
     fls = [fl.copy() for _ in range(10)]
     del fl  # we don't want to accidentally use this below
+    for i, fl in enumerate(fls):
+        fl.attrs.update(flight_id=f"test_{i}")
 
     cocip = Cocip(
         met=met,
@@ -1341,8 +1343,7 @@ def test_cocip_fleet(fl: Flight, met: MetDataset, rad: MetDataset):
         process_emissions=False,
         humidity_scaling=ExponentialBoostHumidityScaling(),
     )
-    with pytest.raises(ValueError, match="Duplicate 'flight_id'"):
-        cocip.eval(fls)
+    cocip.eval(fls)
 
     # confirm nothing has been mutated (using default copy=True)
     for fl in fls:

--- a/tests/unit/test_flight.py
+++ b/tests/unit/test_flight.py
@@ -488,7 +488,7 @@ def test_altitude_interpolation(fl: Flight) -> None:
 
     # Takes less than 10 minutes to descent to next recorded altitude (Nominal ROCD = 2500 ft/min)
     index_sep = np.argwhere(fl13["time"] == pd.to_datetime("2000-01-01 00:50:00"))[0][0]
-    np.testing.assert_array_almost_equal(fl13.altitude_ft[: index_sep + 1], 30000.0, decimal=0)
+    np.testing.assert_array_almost_equal(fl13.altitude_ft[: index_sep], 30000.0, decimal=0)
     assert _check_rocd(fl13)
 
     # SCENARIO 5: If shallow descent (-250 < rocd < 0 ft/min), then assume descent in last step.
@@ -501,7 +501,7 @@ def test_altitude_interpolation(fl: Flight) -> None:
         altitude=units.ft_to_m(alt_ft),
     )
     fl14 = fl_alt.resample_and_fill("1min")
-    np.testing.assert_array_almost_equal(fl14.altitude_ft[:-6], 31000.0, decimal=0)
+    np.testing.assert_array_almost_equal(fl14.altitude_ft[:5], 31000.0, decimal=0)
     np.testing.assert_array_almost_equal(fl14.altitude_ft[-6:], 30000.0, decimal=0)
     assert _check_rocd(fl14)
 

--- a/tests/unit/test_flight.py
+++ b/tests/unit/test_flight.py
@@ -548,11 +548,6 @@ def test_altitude_interpolation(fl: Flight) -> None:
     fl17 = fl_alt.resample_and_fill("1min", nominal_rocd=30)
     assert _check_rocd(fl17, nominal_rocd=30)
 
-    # test warning with low nominal rocd
-    with pytest.warns(UserWarning, match="Rate of climb/descent values greater than nominal"):
-        fl18 = fl_alt.resample_and_fill("1min", nominal_rocd=1)
-        assert not _check_rocd(fl18, nominal_rocd=1)
-
     # test `drop` kwarg
     fl_alt["extrakey"] = np.linspace(0, 10, 10)
     fl_alt["level"] = fl_alt.level

--- a/tests/unit/test_flight.py
+++ b/tests/unit/test_flight.py
@@ -488,7 +488,7 @@ def test_altitude_interpolation(fl: Flight) -> None:
 
     # Takes less than 10 minutes to descent to next recorded altitude (Nominal ROCD = 2500 ft/min)
     index_sep = np.argwhere(fl13["time"] == pd.to_datetime("2000-01-01 00:50:00"))[0][0]
-    np.testing.assert_array_almost_equal(fl13.altitude_ft[: index_sep], 30000.0, decimal=0)
+    np.testing.assert_array_almost_equal(fl13.altitude_ft[:index_sep], 30000.0, decimal=0)
     assert _check_rocd(fl13)
 
     # SCENARIO 5: If shallow descent (-250 < rocd < 0 ft/min), then assume descent in last step.

--- a/tests/unit/test_flight.py
+++ b/tests/unit/test_flight.py
@@ -441,7 +441,7 @@ def test_altitude_interpolation(fl: Flight) -> None:
     fl10 = fl_alt.resample_and_fill("1min")
     index_sep = np.argwhere(fl10["time"] == pd.to_datetime("2000-01-01 02:00:00"))[0][0]
     np.testing.assert_array_almost_equal(fl10.altitude_ft[:index_sep], 35000.0, decimal=0)
-    np.testing.assert_array_almost_equal(fl10.altitude_ft[index_sep + 1:], 36000.0, decimal=0)
+    np.testing.assert_array_almost_equal(fl10.altitude_ft[index_sep + 1 :], 36000.0, decimal=0)
     assert _check_rocd(fl10)
 
     # SCENARIO 2: If large time gap and altitude difference, climb until desired altitude and cruise
@@ -458,7 +458,7 @@ def test_altitude_interpolation(fl: Flight) -> None:
 
     # Takes around 10 minutes to climb to next recorded altitude (Nominal ROCD = 2500 ft/min)
     index_sep = np.argwhere(fl11["time"] == pd.to_datetime("2000-01-01 00:10:00"))[0][0]
-    np.testing.assert_array_almost_equal(fl11.altitude_ft[index_sep + 1:], 30000.0, decimal=0)
+    np.testing.assert_array_almost_equal(fl11.altitude_ft[index_sep + 1 :], 30000.0, decimal=0)
     assert _check_rocd(fl11)
 
     # SCENARIO 3: If shallow climb (0 < rocd < 500 ft/min), assume climb in next time step
@@ -488,7 +488,7 @@ def test_altitude_interpolation(fl: Flight) -> None:
 
     # Takes less than 10 minutes to descent to next recorded altitude (Nominal ROCD = 2500 ft/min)
     index_sep = np.argwhere(fl13["time"] == pd.to_datetime("2000-01-01 00:50:00"))[0][0]
-    np.testing.assert_array_almost_equal(fl13.altitude_ft[:index_sep + 1], 30000.0, decimal=0)
+    np.testing.assert_array_almost_equal(fl13.altitude_ft[: index_sep + 1], 30000.0, decimal=0)
     assert _check_rocd(fl13)
 
     # SCENARIO 5: If shallow descent (-250 < rocd < 0 ft/min), then assume descent in last step.
@@ -520,7 +520,7 @@ def test_altitude_interpolation(fl: Flight) -> None:
     index_sep_1 = np.argwhere(fl15["time"] == pd.to_datetime("2000-01-01 00:10:00"))[0][0]
     index_sep_2 = np.argwhere(fl15["time"] == pd.to_datetime("2000-01-01 00:50:00"))[0][0]
     np.testing.assert_array_almost_equal(
-        fl15.altitude_ft[index_sep_1 + 1:index_sep_2], 30000.0, decimal=0
+        fl15.altitude_ft[index_sep_1 + 1 : index_sep_2], 30000.0, decimal=0
     )
     assert _check_rocd(fl15)
 


### PR DESCRIPTION
Closes #XX

## Changes

Improve `_altitude_interpolation` function in `resample_and_fill` and ensure it is consistent with the existing GAIA publication (Teoh et al., 2024)

#### Breaking changes

#### Features

#### Fixes

#### Internals

The function `_altitude_interpolation` now accounts for various scenarios. For example: 
1. Flight will automatically climb to an assumed cruise altitude if the first and next known waypoints are at very low altitudes with a large time gap, 
2. If there are large time gaps between known waypoints with a small altitude difference, then the flight will climb at the mid-point
3. If there are large time gaps and positive altitude difference, then the flight will climb at the start of its interpolation until the known cruising altitude and start its cruise phase. 
4. If there are large time gaps and negative altitude difference, then the flight will continue cruising and only starts to descent towards the end of the interpolation. 
5. If there is a shallow climb (ROCD < 500 ft/min), then always assume that the flight will climb at the next time step 
6. If there is a shallow descent (-250 < ROCD < 0 ft/min), then always assume that the flight will descent at the final time step 

Conditions (3) to (6) is based on the logic that the aircraft will generally prefer to climb to a higher altitude as early as possible, and descent to a lower altitude as late as possible, because a higher altitude can reduce drag and fuel consumption.

Therefore, the optional input parameter `climb_descend_at_end` is no longer needed. 

## Tests

- [ ] QC test passes locally (`make test`)
- [ ] CI tests pass

## Reviewer

> Select @ reviewer
