### PR TITLE
engine-deterioration-updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
 - Publish to PyPI using [trusted publishing](https://docs.pypi.org/trusted-publishers/using-a-publisher/).
 - Update `pycontrails-bada` installation instructions.
 - Floor the pycontrails version when running the docs workflow. This ensures that the [hosted documentation](https://py.contrails.org) references the last stable release.
+- Move the `engine_deterioration_factor` from `PSFlightParams` to `AircraftPerformanceParams` so it can be used by both the PS model and BADA.
+- Include `engine_deterioration_factor` in `AircraftPerformanceGridParams`.
 
 ## v0.54.2
 

--- a/pycontrails/core/aircraft_performance.py
+++ b/pycontrails/core/aircraft_performance.py
@@ -35,12 +35,8 @@ DEFAULT_LOAD_FACTOR = 0.7
 
 
 @dataclasses.dataclass
-class AircraftPerformanceParams(ModelParams):
-    """Parameters for :class:`AircraftPerformance`."""
-
-    #: Whether to correct fuel flow to ensure it remains within
-    #: the operational limits of the aircraft type.
-    correct_fuel_flow: bool = True
+class CommonAircraftPerformanceParams:
+    """Params for :class:`AircraftPerformanceParams` and :class`AircraftPerformanceGridParams`."""
 
     #: Account for "in-service" engine deterioration between maintenance cycles.
     #: Default value is set to +2.5% increase in fuel consumption.
@@ -48,6 +44,15 @@ class AircraftPerformanceParams(ModelParams):
     # Gurrola Arrieta, M.D.J., Botez, R.M. and Lasne, A., 2024. An Engine Deterioration Model for
     # Predicting Fuel Consumption Impact in a Regional Aircraft. Aerospace, 11(6), p.426.
     engine_deterioration_factor: float = 0.025
+
+
+@dataclasses.dataclass
+class AircraftPerformanceParams(ModelParams, CommonAircraftPerformanceParams):
+    """Parameters for :class:`AircraftPerformance`."""
+
+    #: Whether to correct fuel flow to ensure it remains within
+    #: the operational limits of the aircraft type.
+    correct_fuel_flow: bool = True
 
     #: The number of iterations used to calculate aircraft mass and fuel flow.
     #: The default value of 3 is sufficient for most cases.
@@ -554,7 +559,7 @@ class AircraftPerformanceData:
 
 
 @dataclasses.dataclass
-class AircraftPerformanceGridParams(ModelParams):
+class AircraftPerformanceGridParams(ModelParams, CommonAircraftPerformanceParams):
     """Parameters for :class:`AircraftPerformanceGrid`."""
 
     #: Fuel type

--- a/pycontrails/core/aircraft_performance.py
+++ b/pycontrails/core/aircraft_performance.py
@@ -42,6 +42,13 @@ class AircraftPerformanceParams(ModelParams):
     #: the operational limits of the aircraft type.
     correct_fuel_flow: bool = True
 
+    #: Account for "in-service" engine deterioration between maintenance cycles.
+    #: Default value is set to +2.5% increase in fuel consumption.
+    # Reference:
+    # Gurrola Arrieta, M.D.J., Botez, R.M. and Lasne, A., 2024. An Engine Deterioration Model for
+    # Predicting Fuel Consumption Impact in a Regional Aircraft. Aerospace, 11(6), p.426.
+    engine_deterioration_factor: float = 0.025
+
     #: The number of iterations used to calculate aircraft mass and fuel flow.
     #: The default value of 3 is sufficient for most cases.
     n_iter: int = 3

--- a/pycontrails/models/ps_model/ps_aircraft_params.py
+++ b/pycontrails/models/ps_model/ps_aircraft_params.py
@@ -11,6 +11,7 @@ from typing import Any
 import numpy as np
 import pandas as pd
 
+from pycontrails.core.aircraft_performance import AircraftPerformanceParams
 from pycontrails.physics import constants as c
 
 #: Path to the Poll-Schumann aircraft parameters CSV file.
@@ -193,7 +194,7 @@ def _row_to_aircraft_engine_params(tup: Any) -> tuple[str, PSAircraftEngineParam
 
 @functools.cache
 def load_aircraft_engine_params(
-    engine_deterioration_factor: float = 0.025,
+    engine_deterioration_factor: float = AircraftPerformanceParams.engine_deterioration_factor,
 ) -> Mapping[str, PSAircraftEngineParams]:
     """
     Extract aircraft-engine parameters for each aircraft type supported by the PS model.
@@ -254,7 +255,7 @@ def load_aircraft_engine_params(
     }
 
     df = pd.read_csv(PS_FILE_PATH, dtype=dtypes)
-    df["eta_1"] = df["eta_1"] * (1.0 - engine_deterioration_factor)
+    df["eta_1"] *= 1.0 - engine_deterioration_factor
 
     return dict(_row_to_aircraft_engine_params(tup) for tup in df.itertuples(index=False))
 

--- a/pycontrails/models/ps_model/ps_grid.py
+++ b/pycontrails/models/ps_model/ps_grid.py
@@ -333,6 +333,7 @@ def ps_nominal_grid(
     q_fuel: float = JetA.q_fuel,
     mach_number: float | None = None,
     maxiter: int = PSGridParams.maxiter,
+    engine_deterioration_factor: float = PSGridParams.engine_deterioration_factor,
 ) -> xr.Dataset:
     """Calculate the nominal performance grid for a given aircraft type.
 
@@ -359,6 +360,9 @@ def ps_nominal_grid(
         The Mach number. If None (default), the PS design Mach number is used.
     maxiter : int, optional
         Passed into :func:`scipy.optimize.newton`.
+    engine_deterioration_factor : float, optional
+        The engine deterioration factor,
+        by default :attr:`PSGridParams.engine_deterioration_factor`.
 
     Returns
     -------
@@ -428,7 +432,7 @@ def ps_nominal_grid(
 
     air_pressure = level * 100.0
 
-    aircraft_engine_params = ps_model.load_aircraft_engine_params()
+    aircraft_engine_params = ps_model.load_aircraft_engine_params(engine_deterioration_factor)
 
     try:
         atyp_param = aircraft_engine_params[aircraft_type]
@@ -542,6 +546,7 @@ def ps_nominal_optimize_mach(
     sin_a: ArrayOrFloat | None = None,
     cos_a: ArrayOrFloat | None = None,
     q_fuel: float = JetA.q_fuel,
+    engine_deterioration_factor: float = PSGridParams.engine_deterioration_factor,
 ) -> xr.Dataset:
     """Calculate the nominal optimal mach number for a given aircraft type.
 
@@ -580,6 +585,9 @@ def ps_nominal_optimize_mach(
         specified if wind data is provided. Will be ignored if wind data is not provided.
     q_fuel : float, optional
         The fuel heating value, by default :attr:`JetA.q_fuel`.
+    engine_deterioration_factor : float, optional
+        The engine deterioration factor,
+        by default :attr:`PSGridParams.engine_deterioration_factor`.
 
     Returns
     -------
@@ -602,7 +610,7 @@ def ps_nominal_optimize_mach(
     """
     dims = ("level",)
     coords = {"level": level}
-    aircraft_engine_params = ps_model.load_aircraft_engine_params()
+    aircraft_engine_params = ps_model.load_aircraft_engine_params(engine_deterioration_factor)
     try:
         atyp_param = aircraft_engine_params[aircraft_type]
     except KeyError as exc:

--- a/pycontrails/models/ps_model/ps_model.py
+++ b/pycontrails/models/ps_model/ps_model.py
@@ -51,13 +51,6 @@ class PSFlightParams(AircraftPerformanceParams):
     #: efficiency to always exceed this value.
     eta_over_eta_b_min: float | None = 0.5
 
-    #: Account for "in-service" engine deterioration between maintenance cycles.
-    #: Default value is set to +2.5% increase in fuel consumption.
-    # Reference:
-    # Gurrola Arrieta, M.D.J., Botez, R.M. and Lasne, A., 2024. An Engine Deterioration Model for
-    # Predicting Fuel Consumption Impact in a Regional Aircraft. Aerospace, 11(6), p.426.
-    engine_deterioration_factor: float = 0.025
-
 
 class PSFlight(AircraftPerformance):
     """Simulate aircraft performance using Poll-Schumann (PS) model.


### PR DESCRIPTION
Closes #XX

## Changes

- Implement changes to be align with the latest pycontrails-bada branch (Feature/degradation effects)

#### Breaking changes

#### Features

#### Fixes

#### Internals

- Move `engine_deterioration_factor` from `PSFlightParams` to `AircraftPerformanceParams` so it can be used by both the PS model and BADA. 

## Tests

- [ ] QC test passes locally (`make test`)
- [ ] CI tests pass

## Reviewer

> Select @ reviewer
