### PR TITLE
Support for model-agnostic met data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features
 
+- Add support for generic (model-agnostic) meteorology data to `Cocip` and `CocipGrid`.
+
 - Add two new parameters to the `DryAdvection` model.
   - If the `verbose_outputs` parameter is enabled, additional wind-shear data is included in the output.
   - If the `include_source_in_output` parameter is enabled, the source data with any of the intermediate artifacts (e.g., interpolated met data, wind-shear data, etc.) is included in the output.

--- a/pycontrails/core/met_var.py
+++ b/pycontrails/core/met_var.py
@@ -282,6 +282,35 @@ VerticalVelocity = MetVariable(
     ),
 )
 
+MassFractionOfCloudLiquidWaterInAir = MetVariable(
+    short_name="clw",
+    standard_name="mass_fraction_of_cloud_liquid_water_in_air",
+    long_name="Mass fraction of cloud liquid water in air",
+    units="kg kg**-1",
+    level_type="isobaricInhPa",
+    amip="clw",
+    description=("The mass fraction of cloud liquid water in moist air."),
+)
+
+MassFractionOfCloudIceInAir = MetVariable(
+    short_name="cli",
+    standard_name="mass_fraction_of_cloud_ice_in_air",
+    long_name="Mass fraction of cloud ice in air",
+    units="kg kg**-1",
+    level_type="isobaricInhPa",
+    amip="cli",
+    description=("The mass fraction of cloud ice in moist air."),
+)
+
+CloudAreaFractionInAtmosphereLayer = MetVariable(
+    short_name="cl",
+    standard_name="cloud_area_fraction_in_atmosphere_layer",
+    long_name="Cloud area fraction in atmosphere layer",
+    units="[0 - 1]",
+    level_type="isobaricInhPa",
+    description=("The fraction of the horizontal area of a grid cell that contains cloud."),
+)
+
 
 # ----
 # Single level variables
@@ -303,5 +332,38 @@ SurfacePressure = MetVariable(
         "on the surface of land, sea and in-land water. It is a measure of the "
         "weight of all the air in a column vertically above the area of the "
         "Earth's surface represented at a fixed point."
+    ),
+)
+
+TOANetDownwardShortwaveFlux = MetVariable(
+    short_name="rst",
+    standard_name="toa_net_downward_shortwave_flux",
+    long_name="TOA net downward shortwave flux",
+    units="W m**-2",
+    level_type="nominalTop",
+    amip="rst",
+    description=(
+        '"shortwave" means shortwave radiation. "toa" means top of atmosphere. '
+        '"Downward" indicates a vector component which is positive when directed '
+        "downward (negative upward). Net downward radiation is the difference "
+        "between radiation from above (downwelling) and radiation from below (upwelling). "
+        "In accordance with common usage in geophysical disciplines, "
+        '"flux" implies per unit area, called "flux density" in physics.'
+    ),
+)
+
+TOAOutgoingLongwaveFlux = MetVariable(
+    short_name="rlut",
+    standard_name="toa_outgoing_longwave_flux",
+    long_name="TOA outgoing longwave_flux",
+    units="W m**-2",
+    level_type="nominalTop",
+    amip="rlut",
+    description=(
+        '"longwave" means longwave radiation. "toa" means top of atmosphere. '
+        "The TOA outgoing longwave flux is the upwelling thermal radiative flux, "
+        'often called the "outgoing longwave radiation" or "OLR". '
+        "In accordance with common usage in geophysical disciplines, "
+        '"flux" implies per unit area, called "flux density" in physics.'
     ),
 )

--- a/pycontrails/models/cocip/cocip.py
+++ b/pycontrails/models/cocip/cocip.py
@@ -68,11 +68,24 @@ class Cocip(Model):
     -----
     **Inputs**
 
-    The required meteorology variables depend on the data source (e.g. ECMWF, GFS).
+    The required meteorology variables depend on the data source. :class:`Cocip`
+    supports data-source-specific variables from ECMWF models (HRES, ERA5) and the NCEP GFS, plus
+    a generic set of model-agnostic variables.
 
     See :attr:`met_variables` and :attr:`rad_variables` for the list of required variables
     to the ``met`` and ``rad`` parameters, respectively.
     When an item in one of these arrays is a :class:`tuple`, variable keys depend on data source.
