### PR TITLE
fix CocipGrid met downselection in time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Change the order of advected points returned by `DryAdvection` to be consistent with the input order at each time step.
 - Add the `RUF` ruleset for linting and formatting the codebase.
 - Update type hints for `numpy` 2.2 compatibility. Additional changes may be required after the next iteration of the `numpy` 2.2 series.
+- Relax the tolerance passed into `scipy.optimize.newton` in `ps_nominal_grid` to avoid more convergence warnings. These warnings were more distracting than informative.
 
 ## v0.54.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix the `ERA5` interface when making a pressure-level request with a single pressure level. This change accommodates CDS-Beta server behavior. Previously, a ValueError was raised in this case.
 - Bypass the ValueError raised by `dask.array.gradient` when the input array is not correctly chunk along the level dimension. Previously, `Cocip` would raise an error when computing tau cirrus in the case that the `met` data had single chunks along the level dimension.
 - Fix the `CocipGrid` met downselection process to accommodate cases where `dt_integration` is as large as the time step of the met data. Previously, due to out-of-bounds interpolation, the output of `CocipGrid(met=met, rad=rad, dt_integration="1 hour")` was zero everywhere when the `met` and `rad` data had a time step of 1 hour.
+- By default, don't interpolate air temperature when running the `DryAdvection` model in a point-wise manner (no wind-shear simulation).
 
 ### Internals
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Fix the `ERA5` interface when making a pressure-level request with a single pressure level. This change accommodates CDS-Beta server behavior. Previously, a ValueError was raised in this case.
 - Bypass the ValueError raised by `dask.array.gradient` when the input array is not correctly chunk along the level dimension. Previously, `Cocip` would raise an error when computing tau cirrus in the case that the `met` data had single chunks along the level dimension.
-- Fix the `CocipGrid` met downselection process to accommodate cases where `dt_integration` is as large as the time step of the met data. Previously, the output of `CocipGrid(met=met, rad=rad, dt_integration="1 hour")` was zero everywhere when the `met` and `rad` data had a time step of 1 hour.
+- Fix the `CocipGrid` met downselection process to accommodate cases where `dt_integration` is as large as the time step of the met data. Previously, due to out-of-bounds interpolation, the output of `CocipGrid(met=met, rad=rad, dt_integration="1 hour")` was zero everywhere when the `met` and `rad` data had a time step of 1 hour.
 
 ### Internals
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Bypass the ValueError raised by `dask.array.gradient` when the input array is not correctly chunk along the level dimension. Previously, `Cocip` would raise an error when computing tau cirrus in the case that the `met` data had single chunks along the level dimension.
 - Fix the `CocipGrid` met downselection process to accommodate cases where `dt_integration` is as large as the time step of the met data. Previously, due to out-of-bounds interpolation, the output of `CocipGrid(met=met, rad=rad, dt_integration="1 hour")` was zero everywhere when the `met` and `rad` data had a time step of 1 hour.
 - By default, don't interpolate air temperature when running the `DryAdvection` model in a point-wise manner (no wind-shear simulation).
+- Use native python types (as opposed to `numpy` scalars) in the `PSAircraftEngineParams` dataclass.
 
 ### Internals
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fix the `CocipGrid` met downselection process to accommodate cases where `dt_integration` is as large as the time step of the met data. Previously, due to out-of-bounds interpolation, the output of `CocipGrid(met=met, rad=rad, dt_integration="1 hour")` was zero everywhere when the `met` and `rad` data had a time step of 1 hour.
 - By default, don't interpolate air temperature when running the `DryAdvection` model in a point-wise manner (no wind-shear simulation).
 - Use native python types (as opposed to `numpy` scalars) in the `PSAircraftEngineParams` dataclass.
