### PR TITLE
Fix mypy errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Internals
 
+- Suppress mypy `return-value` errors for functions in `geo.py` where mypy fails to correctly infer return types of numpy ufuncs applied to xarray objects.
 - Change `AircraftPerformance` and downstream implementations for better support in running over `Fleet` sources. The runtime of `PSFlight` remains the same.
 
 ## v0.54.5

--- a/pycontrails/physics/geo.py
+++ b/pycontrails/physics/geo.py
@@ -516,7 +516,7 @@ def solar_constant(theta_rad: ArrayLike) -> ArrayLike:
         + (0.000077 * np.sin(theta_rad * 2))
     )
 
-    return constants.solar_constant * orbital_effect
+    return constants.solar_constant * orbital_effect  # type: ignore[return-value]
 
 
 def cosine_solar_zenith_angle(
@@ -662,7 +662,7 @@ def solar_declination_angle(theta_rad: ArrayLike) -> ArrayLike:
     :func:`cosine_solar_zenith_angle`
     """
     return (
-        0.396372
+        0.396372  # type: ignore[return-value]
         - (22.91327 * np.cos(theta_rad))
         + (4.02543 * np.sin(theta_rad))
         - (0.387205 * np.cos(2 * theta_rad))
@@ -729,7 +729,7 @@ def orbital_correction_for_solar_hour_angle(theta_rad: ArrayLike) -> ArrayLike:
     Tested against :cite:`noaaSolarCalculationDetails`
     """
     return (
-        0.004297
+        0.004297  # type: ignore[return-value]
         + (0.107029 * np.cos(theta_rad))
         - (1.837877 * np.sin(theta_rad))
         - (0.837378 * np.cos(2 * theta_rad))


### PR DESCRIPTION
### Internals
- Suppress mypy `return-value` errors for functions in `geo.py` where mypy fails to correctly infer return types of numpy ufuncs applied to xarray objects.



## Tests

- [x] QC test passes locally (`make test`)
- [x] CI tests pass