+
+    A warning will be raised if meteorology data is from a source not currently supported by
+    a pycontrails datalib. In this case it is the responsibility of the user to ensure that
+    meteorology data is formatted correctly. The warning can be suppressed with a context manager:
+
+    .. code-block:: python
+        :emphasize-lines: 1,2
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=UserWarning, message="Unknown provider")
+            cocip = Cocip(met, rad, ...)
 
     The current list of required variables (labelled by ``"standard_name"``):
 

--- a/pycontrails/models/cocip/cocip.py
+++ b/pycontrails/models/cocip/cocip.py
@@ -1540,11 +1540,6 @@ def _process_rad(rad: MetDataset) -> MetDataset:
     These variables are used to calculate the reflected solar radiation (RSR),
     and outgoing longwave radiation (OLR).
 
-    This routine is only used for radiation data from ECMWF models. In all other
-    cases it is the responsibility of the user to ensure that radiative fluxes
-    have units of W m-2 and to adjust the time coordinates, if appropriate, when
-    fluxes are time-averaged.
-
     The time stamp is adjusted by ``shift_radiation_time`` to account for
     accumulated values being averaged over the time period.
 
@@ -1938,7 +1933,7 @@ def calc_shortwave_radiation(
     Raises
     ------
     ValueError
-        If ``rad`` does not contain ``"top_net_downward_shortwave_flux"``,
+        If ``rad`` does not contain ``"toa_net_downward_shortwave_flux"``,
         ``"toa_upward_shortwave_flux"`` or ``"top_net_solar_radiation"`` variable.
 
     Notes

--- a/pycontrails/models/cocip/cocip.py
+++ b/pycontrails/models/cocip/cocip.py
@@ -81,8 +81,9 @@ class Cocip(Model):
     meteorology data is formatted correctly. The warning can be suppressed with a context manager:
 
     .. code-block:: python
-        :emphasize-lines: 1,2
+        :emphasize-lines: 2,3
 
+        import warnings
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=UserWarning, message="Unknown provider")
             cocip = Cocip(met, rad, ...)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -212,6 +212,38 @@ def rad_cocip1() -> MetDataset:
 
 
 @pytest.fixture()
+def met_generic_cocip1() -> MetDataset:
+    """Generic meteorology to run cocip with ``flight-cocip1``."""
+    path = get_static_path("met-era5-cocip1.nc")
+    ds = xr.open_dataset(path).astype("float32")
+    ds["air_pressure"] = ds["air_pressure"].astype("float32")
+    ds["altitude"] = ds["altitude"].astype("float32")
+    ds = ds.rename(
+        {
+            "specific_cloud_ice_water_content": "mass_fraction_of_cloud_ice_in_air",
+            "fraction_of_cloud_cover": "cloud_area_fraction_in_atmosphere_layer",
+        }
+    )
+    return MetDataset(ds, provider="Generic")
+
+
+@pytest.fixture()
+def rad_generic_cocip1() -> MetDataset:
+    """Generic radiation data to run cocip with ``flight-cocip1``."""
+    path = get_static_path("rad-era5-cocip1.nc")
+    ds = xr.open_dataset(path)
+    ds = ds.rename(
+        {
+            "top_net_solar_radiation": "toa_net_downward_shortwave_flux",
+            "top_net_thermal_radiation": "toa_outgoing_longwave_flux",
+        }
+    )
+    ds["toa_outgoing_longwave_flux"] *= -1
+    ds = ds.assign_coords({"time": ds["time"] - np.timedelta64(30, "m")})
+    return MetDataset(ds, provider="Generic")
+
+
+@pytest.fixture()
 def met_cocip_nonuniform_time(met_cocip1: MetDataset) -> MetDataset:
     """Return a MetDataset with nonuniform time."""
     ds = met_cocip1.data
@@ -252,6 +284,35 @@ def rad_cocip2() -> MetDataset:
     path = get_static_path("rad-era5-cocip2.nc")
     ds = xr.open_dataset(path)
     return MetDataset(ds, provider="ECMWF", dataset="ERA5", product="reanalysis")
