### PR TITLE
ERA5 fix to allow pressure-levels data with one pressure level

### DIFF
--- a/pycontrails/datalib/ecmwf/era5.py
+++ b/pycontrails/datalib/ecmwf/era5.py
@@ -539,9 +539,9 @@ class ERA5(ECMWFAPI):
             LOG.debug("Input dataset processed with pycontrails > 0.29")
             return ds
 
-        # For "reanalysis-era5-single-levels" or if self.pressure_levels length == 1,
+        # For "reanalysis-era5-single-levels"
         # then the netcdf file does not contain the dimension "level"
-        if len(self.pressure_levels) == 1:
+        if "single-levels" in self.dataset:
             ds = ds.expand_dims(level=self.pressure_levels)
 
         # New CDS-Beta gives "valid_time" instead of "time"

--- a/pycontrails/datalib/ecmwf/era5.py
+++ b/pycontrails/datalib/ecmwf/era5.py
@@ -541,7 +541,7 @@ class ERA5(ECMWFAPI):
 
         # For "reanalysis-era5-single-levels"
         # then the netcdf file does not contain the dimension "level"
-        if "single-levels" in self.dataset:
+        if self.is_single_level:
             ds = ds.expand_dims(level=self.pressure_levels)
 
         # New CDS-Beta gives "valid_time" instead of "time"


### PR DESCRIPTION
Behavior so far:
- downloading ERA5 pressure-level data for a single pressure level caused an issue, as "level" was assigned to the dataset twice (due to the CDS-Beta compatibility bugfix)
- _downloading ERA5 pressure-level data works fine for multiple pressure levels_
- _downloading ERA5 single-level data works fine_

Now:
- downloading ERA5 pressure-level data also works for a single pressure level

## Tests

- [x] QC test locally (`make test`)
-- `6 failed, 1017 passed, 161 skipped, 1 xpassed`
-- all the failed tests are GOES tests, and I manually skipped LEO tests
- [ ] CI tests pass

## Reviewer
Thanks @zebengberg !