### PR TITLE
Feature/polar advection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
 
 - Create new function `ps_nominal_optimize_mach` which computes the optimal mach number given a set of operating conditions.
 - Add a new `jet.aircraft_load_factor` function to estimate aircraft (passenger/cargo) load factor based on historical monthly and regional load factors provided by IATA. This improves upon the default load factor assumption. Historical load factor databases will be continuously updated as new data is released.
+- Use a 2D Cartesian-like plane to advect particles near the poles (>80° in latitude) to avoid numerical instabilities and singularities caused by convergence of meridians. This new advection scheme is used for contrail advection in the `Cocip`, `CocipGrid`, and `DryAdvection` models. See the `geo.advect_horizontal` function for more details.
+
+### Breaking changes
+
+- By default, the `CocipGrid.create_source` static method will return latitude values from -90 to 90 degrees. This change is motivated by the new advection scheme used near the poles. Previously, this method returned latitude values from -80 to 80 degrees.
 
 ### Fixes
 

--- a/pycontrails/models/cocip/cocip.py
+++ b/pycontrails/models/cocip/cocip.py
@@ -2296,26 +2296,9 @@ def calc_timestep_contrail_evolution(
     dt = time_2_array - time_1
 
     # get new contrail location & segment properties after t_step
-
-    # Use simple spherical advection if position is far from the poles (<= 80.0 degrees)
-    longitude_2 = geo.advect_longitude(longitude_1, latitude_1, u_wind_1, dt)
-    latitude_2 = geo.advect_latitude(latitude_1, v_wind_1, dt)
+    longitude_2, latitude_2 = geo.advect_horizontal(longitude_1, latitude_1, u_wind_1, v_wind_1, dt)
     level_2 = geo.advect_level(level_1, vertical_velocity_1, rho_air_1, terminal_fall_speed_1, dt)
     altitude_2 = units.pl_to_m(level_2)
-
-    # Use Cartesian advection if position is near the poles (> 80.0 degrees)
-    near_the_poles = np.abs(latitude_1) > 80.0
-    if np.any(near_the_poles):
-        lon_2_poles, lat_2_poles = geo.advect_longitude_and_latitude_near_poles(
-            longitude_1[near_the_poles],
-            latitude_1[near_the_poles],
-            u_wind_1[near_the_poles],
-            v_wind_1[near_the_poles],
-            dt[near_the_poles],
-        )
-
-        longitude_2[near_the_poles] = lon_2_poles
-        latitude_2[near_the_poles] = lat_2_poles
 
     contrail_2 = GeoVectorDataset(
         {

--- a/pycontrails/models/cocip/cocip.py
+++ b/pycontrails/models/cocip/cocip.py
@@ -2296,7 +2296,7 @@ def calc_timestep_contrail_evolution(
     dt = time_2_array - time_1
 
     # get new contrail location & segment properties after t_step
-    
+
     # Use simple spherical advection if position is far from the poles (<= 80.0 degrees)
     longitude_2 = geo.advect_longitude(longitude_1, latitude_1, u_wind_1, dt)
     latitude_2 = geo.advect_latitude(latitude_1, v_wind_1, dt)
@@ -2306,7 +2306,7 @@ def calc_timestep_contrail_evolution(
     # Use Cartesian advection if position is near the poles (> 80.0 degrees)
     near_the_poles = np.abs(latitude_1) > 80.0
     if np.any(near_the_poles):
-        lon_2_poles, lat_2_poles = geo.advect_longitude_and_latitude_at_poles(
+        lon_2_poles, lat_2_poles = geo.advect_longitude_and_latitude_near_poles(
             longitude_1[near_the_poles],
             latitude_1[near_the_poles],
             u_wind_1[near_the_poles],

--- a/pycontrails/models/cocip/cocip.py
+++ b/pycontrails/models/cocip/cocip.py
@@ -2296,10 +2296,26 @@ def calc_timestep_contrail_evolution(
     dt = time_2_array - time_1
 
     # get new contrail location & segment properties after t_step
+    
+    # Use simple spherical advection if position is far from the poles (<= 80.0 degrees)
     longitude_2 = geo.advect_longitude(longitude_1, latitude_1, u_wind_1, dt)
     latitude_2 = geo.advect_latitude(latitude_1, v_wind_1, dt)
     level_2 = geo.advect_level(level_1, vertical_velocity_1, rho_air_1, terminal_fall_speed_1, dt)
     altitude_2 = units.pl_to_m(level_2)
+
+    # Use Cartesian advection if position is near the poles (> 80.0 degrees)
+    near_the_poles = np.abs(latitude_1) > 80.0
+    if np.any(near_the_poles):
+        lon_2_poles, lat_2_poles = geo.advect_longitude_and_latitude_at_poles(
+            longitude_1[near_the_poles],
+            latitude_1[near_the_poles],
+            u_wind_1[near_the_poles],
+            v_wind_1[near_the_poles],
+            dt[near_the_poles],
+        )
+
+        longitude_2[near_the_poles] = lon_2_poles
+        latitude_2[near_the_poles] = lat_2_poles
 
     contrail_2 = GeoVectorDataset(
         {

--- a/pycontrails/models/cocipgrid/cocip_grid.py
+++ b/pycontrails/models/cocipgrid/cocip_grid.py
@@ -2054,10 +2054,13 @@ def advect(
     time_t2 = time + dt
     age_t2 = age + dt
 
-    longitude_t2 = geo.advect_longitude(
-        longitude=longitude, latitude=latitude, u_wind=u_wind, dt=dt
+    longitude_t2, latitude_t2 = geo.advect_horizontal(
+        longitude=longitude,
+        latitude=latitude,
+        u_wind=u_wind,
+        v_wind=v_wind,
+        dt=dt,
     )
-    latitude_t2 = geo.advect_latitude(latitude=latitude, v_wind=v_wind, dt=dt)
     level_t2 = geo.advect_level(level, vertical_velocity, rho_air, terminal_fall_speed, dt)
     altitude_t2 = units.pl_to_m(level_t2)
 
@@ -2089,15 +2092,20 @@ def advect(
     u_wind_tail = contrail["eastward_wind_tail"]
     v_wind_tail = contrail["northward_wind_tail"]
 
-    longitude_head_t2 = geo.advect_longitude(
-        longitude=longitude_head, latitude=latitude_head, u_wind=u_wind_head, dt=dt_head
+    longitude_head_t2, latitude_head_t2 = geo.advect_horizontal(
+        longitude=longitude_head,
+        latitude=latitude_head,
+        u_wind=u_wind_head,
+        v_wind=v_wind_head,
+        dt=dt_head,
     )
-    latitude_head_t2 = geo.advect_latitude(latitude=latitude_head, v_wind=v_wind_head, dt=dt_head)
-
-    longitude_tail_t2 = geo.advect_longitude(
-        longitude=longitude_tail, latitude=latitude_tail, u_wind=u_wind_tail, dt=dt_tail
+    longitude_tail_t2, latitude_tail_t2 = geo.advect_horizontal(
+        longitude=longitude_tail,
+        latitude=latitude_tail,
+        u_wind=u_wind_tail,
+        v_wind=v_wind_tail,
+        dt=dt_tail,
     )
-    latitude_tail_t2 = geo.advect_latitude(latitude=latitude_tail, v_wind=v_wind_tail, dt=dt_tail)
 
     segment_length_t2 = geo.haversine(
         lons0=longitude_head_t2,

--- a/pycontrails/models/cocipgrid/cocip_grid.py
+++ b/pycontrails/models/cocipgrid/cocip_grid.py
@@ -816,6 +816,9 @@ class CocipGrid(models.Model):
         """
         Shortcut to create a :class:`MetDataset` source from coordinate arrays.
 
+        .. versionchanged:: 0.54.3
+            By default, the returned latitude values now extend to the poles.
+
         Parameters
         ----------
         level : level: npt.NDArray[np.float64] | list[float] | float
@@ -829,8 +832,6 @@ class CocipGrid(models.Model):
         longitude, latitude : npt.NDArray[np.float64] | list[float], optional
             Longitude and latitude arrays, by default None. If not specified, values of
             ``lon_step`` and ``lat_step`` are used to define ``longitude`` and ``latitude``.
-            To avoid model degradation at the poles, latitude values are expected to be
-            between -80 and 80 degrees.
         lon_step, lat_step : float, optional
             Longitude and latitude resolution, by default 1.0.
             Only used if parameter ``longitude`` (respective ``latitude``) not specified.
@@ -847,15 +848,11 @@ class CocipGrid(models.Model):
         if longitude is None:
             longitude = np.arange(-180, 180, lon_step, dtype=float)
         if latitude is None:
-            latitude = np.arange(-80, 80.000001, lat_step, dtype=float)
+            latitude = np.arange(-90, 90.000001, lat_step, dtype=float)
 
-        out = MetDataset.from_coords(longitude=longitude, latitude=latitude, level=level, time=time)
-
-        if np.any(out.data.latitude > 80.0001) or np.any(out.data.latitude < -80.0001):
-            msg = "Model only supports latitude between -80 and 80."
-            raise ValueError(msg)
-
-        return out
+        return MetDataset.from_coords(
+            longitude=longitude, latitude=latitude, level=level, time=time
+        )
 
 
 ################################

--- a/pycontrails/models/dry_advection.py
+++ b/pycontrails/models/dry_advection.py
@@ -404,15 +404,20 @@ def _calc_geometry(
     u_wind_tail = vector.data.pop("eastward_wind_tail")
     v_wind_tail = vector.data.pop("northward_wind_tail")
 
-    longitude_head_t2 = geo.advect_longitude(
-        longitude=longitude_head, latitude=latitude_head, u_wind=u_wind_head, dt=dt
+    longitude_head_t2, latitude_head_t2 = geo.advect_horizontal(
+        longitude=longitude_head,
+        latitude=latitude_head,
+        u_wind=u_wind_head,
+        v_wind=v_wind_head,
+        dt=dt,
     )
-    latitude_head_t2 = geo.advect_latitude(latitude=latitude_head, v_wind=v_wind_head, dt=dt)
-
-    longitude_tail_t2 = geo.advect_longitude(
-        longitude=longitude_tail, latitude=latitude_tail, u_wind=u_wind_tail, dt=dt
+    longitude_tail_t2, latitude_tail_t2 = geo.advect_horizontal(
+        longitude=longitude_tail,
+        latitude=latitude_tail,
+        u_wind=u_wind_tail,
+        v_wind=v_wind_tail,
+        dt=dt,
     )
-    latitude_tail_t2 = geo.advect_latitude(latitude=latitude_tail, v_wind=v_wind_tail, dt=dt)
 
     azimuth_2 = geo.azimuth(
         lons0=longitude_tail_t2,
@@ -445,8 +450,7 @@ def _evolve_one_step(
     longitude = vector["longitude"]
 
     dt = t - vector["time"]
-    longitude_2 = geo.advect_longitude(longitude, latitude, u_wind, dt)  # type: ignore[arg-type]
-    latitude_2 = geo.advect_latitude(latitude, v_wind, dt)  # type: ignore[arg-type]
+    longitude_2, latitude_2 = geo.advect_horizontal(longitude, latitude, u_wind, v_wind, dt)  # type: ignore[arg-type]
     level_2 = geo.advect_level(
         vector.level,
         vertical_velocity,

--- a/pycontrails/physics/geo.py
+++ b/pycontrails/physics/geo.py
@@ -862,8 +862,10 @@ def advect_longitude_and_latitude_near_poles(
     v_wind: ArrayLike,
     dt: npt.NDArray[np.timedelta64] | np.timedelta64,
 ) -> tuple[ArrayLike, ArrayLike]:
-    r"""Calculate the longitude and latitude of a particle after time `dt` caused by advection
-    due to wind near the poles (above 80 degrees North and South).
+    r"""Advect a particle near the poles.
+
+    This function calculates the longitude and latitude of a particle after time ``dt``
+    caused by advection due to wind near the poles (above 80 degrees North and South).
 
     Automatically wrap over the antimeridian if necessary.
 
@@ -917,7 +919,7 @@ def advect_longitude_and_latitude_near_poles(
     y_cartesian_new = y_cartesian + dt_s * y_wind
 
     # Convert `y_cartesian_new` back to `latitude`, [:math:`\deg`]
-    dist_squared = x_cartesian_new ** 2 + y_cartesian_new ** 2
+    dist_squared = x_cartesian_new**2 + y_cartesian_new**2
     new_latitude = (90.0 - np.sqrt(dist_squared)) * hemisphere_sign
 
     # Convert `x_cartesian_new` back to `longitude`, [:math:`\deg`]
@@ -928,7 +930,7 @@ def advect_longitude_and_latitude_near_poles(
         longitude,
         90.0 + units.radians_to_degrees(new_lon_rad) * hemisphere_sign,
     )
-    #new_longitude = 90.0 + units.radians_to_degrees(new_lon_rad) * hemisphere_sign
+    # new_longitude = 90.0 + units.radians_to_degrees(new_lon_rad) * hemisphere_sign
     new_longitude = (new_longitude + 180.0) % 360.0 - 180.0  # wrap antimeridian
     return new_longitude, new_latitude
 

--- a/tests/unit/test_cocip_grid.py
+++ b/tests/unit/test_cocip_grid.py
@@ -135,23 +135,12 @@ def test_met_too_short(
         gc._check_met_covers_source()
 
 
-def test_create_bad_latitude() -> None:
-    """Check that an error is raised when latitude values are too close to the poles."""
-    with pytest.raises(ValueError, match="latitude"):
-        CocipGrid.create_source(
-            level=[220, 230, 240, 250],
-            time=np.datetime64("2019-01-01"),
-            longitude=np.linspace(-35, -25, 40),
-            latitude=np.asarray([83, 85, 86]),
-        )
-
-
 def test_create_lon_lat_unspecified() -> None:
     """Ensure `CocipGrid` uses `lon_step` and `lat_step` of 1."""
     source = CocipGrid.create_source(level=[220, 250], time=np.datetime64("2019-01-01"))
     assert source.data["longitude"].size == 360
-    assert source.data["latitude"].size == 161  # -80 to 80
-    assert source.shape == (360, 161, 2, 1)
+    assert source.data["latitude"].size == 181  # -90 to 90
+    assert source.shape == (360, 181, 2, 1)
 
 
 def test_create_lon_lat_step_args() -> None:
@@ -163,8 +152,8 @@ def test_create_lon_lat_step_args() -> None:
         lat_step=5,
     )
     assert source.data["longitude"].size == 72
-    assert source.data["latitude"].size == 33
-    assert source.shape == (72, 33, 4, 1)
+    assert source.data["latitude"].size == 37
+    assert source.shape == (72, 37, 4, 1)
 
 
 def test_init_avoid_double_process(instance_params: dict[str, Any]) -> None:

--- a/tests/unit/test_geo.py
+++ b/tests/unit/test_geo.py
@@ -281,3 +281,22 @@ def test_azimuth(geod: pyproj.Geod, rand_geo_data: dict[str, np.ndarray]):
 
     np.testing.assert_array_almost_equal(sin_azimuth, cos_a, decimal=10)
     np.testing.assert_array_almost_equal(cos_azimuth, sin_a, decimal=10)
+
+
+def test_advection_near_poles():
+    longitude = np.array([0.0, -90.0, 45.0, 70.0, 70.0, 45.0])
+    latitude = np.array([90.0, 85.0, 82.0, 90.0, -89.0, 82.0])
+    u_wind = np.array([0.0, 0.0, 20.0, 20.0, 20.0, -20.0])
+    v_wind = np.array([0.0, 0.0, 20.0, 20.0, 20.0, -20.0])
+    dt = np.timedelta64(300, "s")
+
+    longitude_new, latitude_new = geo.advect_longitude_and_latitude_near_poles(
+        longitude, latitude, u_wind, v_wind, dt
+    )
+
+    lon_new_expected = np.array([0.0, -90.0, 45.39, -155.0, 72.93, 44.62])
+    lat_new_expected = np.array([90.0, 85.0, 82.05, 89.92, -88.94, 81.95])
+    np.testing.assert_array_almost_equal(longitude_new, lon_new_expected, decimal=2)
+    np.testing.assert_array_almost_equal(latitude_new, lat_new_expected, decimal=2)
+    return
+

--- a/tests/unit/test_geo.py
+++ b/tests/unit/test_geo.py
@@ -298,5 +298,3 @@ def test_advection_near_poles():
     lat_new_expected = np.array([90.0, 85.0, 82.05, 89.92, -88.94, 81.95])
     np.testing.assert_array_almost_equal(longitude_new, lon_new_expected, decimal=2)
     np.testing.assert_array_almost_equal(latitude_new, lat_new_expected, decimal=2)
-    return
-


### PR DESCRIPTION
Closes #XX

## Changes

- Use a 2-D Cartesian-like plane to advect contrails near the poles (>80° in latitude) to avoid numerical instabilities and singularities caused by convergence of meridians. This makes it consistent with the implementation of CoCiP Fortran. 

#### Breaking changes

#### Features

#### Fixes

#### Internals

## Tests

- [ ] QC test passes locally (`make test`)
- [ ] CI tests pass

## Reviewer

> Select @ reviewer