+
+
+@pytest.fixture()
+def met_generic_cocip2() -> MetDataset:
+    """Generic meteorology to run cocip with ``flight-cocip2.csv``."""
+    path = get_static_path("met-era5-cocip2.nc")
+    ds = xr.open_dataset(path)
+    ds = ds.rename(
+        {
+            "specific_cloud_ice_water_content": "mass_fraction_of_cloud_ice_in_air",
+        }
+    )
+    return MetDataset(ds, provider="Generic")
+
+
+@pytest.fixture()
+def rad_generic_cocip2() -> MetDataset:
+    """Generic radiation data to run cocip with ``flight-cocip2.csv``."""
+    path = get_static_path("rad-era5-cocip2.nc")
+    ds = xr.open_dataset(path)
+    ds = ds.rename(
+        {
+            "top_net_solar_radiation": "toa_net_downward_shortwave_flux",
+            "top_net_thermal_radiation": "toa_outgoing_longwave_flux",
+        }
+    )
+    ds["toa_outgoing_longwave_flux"] *= -1
+    ds["time"].attrs = {}  # don't mark time as already shifted
+    return MetDataset(ds, provider="Generic")
 
 
 @pytest.fixture()

--- a/tests/unit/test_cocip.py
+++ b/tests/unit/test_cocip.py
@@ -195,6 +195,35 @@ def cocip_no_ef_lowmem_indices(fl: Flight, met: MetDataset, rad: MetDataset) -> 
 
 
 @pytest.fixture()
+def cocip_no_ef_generic(
+    fl: Flight, met_generic_cocip1: MetDataset, rad_generic_cocip1: MetDataset
+) -> Cocip:
+    """Return `Cocip` instance evaluated on modified `fl` using generic met data."""
+    fl.update(longitude=np.linspace(-29, -32, 20, dtype=float))
+    fl.update(latitude=np.linspace(54, 55, 20, dtype=float))
+    fl.update(altitude=np.full(20, 10000.0, dtype=float))
+
+    # set all radiative forcing to 0
+    rad2 = rad_generic_cocip1.copy()
+    rad2.data["toa_net_downward_shortwave_flux"] = xr.zeros_like(
+        rad2.data["toa_net_downward_shortwave_flux"]
+    )
+    rad2.data["toa_outgoing_longwave_flux"] = xr.zeros_like(rad2.data["toa_outgoing_longwave_flux"])
+
+    # run - will not find any persistent contrails
+    params = {
+        "max_age": np.timedelta64(3, "h"),
+        "process_emissions": False,
+        "humidity_scaling": ExponentialBoostHumidityScaling(),
+    }
+    with pytest.warns(UserWarning, match="Unknown provider 'Generic'"):
+        cocip = Cocip(met_generic_cocip1.copy(), rad=rad2, params=params)
+    cocip.eval(source=fl)
+
+    return cocip
+
+
+@pytest.fixture()
 def cocip_persistent(fl: Flight, met: MetDataset, rad: MetDataset) -> Cocip:
     """Return `Cocip` instance evaluated on modified `fl`."""
     fl.update(longitude=np.linspace(-29, -32, 20))