+- Ensure the `PSGrid` model maintains the precision of the `source`. Previously, float32 precision was lost per [NEP 50](https://numpy.org/neps/nep-0050-scalar-promotion.html).
 
 ### Internals
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fix the `ERA5` interface when making a pressure-level request with a single pressure level. This change accommodates CDS-Beta server behavior. Previously, a ValueError was raised in this case.
 - Bypass the ValueError raised by `dask.array.gradient` when the input array is not correctly chunk along the level dimension. Previously, `Cocip` would raise an error when computing tau cirrus in the case that the `met` data had single chunks along the level dimension.
+- Fix the `CocipGrid` met downselection process to accommodate cases where `dt_integration` is as large as the time step of the met data. Previously, the output of `CocipGrid(met=met, rad=rad, dt_integration="1 hour")` was zero everywhere when the `met` and `rad` data had a time step of 1 hour.
 
 ### Internals
 

--- a/pycontrails/models/cocipgrid/cocip_grid.py
+++ b/pycontrails/models/cocipgrid/cocip_grid.py
@@ -246,8 +246,7 @@ class CocipGrid(models.Model):
             downwash_vectors_this_step = []
             for vector in self._generate_new_vectors(time_idx):
                 t0 = vector["time"].min()
-                t1 = vector["time"].max()
-                met, rad = self._maybe_downselect_met_rad(met, rad, t0, t1)
+                met, rad = self._maybe_downselect_met_rad(met, rad, t0, time_end)
                 downwash, verbose_dict = _run_downwash(vector, met, rad, self.params)
 
                 if downwash:
@@ -266,8 +265,7 @@ class CocipGrid(models.Model):
 
             for vector in itertools.chain(existing_vectors, downwash_vectors_this_step):
                 t0 = vector["time"].min()
-                t1 = time_end
-                met, rad = self._maybe_downselect_met_rad(met, rad, t0, t1)
+                met, rad = self._maybe_downselect_met_rad(met, rad, t0, time_end)
                 contrail, ef = _evolve_vector(
                     vector,
                     met=met,
@@ -2583,4 +2581,6 @@ def _maybe_downselect_mds(
         i1 = min(i1 + 1, big_time.size)
         ds_concat.append(big_mds.data.isel(time=slice(i0, i1)))
 
+    # If little_mds is loaded into memory but big_mds is not,
+    # the concat operation below will load the slice of big_mds into memory.
     return MetDataset(xr.concat(ds_concat, dim="time"), copy=False)

--- a/pycontrails/models/dry_advection.py
+++ b/pycontrails/models/dry_advection.py
@@ -242,7 +242,6 @@ def _perform_interp_for_step(
     vector.setdefault("level", vector.level)
     air_pressure = vector.setdefault("air_pressure", vector.air_pressure)
 
-    air_temperature = models.interpolate_met(met, vector, "air_temperature", **interp_kwargs)
     models.interpolate_met(met, vector, "northward_wind", "v_wind", **interp_kwargs)
     models.interpolate_met(met, vector, "eastward_wind", "u_wind", **interp_kwargs)
     models.interpolate_met(
@@ -258,6 +257,7 @@ def _perform_interp_for_step(
         # Early exit for pointwise only simulation
         return
 
+    air_temperature = models.interpolate_met(met, vector, "air_temperature", **interp_kwargs)
     air_pressure_lower = thermo.pressure_dz(air_temperature, air_pressure, dz_m)
     vector["air_pressure_lower"] = air_pressure_lower
     level_lower = air_pressure_lower / 100.0

--- a/pycontrails/models/ps_model/ps_aircraft_params.py
+++ b/pycontrails/models/ps_model/ps_aircraft_params.py
@@ -13,6 +13,7 @@ import pandas as pd
 
 from pycontrails.core.aircraft_performance import AircraftPerformanceParams
 from pycontrails.physics import constants as c
+from pycontrails.utils.types import ArrayOrFloat
 
 #: Path to the Poll-Schumann aircraft parameters CSV file.
 PS_FILE_PATH = pathlib.Path(__file__).parent / "static" / "ps-aircraft-params-20240524.csv"
@@ -260,18 +261,18 @@ def load_aircraft_engine_params(
     return dict(_row_to_aircraft_engine_params(tup) for tup in df.itertuples(index=False))
 
 
-def turbine_entry_temperature_at_max_take_off(first_flight: float) -> float:
+def turbine_entry_temperature_at_max_take_off(first_flight: ArrayOrFloat) -> ArrayOrFloat:
     """
     Calculate turbine entry temperature at maximum take-off rating.
 
     Parameters
     ----------
-    first_flight: float
+    first_flight: ArrayOrFloat
         Year of first flight
 
     Returns
     -------
-    float
+    ArrayOrFloat
         Turbine entry temperature at maximum take-off rating, ``tet_mto``, [:math:`K`]
 
     Notes
@@ -285,7 +286,7 @@ def turbine_entry_temperature_at_max_take_off(first_flight: float) -> float:
     - :cite:`cumpstyJetPropulsion2015`
     """
     out = 2000.0 * (1.0 - np.exp(62.8 - 0.0325 * first_flight))
-    if isinstance(out, np.ndarray):
+    if isinstance(first_flight, np.ndarray):
         return out
     return out.item()
 

--- a/pycontrails/models/ps_model/ps_aircraft_params.py
+++ b/pycontrails/models/ps_model/ps_aircraft_params.py
@@ -284,7 +284,10 @@ def turbine_entry_temperature_at_max_take_off(first_flight: float) -> float:
     ----------
     - :cite:`cumpstyJetPropulsion2015`
     """
-    return 2000.0 * (1 - np.exp(62.8 - 0.0325 * first_flight))
+    out = 2000.0 * (1.0 - np.exp(62.8 - 0.0325 * first_flight))
+    if isinstance(out, np.ndarray):
+        return out
+    return out.item()
 
 
 def turbine_entry_temperature_at_max_continuous_climb(tet_mto: float) -> float:

--- a/pycontrails/models/ps_model/ps_grid.py
+++ b/pycontrails/models/ps_model/ps_grid.py
@@ -394,6 +394,10 @@ def ps_nominal_grid(
     KeyError
         If "aircraft_type" is not supported by the PS model.
 
+    See Also
+    --------
+    ps_nominal_optimize_mach
+
     Examples
     --------
     >>> level = np.arange(200, 300, 10, dtype=float)
@@ -407,16 +411,16 @@ def ps_nominal_grid(
     >>> perf.to_dataframe()
            aircraft_mass  engine_efficiency  fuel_flow
     level
-    200.0   58416.230843           0.300958   0.575635
+    200.0   58416.230844           0.300958   0.575635
     210.0   61617.676624           0.300958   0.604417
-    220.0   64829.702583           0.300958   0.633199
-    230.0   68026.415695           0.300958   0.662998
+    220.0   64829.702584           0.300958   0.633199
+    230.0   68026.415694           0.300958   0.662998
     240.0   71187.897060           0.300958   0.694631
-    250.0   71775.399825           0.300824   0.703349
-    260.0   71765.716737           0.300363   0.708259
-    270.0   71752.405400           0.299671   0.714514
-    280.0   71736.129079           0.298823   0.721878
-    290.0   71717.392170           0.297875   0.730169
+    250.0   71775.399880           0.300824   0.703349
+    260.0   71765.716789           0.300363   0.708259
+    270.0   71752.405449           0.299671   0.714514
+    280.0   71736.129125           0.298823   0.721878
+    290.0   71717.392213           0.297875   0.730169
 
     >>> # Now compute it for a higher Mach number
     >>> perf = ps_nominal_grid("A320", level=level, mach_number=0.78)
@@ -425,14 +429,14 @@ def ps_nominal_grid(
     level
     200.0   57941.825236           0.306598   0.596100
     210.0   60626.062062           0.306605   0.621331
-    220.0   63818.498306           0.306605   0.650918
-    230.0   66993.691517           0.306605   0.681551
-    240.0   70129.930503           0.306605   0.714069
-    250.0   71703.009059           0.306560   0.732944
-    260.0   71690.188652           0.306239   0.739276
-    270.0   71673.392089           0.305694   0.747052
-    280.0   71653.431321           0.304997   0.755990
-    290.0   71630.901315           0.304201   0.765883
+    220.0   63818.498305           0.306605   0.650918
+    230.0   66993.691515           0.306605   0.681551
+    240.0   70129.930502           0.306605   0.714069
+    250.0   71703.009114           0.306560   0.732944
+    260.0   71690.188703           0.306239   0.739276
+    270.0   71673.392137           0.305694   0.747052
+    280.0   71653.431366           0.304997   0.755990
+    290.0   71630.901358           0.304201   0.765883
     """
     dims, coords, air_pressure, air_temperature = _parse_variables(level, air_temperature)
 
@@ -555,7 +559,7 @@ def ps_nominal_optimize_mach(
     """Calculate the nominal optimal mach number for a given aircraft type.
 
     This function is similar to the :class:`ps_nominal_grid` method, but rather than
-    maximizing engine efficiecy by adjusting aircraft, we are minimizing cost by adjusting
+    maximizing engine efficiency by adjusting aircraft, we are minimizing cost by adjusting
     mach number.
 
     Parameters
@@ -602,8 +606,7 @@ def ps_nominal_optimize_mach(
         - ``"mach_number"``: The mach number that minimizes segment cost
         - ``"fuel_flow"`` : Fuel flow rate, [:math:`kg/s`]
         - ``"engine_efficiency"`` : Engine efficiency
-        - ``"aircraft_mass"`` : Aircraft mass,
-          [:math:`kg`]
+        - ``"aircraft_mass"`` : Aircraft mass, [:math:`kg`]
 
     Raises
     ------
@@ -611,6 +614,10 @@ def ps_nominal_optimize_mach(
         If "aircraft_type" is not supported by the PS model.
     ValueError
         If wind data is provided without segment angles.
+
+    See Also
+    --------
+    ps_nominal_grid
     """
     dims = ("level",)
     coords = {"level": level}

--- a/pycontrails/models/ps_model/ps_grid.py
+++ b/pycontrails/models/ps_model/ps_grid.py
@@ -192,8 +192,10 @@ def _nominal_perf(aircraft_mass: ArrayOrFloat, perf: _PerfVariables) -> Aircraft
     mach_number = perf.mach_number
     q_fuel = perf.q_fuel
 
-    theta = 0.0
-    dv_dt = 0.0
+    # Using np.float32 here avoids scalar promotion to float64 via numpy 2.0 and NEP50
+    # In other words, the dtype of the perf variables is maintained
+    theta = np.float32(0.0)
+    dv_dt = np.float32(0.0)
 
     rn = ps_model.reynolds_number(
         atyp_param.wing_surface_area, mach_number, air_temperature, air_pressure

--- a/pycontrails/models/ps_model/ps_grid.py
+++ b/pycontrails/models/ps_model/ps_grid.py
@@ -479,7 +479,7 @@ def ps_nominal_grid(
         func=_newton_func,
         args=(perf,),
         x0=x0,
-        tol=1.0,
+        tol=80.0,  # use roughly the weight of a passenger as a tolerance
         disp=False,
         maxiter=maxiter,
     )

--- a/pycontrails/models/ps_model/ps_grid.py
+++ b/pycontrails/models/ps_model/ps_grid.py
@@ -309,7 +309,6 @@ def _parse_variables(
 
     Returns a tuple of ``(dims, coords, air_pressure, air_temperature)``.
     """
-
     if isinstance(air_temperature, xr.DataArray):
         if level is not None:
             msg = "If 'air_temperature' is a DataArray, 'level' must be None"
@@ -322,21 +321,22 @@ def _parse_variables(
             raise KeyError(msg) from exc
 
         air_temperature, pressure_da = xr.broadcast(air_temperature, pressure_da)
-        dims = air_temperature.dims
-        coords = air_temperature.coords
-        return dims, coords, np.asarray(pressure_da), np.asarray(air_temperature)
+        return (  # type: ignore[return-value]
+            air_temperature.dims,
+            air_temperature.coords,
+            np.asarray(pressure_da),
+            np.asarray(air_temperature),
+        )
 
     if level is None:
         msg = "The 'level' argument must be provided"
         raise ValueError(msg)
 
-    dims = ("level",)
-    coords = {"level": level}
     air_pressure = level * 100.0
     if air_temperature is None:
         altitude_m = units.pl_to_m(level)
         air_temperature = units.m_to_T_isa(altitude_m)
-    return dims, coords, air_pressure, air_temperature
+    return ("level",), {"level": level}, air_pressure, air_temperature
 
 
 def ps_nominal_grid(

--- a/pycontrails/models/ps_model/ps_model.py
+++ b/pycontrails/models/ps_model/ps_model.py
@@ -840,7 +840,7 @@ def propulsion_efficiency_over_max_propulsion_efficiency(
     """
     c_t_over_c_t_eta_b = c_t / c_t_eta_b
 
-    sigma = np.where(mach_num < 0.4, 1.3 * (0.4 - mach_num), 0.0)
+    sigma = np.where(mach_num < 0.4, 1.3 * (0.4 - mach_num), np.float32(0.0))  # avoid promotion
 
     eta_over_eta_b_low = (
         10.0 * (1.0 + 0.8 * (sigma - 0.43) - 0.6027 * sigma * 0.43) * c_t_over_c_t_eta_b

--- a/tests/unit/test_cocip_grid.py
+++ b/tests/unit/test_cocip_grid.py
@@ -324,7 +324,7 @@ def test_grid_survival_fraction(instance_params: dict[str, Any], source: MetData
         ),
         (
             np.datetime64("2019-01-01T12:00"),
-            [np.datetime64("2019-01-01T11:00"), np.datetime64("2019-01-01T12:00")],
+            [np.datetime64("2019-01-01T12:00")],
             [np.datetime64("2019-01-01T11:30")],
         ),
         (
@@ -342,7 +342,7 @@ def test_initial_maybe_downselect_met_rad(
 ) -> None:
     """Test initial selection of bracketing met and rad time steps"""
     model = CocipGrid(**instance_params)
-    met, rad = model._maybe_downselect_met_rad(None, None, time)
+    met, rad = model._maybe_downselect_met_rad(None, None, time, time)
     np.testing.assert_array_equal(met["time"].values, expected_met)
     np.testing.assert_array_equal(rad["time"].values, expected_rad)
 
@@ -353,13 +353,13 @@ def test_maybe_downselect_met_rad(instance_params: dict[str, Any]):
 
     # initial selection
     time = np.datetime64("2018-12-31T23:00")
-    met, rad = model._maybe_downselect_met_rad(None, None, time)
+    met, rad = model._maybe_downselect_met_rad(None, None, time, time)
     np.testing.assert_array_equal(met["time"].values, [np.datetime64("2019-01-01T00:00")])
     np.testing.assert_array_equal(rad["time"].values, [np.datetime64("2018-12-31T23:30")])
 
     # advance to after first forecast step
     time = np.datetime64("2019-01-01T00:15")
-    met, rad = model._maybe_downselect_met_rad(met, rad, time)
+    met, rad = model._maybe_downselect_met_rad(met, rad, time, time)
     np.testing.assert_array_equal(
         met["time"].values,
         [
@@ -373,7 +373,7 @@ def test_maybe_downselect_met_rad(instance_params: dict[str, Any]):
 
     # no update required
     time = np.datetime64("2019-01-01T00:20")
-    met, rad = model._maybe_downselect_met_rad(met, rad, time)
+    met, rad = model._maybe_downselect_met_rad(met, rad, time, time)
     np.testing.assert_array_equal(
         met["time"].values,
         [
@@ -387,7 +387,7 @@ def test_maybe_downselect_met_rad(instance_params: dict[str, Any]):
 
     # advance one forecast step
     time = np.datetime64("2019-01-01T01:15")
-    met, rad = model._maybe_downselect_met_rad(met, rad, time)
+    met, rad = model._maybe_downselect_met_rad(met, rad, time, time)
     np.testing.assert_array_equal(
         met["time"].values, [np.datetime64("2019-01-01T01:00"), np.datetime64("2019-01-01T02:00")]
     )
@@ -397,7 +397,7 @@ def test_maybe_downselect_met_rad(instance_params: dict[str, Any]):
 
     # advance multiple forecast steps
     time = np.datetime64("2019-01-01T08:15")
-    met, rad = model._maybe_downselect_met_rad(met, rad, time)
+    met, rad = model._maybe_downselect_met_rad(met, rad, time, time)
     np.testing.assert_array_equal(
         met["time"].values, [np.datetime64("2019-01-01T08:00"), np.datetime64("2019-01-01T09:00")]
     )
@@ -407,7 +407,7 @@ def test_maybe_downselect_met_rad(instance_params: dict[str, Any]):
 
     # advance past end of forecast
     time = np.datetime64("2019-01-01T13:00")
-    met, rad = model._maybe_downselect_met_rad(met, rad, time)
+    met, rad = model._maybe_downselect_met_rad(met, rad, time, time)
     np.testing.assert_array_equal(met["time"].values, [np.datetime64("2019-01-01T12:00")])
     np.testing.assert_array_equal(rad["time"].values, [np.datetime64("2019-01-01T11:30")])
 

--- a/tests/unit/test_dry_advection.py
+++ b/tests/unit/test_dry_advection.py
@@ -43,7 +43,7 @@ def test_dry_advection(
     assert out["age"].max() == np.timedelta64(1, "h")
 
     if azimuth is None:
-        assert len(out.data) == 11
+        assert len(out.data) == 10
     else:
         assert len(out.data) == 16
 

--- a/tests/unit/test_dtypes.py
+++ b/tests/unit/test_dtypes.py
@@ -13,6 +13,7 @@ from pycontrails.models.cocip import Cocip
 from pycontrails.models.cocipgrid import CocipGrid
 from pycontrails.models.humidity_scaling import ConstantHumidityScaling
 from pycontrails.models.issr import ISSR
+from pycontrails.models.ps_model import PSGrid
 from pycontrails.models.sac import SAC
 from pycontrails.physics import units
 
@@ -234,3 +235,10 @@ def test_cocip_grid(
     # And importantly, they are the same with BADA3 or BADA4
     nonzero = np.flatnonzero(out["ef_per_m"].data.values.ravel())
     np.testing.assert_array_equal(nonzero, [38, 46, 52, 53, 54, 61, 62, 70])
+
+
+def test_ps_grid(met_cocip1: MetDataset) -> None:
+    """Confirm the ``PSGrid`` model maintains float32 precision."""
+    psgrid = PSGrid(met=met_cocip1)
+    out = psgrid.eval()
+    assert all(d == "float32" for d in out.data.dtypes.values())

--- a/tests/unit/test_ps_model.py
+++ b/tests/unit/test_ps_model.py
@@ -11,7 +11,13 @@ import pycontrails.models.ps_model.ps_aircraft_params as ps_params
 import pycontrails.models.ps_model.ps_model as ps
 import pycontrails.models.ps_model.ps_operational_limits as ps_lims
 from pycontrails import Fleet, Flight, FlightPhase, GeoVectorDataset, MetDataset
-from pycontrails.models.ps_model import PSFlight, PSGrid, ps_nominal_grid, ps_nominal_optimize_mach
+from pycontrails.models.ps_model import (
+    PSFlight,
+    PSGrid,
+    load_aircraft_engine_params,
+    ps_nominal_grid,
+    ps_nominal_optimize_mach,
+)
 from pycontrails.physics import units
 
 from .conftest import get_static_path
@@ -35,6 +41,15 @@ def test_aircraft_type_coverage() -> None:
     for atyp in aircraft_types:
         with pytest.raises(KeyError, match=f"Aircraft type {atyp} not covered by the PS model."):
             ps_model.check_aircraft_type_availability(atyp)
+
+
+def test_aircraft_engine_params_types() -> None:
+    """Check that the aircraft engine parameters are parsed into native python (not numpy) types."""
+    aircraft_engine_params = load_aircraft_engine_params()
+    for params in aircraft_engine_params.values():
+        for key, val in params.__dict__.items():
+            assert isinstance(val, str | bool | int | float), f"Key: {key}, Value: {val}"
+            assert not isinstance(val, np.generic), f"Key: {key}, Value: {val}"
 
 
 def test_synonym_list() -> None:


### PR DESCRIPTION
#### Fixes

- Fix the `CocipGrid` met downselection process to accommodate cases where `dt_integration` is as large as the time step of the met data. Previously, the output of `CocipGrid(met=met, rad=rad, dt_integration="1 hour")` was zero everywhere when the `met` and `rad` data had a time step of 1 hour.

## Tests

- [x] QC test passes locally (`make test`)
- [x] CI tests pass