@@ -267,6 +296,38 @@ def cocip_persistent_lowmem_indices(fl: Flight, met: MetDataset, rad: MetDataset
 
 
 @pytest.fixture()
+def cocip_persistent_generic(
+    fl: Flight, met_generic_cocip1: MetDataset, rad_generic_cocip1: MetDataset
+) -> Cocip:
+    """Return `Cocip` instance evaluated on modified `fl` with generic met data."""
+    fl.update(longitude=np.linspace(-29, -32, 20))
+    fl.update(latitude=np.linspace(56, 57, 20))
+    fl.update(altitude=np.linspace(10900, 10900, 20))
+
+    # Use a non-default met_time_buffer for backwards compatibility with original
+    # pinned test data. This only affects the test_grid_cirrus test below. Flight
+    # waypoint data remains unchanged.
+    params = {
+        "max_age": np.timedelta64(3, "h"),
+        "process_emissions": False,
+        "verbose_outputs": True,
+        "met_time_buffer": (np.timedelta64(0, "h"), np.timedelta64(1, "h")),
+        "humidity_scaling": ExponentialBoostHumidityScaling(),
+        "compute_atr20": True,
+    }
+    with pytest.warns(UserWarning, match="Unknown provider 'Generic'"):
+        cocip = Cocip(met_generic_cocip1.copy(), rad=rad_generic_cocip1.copy(), params=params)
+
+    # Eventually the advected waypoints will blow out of bounds
+    # Specifically, there is a contrail at 4:30 with latitude larger than 59
+    # We acknowledge this here
+    with pytest.warns(UserWarning, match="At time .* contrail has no intersection with the met"):
+        cocip.eval(source=fl)
+
+    return cocip
+
+
+@pytest.fixture()
 def cocip_persistent2(
     flight_cocip2: Flight, met_cocip2: MetDataset, rad_cocip2: MetDataset
 ) -> Cocip:
@@ -322,6 +383,29 @@ def cocip_persistent2_lowmem_indices(
     }
     cocip = Cocip(met=met_cocip2.copy(), rad=rad_cocip2.copy(), params=params)
     cocip.eval(source=flight_cocip2)
+    return cocip
+
+
+@pytest.fixture()
+def cocip_persistent2_generic(
+    flight_cocip2: Flight, met_generic_cocip2: MetDataset, rad_generic_cocip2: MetDataset
+) -> Cocip:
+    """Return ``Cocip`` instance evaluated on modified ``flight_cocip2`` with generic met data."""
+
+    # Use a non-default met_time_buffer for backwards compatibility with original
+    # pinned test data. This only affects the test_grid_cirrus test below. Flight
+    # waypoint data remains unchanged.
+    params = {
+        "max_age": np.timedelta64(5, "h"),
+        "process_emissions": False,
+        "verbose_outputs": True,
+        "interpolation_bounds_error": True,
+        "humidity_scaling": ExponentialBoostHumidityScaling(),
+    }
+    with pytest.warns(UserWarning, match="Unknown provider 'Generic'"):
+        cocip = Cocip(met=met_generic_cocip2.copy(), rad=rad_generic_cocip2.copy(), params=params)
+    cocip.eval(source=flight_cocip2)
+
     return cocip
 
 
@@ -942,6 +1026,30 @@ def test_eval_lowmem(reference: str, lowmem: str, request: pytest.FixtureRequest
     cocip_lowmem = request.getfixturevalue(lowmem)
     pd.testing.assert_frame_equal(cocip.source.dataframe, cocip_lowmem.source.dataframe)
     pd.testing.assert_frame_equal(cocip.contrail, cocip_lowmem.contrail)
+
+
+@pytest.mark.parametrize(
+    ("reference", "generic"),
+    [
+        ("cocip_no_ef", "cocip_no_ef_generic"),
+        ("cocip_persistent", "cocip_persistent_generic"),
+        ("cocip_persistent2", "cocip_persistent2_generic"),
+    ],
+)
+def test_eval_generic(reference: str, generic: str, request: pytest.FixtureRequest) -> None:
+    """Check that CoCiP output does not change when equivalent generic met data is used."""
+    cocip = request.getfixturevalue(reference)
+    cocip_generic = request.getfixturevalue(generic)
+    # pd.testing.assert_frame_equal(
+    #     cocip.source.dataframe.rename(
+    #         {"specific_cloud_ice_water_content": "mass_fraction_of_cloud_ice_in_air"}, axis=1
+    #     ),
+    #     cocip_generic.source.dataframe,
+    # )
+    pd.testing.assert_frame_equal(
+        cocip.contrail.drop(["top_net_thermal_radiation", "top_net_solar_radiation"], axis=1),
+        cocip_generic.contrail.drop(["toa_net_downward_shortwave_flux"], axis=1),
+    )
 
 
 def test_xarray_contrail(cocip_persistent: Cocip) -> None:


### PR DESCRIPTION
## Changes

#### Features

- Add support for generic (model-agnostic) meteorology data to `Cocip` and `CocipGrid`.

## Tests

- [x] QC test passes locally (`make test`)
- [ ] CI tests pass

## Reviewer

> @zebengberg 
