### PR TITLE
Helper methods for generating lists of required met variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.54.7 (unreleased)
+
+### Features
+
+- Add helper classmethods to `Model`, `Cocip`, and `CocipGrid` for generating lists of required variables from specific data sources.
+
 ## v0.54.6
 
 ### Features

--- a/pycontrails/core/met_var.py
+++ b/pycontrails/core/met_var.py
@@ -367,3 +367,21 @@ TOAOutgoingLongwaveFlux = MetVariable(
         '"flux" implies per unit area, called "flux density" in physics.'
     ),
 )
+
+PRESSURE_LEVEL_VARIABLES = [
+    AirTemperature,
+    SpecificHumidity,
+    RelativeHumidity,
+    Geopotential,
+    GeopotentialHeight,
+    EastwardWind,
+    NorthwardWind,
+    VerticalVelocity,
+    MassFractionOfCloudLiquidWaterInAir,
+    MassFractionOfCloudIceInAir,
+    CloudAreaFractionInAtmosphereLayer,
+]
+
+SINGLE_LEVEL_VARIABLES = [SurfacePressure, TOANetDownwardShortwaveFlux, TOAOutgoingLongwaveFlux]
+
+MET_VARIABLES = PRESSURE_LEVEL_VARIABLES + SINGLE_LEVEL_VARIABLES

--- a/pycontrails/core/models.py
+++ b/pycontrails/core/models.py
@@ -289,7 +289,8 @@ class Model(ABC):
         tuple[MetVariable]
             List of model-agnostic variants of required variables
         """
-        return tuple(_find_match(required, set(MET_VARIABLES)) for required in cls.met_variables)
+        available = set(MET_VARIABLES)
+        return tuple(_find_match(required, available) for required in cls.met_variables)
 
     @classmethod
     def ecmwf_met_variables(cls) -> tuple[MetVariable, ...]:
@@ -300,7 +301,8 @@ class Model(ABC):
         tuple[MetVariable]
             List of ECMWF-specific variants of required variables
         """
-        return tuple(_find_match(required, set(ECMWF_VARIABLES)) for required in cls.met_variables)
+        available = set(ECMWF_VARIABLES)
+        return tuple(_find_match(required, available) for required in cls.met_variables)
 
     @classmethod
     def gfs_met_variables(cls) -> tuple[MetVariable, ...]:
@@ -311,7 +313,8 @@ class Model(ABC):
         tuple[MetVariable]
             List of GFS-specific variants of required variables
         """
-        return tuple(_find_match(required, set(GFS_VARIABLES)) for required in cls.met_variables)
+        available = set(GFS_VARIABLES)
+        return tuple(_find_match(required, available) for required in cls.met_variables)
 
     def _verify_met(self) -> None:
         """Verify integrity of :attr:`met`.

--- a/pycontrails/core/models.py
+++ b/pycontrails/core/models.py
@@ -289,7 +289,7 @@ class Model(ABC):
         tuple[MetVariable]
             List of model-agnostic variants of required variables
         """
-        return tuple(_find_match(required, MET_VARIABLES) for required in cls.met_variables)
+        return tuple(_find_match(required, set(MET_VARIABLES)) for required in cls.met_variables)
 
     @classmethod
     def ecmwf_met_variables(cls) -> tuple[MetVariable, ...]:
@@ -300,7 +300,7 @@ class Model(ABC):
         tuple[MetVariable]
             List of ECMWF-specific variants of required variables
         """
-        return tuple(_find_match(required, ECMWF_VARIABLES) for required in cls.met_variables)
+        return tuple(_find_match(required, set(ECMWF_VARIABLES)) for required in cls.met_variables)
 
     @classmethod
     def gfs_met_variables(cls) -> tuple[MetVariable, ...]:
@@ -311,7 +311,7 @@ class Model(ABC):
         tuple[MetVariable]
             List of GFS-specific variants of required variables
         """
-        return tuple(_find_match(required, GFS_VARIABLES) for required in cls.met_variables)
+        return tuple(_find_match(required, set(GFS_VARIABLES)) for required in cls.met_variables)
 
     def _verify_met(self) -> None:
         """Verify integrity of :attr:`met`.
@@ -843,7 +843,7 @@ def _interp_grid_to_grid(
 
 
 def _find_match(
-    required: MetVariable | Sequence[MetVariable], available: Sequence[MetVariable]
+    required: MetVariable | Sequence[MetVariable], available: set[MetVariable]
 ) -> MetVariable:
     """Find match for required met variable in list of data-source-specific met variables.
 

--- a/pycontrails/core/models.py
+++ b/pycontrails/core/models.py
@@ -179,8 +179,10 @@ class Model(ABC):
 
     #: Required meteorology pressure level variables.
     #: Each element in the list is a :class:`MetVariable` or a ``tuple[MetVariable]``.
-    #: If element is a ``tuple[MetVariable]``, the variable depends on the data source.
-    #: Only one variable in the tuple is required.
+    #: If element is a ``tuple[MetVariable]``, the variable depends on the data source
+    #: and the tuple must include entries for (in order) a model-agnostic variable,
+    #: an ECMWF-specific variable, and a GFS-specific variable.
+    #: Only one of the three variable in the tuple is required for model evaluation.
     met_variables: tuple[MetVariable | tuple[MetVariable, ...], ...]
 
     #: Set of required parameters if processing already complete on ``met`` input.

--- a/pycontrails/core/models.py
+++ b/pycontrails/core/models.py
@@ -276,6 +276,39 @@ class Model(ABC):
 
         return hashlib.sha1(bytes(_hash, "utf-8")).hexdigest()
 
+    @classmethod
+    def generic_met_variables(cls) -> tuple[MetVariable, ...]:
+        """Return a model-agnostic list of required meteorology variables.
+
+        Returns
+        -------
+        tuple[MetVariable]
+            List of model-agnostic variants of required variables
+        """
+        return tuple(v[0] if isinstance(v, tuple) else v for v in cls.met_variables)
+
+    @classmethod
+    def ecmwf_met_variables(cls) -> tuple[MetVariable, ...]:
+        """Return an ECMWF-specific list of required meteorology variables.
+
+        Returns
+        -------
+        tuple[MetVariable]
+            List of ECMWF-specific variants of required variables
+        """
+        return tuple(v[1] if isinstance(v, tuple) else v for v in cls.met_variables)
+
+    @classmethod
+    def gfs_met_variables(cls) -> tuple[MetVariable, ...]:
+        """Return a GFS-specific list of required meteorology variables.
+
+        Returns
+        -------
+        tuple[MetVariable]
+            List of GFS-specific variants of required variables
+        """
+        return tuple(v[2] if isinstance(v, tuple) else v for v in cls.met_variables)
+
     def _verify_met(self) -> None:
         """Verify integrity of :attr:`met`.
 

--- a/pycontrails/models/cocip/cocip.py
+++ b/pycontrails/models/cocip/cocip.py
@@ -493,7 +493,8 @@ class Cocip(Model):
             List of model-agnostic variants of required variables
         """
         return tuple(
-            models._find_match(required, met_var.MET_VARIABLES) for required in cls.rad_variables
+            models._find_match(required, set(met_var.MET_VARIABLES))
+            for required in cls.rad_variables
         )
 
     @classmethod
@@ -506,7 +507,8 @@ class Cocip(Model):
             List of ECMWF-specific variants of required variables
         """
         return tuple(
-            models._find_match(required, ecmwf.ECMWF_VARIABLES) for required in cls.rad_variables
+            models._find_match(required, set(ecmwf.ECMWF_VARIABLES))
+            for required in cls.rad_variables
         )
 
     @classmethod
@@ -519,7 +521,7 @@ class Cocip(Model):
             List of GFS-specific variants of required variables
         """
         return tuple(
-            models._find_match(required, gfs.GFS_VARIABLES) for required in cls.rad_variables
+            models._find_match(required, set(gfs.GFS_VARIABLES)) for required in cls.rad_variables
         )
 
     def _set_timesteps(self) -> None:

--- a/pycontrails/models/cocip/cocip.py
+++ b/pycontrails/models/cocip/cocip.py
@@ -23,6 +23,7 @@ from pycontrails.core.aircraft_performance import AircraftPerformance
 from pycontrails.core.fleet import Fleet
 from pycontrails.core.flight import Flight
 from pycontrails.core.met import MetDataset
+from pycontrails.core.met_var import MetVariable
 from pycontrails.core.models import Model, interpolate_met
 from pycontrails.core.vector import GeoVectorDataset, VectorDataDict
 from pycontrails.datalib import ecmwf, gfs
@@ -481,6 +482,39 @@ class Cocip(Model):
             return self.source.to_flight_list()  # type: ignore[attr-defined]
 
         return self.source
+
+    @classmethod
+    def generic_rad_variables(cls) -> tuple[MetVariable, ...]:
+        """Return a model-agnostic list of required radiation variables.
+
+        Returns
+        -------
+        tuple[MetVariable]
+            List of model-agnostic variants of required variables
+        """
+        return tuple(v[0] if isinstance(v, tuple) else v for v in cls.rad_variables)
+
+    @classmethod
+    def ecmwf_rad_variables(cls) -> tuple[MetVariable, ...]:
+        """Return an ECMWF-specific list of required radiation variables.
+
+        Returns
+        -------
+        tuple[MetVariable]
+            List of ECMWF-specific variants of required variables
+        """
+        return tuple(v[1] if isinstance(v, tuple) else v for v in cls.rad_variables)
+
+    @classmethod
+    def gfs_rad_variables(cls) -> tuple[MetVariable, ...]:
+        """Return a GFS-specific list of required radiation variables.
+
+        Returns
+        -------
+        tuple[MetVariable]
+            List of GFS-specific variants of required variables
+        """
+        return tuple(v[2] if isinstance(v, tuple) else v for v in cls.rad_variables)
 
     def _set_timesteps(self) -> None:
         """Set the :attr:`timesteps` based on the ``source`` time range.

--- a/pycontrails/models/cocip/cocip.py
+++ b/pycontrails/models/cocip/cocip.py
@@ -492,10 +492,8 @@ class Cocip(Model):
         tuple[MetVariable]
             List of model-agnostic variants of required variables
         """
-        return tuple(
-            models._find_match(required, set(met_var.MET_VARIABLES))
-            for required in cls.rad_variables
-        )
+        available = set(met_var.MET_VARIABLES)
+        return tuple(models._find_match(required, available) for required in cls.rad_variables)
 
     @classmethod
     def ecmwf_rad_variables(cls) -> tuple[MetVariable, ...]:
@@ -506,10 +504,8 @@ class Cocip(Model):
         tuple[MetVariable]
             List of ECMWF-specific variants of required variables
         """
-        return tuple(
-            models._find_match(required, set(ecmwf.ECMWF_VARIABLES))
-            for required in cls.rad_variables
-        )
+        available = set(ecmwf.ECMWF_VARIABLES)
+        return tuple(models._find_match(required, available) for required in cls.rad_variables)
 
     @classmethod
     def gfs_rad_variables(cls) -> tuple[MetVariable, ...]:
@@ -520,9 +516,8 @@ class Cocip(Model):
         tuple[MetVariable]
             List of GFS-specific variants of required variables
         """
-        return tuple(
-            models._find_match(required, set(gfs.GFS_VARIABLES)) for required in cls.rad_variables
-        )
+        available = set(gfs.GFS_VARIABLES)
+        return tuple(models._find_match(required, available) for required in cls.rad_variables)
 
     def _set_timesteps(self) -> None:
         """Set the :attr:`timesteps` based on the ``source`` time range.

--- a/pycontrails/models/cocip/cocip.py
+++ b/pycontrails/models/cocip/cocip.py
@@ -18,7 +18,7 @@ import numpy.typing as npt
 import pandas as pd
 import xarray as xr
 
-from pycontrails.core import met_var
+from pycontrails.core import met_var, models
 from pycontrails.core.aircraft_performance import AircraftPerformance
 from pycontrails.core.fleet import Fleet
 from pycontrails.core.flight import Flight
@@ -492,7 +492,9 @@ class Cocip(Model):
         tuple[MetVariable]
             List of model-agnostic variants of required variables
         """
-        return tuple(v[0] if isinstance(v, tuple) else v for v in cls.rad_variables)
+        return tuple(
+            models._find_match(required, met_var.MET_VARIABLES) for required in cls.rad_variables
+        )
 
     @classmethod
     def ecmwf_rad_variables(cls) -> tuple[MetVariable, ...]:
@@ -503,7 +505,9 @@ class Cocip(Model):
         tuple[MetVariable]
             List of ECMWF-specific variants of required variables
         """
-        return tuple(v[1] if isinstance(v, tuple) else v for v in cls.rad_variables)
+        return tuple(
+            models._find_match(required, ecmwf.ECMWF_VARIABLES) for required in cls.rad_variables
+        )
 
     @classmethod
     def gfs_rad_variables(cls) -> tuple[MetVariable, ...]:
@@ -514,7 +518,9 @@ class Cocip(Model):
         tuple[MetVariable]
             List of GFS-specific variants of required variables
         """
-        return tuple(v[2] if isinstance(v, tuple) else v for v in cls.rad_variables)
+        return tuple(
+            models._find_match(required, gfs.GFS_VARIABLES) for required in cls.rad_variables
+        )
 
     def _set_timesteps(self) -> None:
         """Set the :attr:`timesteps` based on the ``source`` time range.

--- a/pycontrails/models/cocipgrid/cocip_grid.py
+++ b/pycontrails/models/cocipgrid/cocip_grid.py
@@ -13,10 +13,9 @@ import numpy.typing as npt
 import pandas as pd
 
 import pycontrails
-from pycontrails.core import MetVariable, met_var, models
+from pycontrails.core import models
 from pycontrails.core.met import MetDataset, maybe_downselect_mds
 from pycontrails.core.vector import GeoVectorDataset, VectorDataset
-from pycontrails.datalib import ecmwf, gfs
 from pycontrails.models import humidity_scaling, sac
 from pycontrails.models.cocip import cocip, contrail_properties, wake_vortex, wind_shear
 from pycontrails.models.cocipgrid.cocip_grid_params import CocipGridParams
@@ -89,6 +88,9 @@ class CocipGrid(models.Model):
     met_variables = cocip.Cocip.met_variables
     rad_variables = cocip.Cocip.rad_variables
     processed_met_variables = cocip.Cocip.processed_met_variables
+    generic_rad_variables = cocip.Cocip.generic_rad_variables
+    ecmwf_rad_variables = cocip.Cocip.ecmwf_rad_variables
+    gfs_rad_variables = cocip.Cocip.gfs_rad_variables
 
     #: Met data is not optional
     met: MetDataset
@@ -435,45 +437,6 @@ class CocipGrid(models.Model):
                 )
 
         return self.source
-
-    @classmethod
-    def generic_rad_variables(cls) -> tuple[MetVariable, ...]:
-        """Return a model-agnostic list of required radiation variables.
-
-        Returns
-        -------
-        tuple[MetVariable]
-            List of model-agnostic variants of required variables
-        """
-        return tuple(
-            models._find_match(required, met_var.MET_VARIABLES) for required in cls.rad_variables
-        )
-
-    @classmethod
-    def ecmwf_rad_variables(cls) -> tuple[MetVariable, ...]:
-        """Return an ECMWF-specific list of required radiation variables.
-
-        Returns
-        -------
-        tuple[MetVariable]
-            List of ECMWF-specific variants of required variables
-        """
-        return tuple(
-            models._find_match(required, ecmwf.ECMWF_VARIABLES) for required in cls.rad_variables
-        )
-
-    @classmethod
-    def gfs_rad_variables(cls) -> tuple[MetVariable, ...]:
-        """Return a GFS-specific list of required radiation variables.
-
-        Returns
-        -------
-        tuple[MetVariable]
-            List of GFS-specific variants of required variables
-        """
-        return tuple(
-            models._find_match(required, gfs.GFS_VARIABLES) for required in cls.rad_variables
-        )
 
     # ---------------------------
     # Common Methods & Properties

--- a/pycontrails/models/cocipgrid/cocip_grid.py
+++ b/pycontrails/models/cocipgrid/cocip_grid.py
@@ -13,7 +13,7 @@ import numpy.typing as npt
 import pandas as pd
 
 import pycontrails
-from pycontrails.core import models
+from pycontrails.core import MetVariable, models
 from pycontrails.core.met import MetDataset, maybe_downselect_mds
 from pycontrails.core.vector import GeoVectorDataset, VectorDataset
 from pycontrails.models import humidity_scaling, sac
@@ -434,6 +434,39 @@ class CocipGrid(models.Model):
                 )
 
         return self.source
+
+    @classmethod
+    def generic_rad_variables(cls) -> tuple[MetVariable, ...]:
+        """Return a model-agnostic list of required radiation variables.
+
+        Returns
+        -------
+        tuple[MetVariable]
+            List of model-agnostic variants of required variables
+        """
+        return tuple(v[0] if isinstance(v, tuple) else v for v in cls.rad_variables)
+
+    @classmethod
+    def ecmwf_rad_variables(cls) -> tuple[MetVariable, ...]:
+        """Return an ECMWF-specific list of required radiation variables.
+
+        Returns
+        -------
+        tuple[MetVariable]
+            List of ECMWF-specific variants of required variables
+        """
+        return tuple(v[1] if isinstance(v, tuple) else v for v in cls.rad_variables)
+
+    @classmethod
+    def gfs_rad_variables(cls) -> tuple[MetVariable, ...]:
+        """Return a GFS-specific list of required radiation variables.
+
+        Returns
+        -------
+        tuple[MetVariable]
+            List of GFS-specific variants of required variables
+        """
+        return tuple(v[2] if isinstance(v, tuple) else v for v in cls.rad_variables)
 
     # ---------------------------
     # Common Methods & Properties

--- a/pycontrails/models/cocipgrid/cocip_grid.py
+++ b/pycontrails/models/cocipgrid/cocip_grid.py
@@ -13,9 +13,10 @@ import numpy.typing as npt
 import pandas as pd
 
 import pycontrails
-from pycontrails.core import MetVariable, models
+from pycontrails.core import MetVariable, met_var, models
 from pycontrails.core.met import MetDataset, maybe_downselect_mds
 from pycontrails.core.vector import GeoVectorDataset, VectorDataset
+from pycontrails.datalib import ecmwf, gfs
 from pycontrails.models import humidity_scaling, sac
 from pycontrails.models.cocip import cocip, contrail_properties, wake_vortex, wind_shear
 from pycontrails.models.cocipgrid.cocip_grid_params import CocipGridParams
@@ -444,7 +445,9 @@ class CocipGrid(models.Model):
         tuple[MetVariable]
             List of model-agnostic variants of required variables
         """
-        return tuple(v[0] if isinstance(v, tuple) else v for v in cls.rad_variables)
+        return tuple(
+            models._find_match(required, met_var.MET_VARIABLES) for required in cls.rad_variables
+        )
 
     @classmethod
     def ecmwf_rad_variables(cls) -> tuple[MetVariable, ...]:
@@ -455,7 +458,9 @@ class CocipGrid(models.Model):
         tuple[MetVariable]
             List of ECMWF-specific variants of required variables
         """
-        return tuple(v[1] if isinstance(v, tuple) else v for v in cls.rad_variables)
+        return tuple(
+            models._find_match(required, ecmwf.ECMWF_VARIABLES) for required in cls.rad_variables
+        )
 
     @classmethod
     def gfs_rad_variables(cls) -> tuple[MetVariable, ...]:
@@ -466,7 +471,9 @@ class CocipGrid(models.Model):
         tuple[MetVariable]
             List of GFS-specific variants of required variables
         """
-        return tuple(v[2] if isinstance(v, tuple) else v for v in cls.rad_variables)
+        return tuple(
+            models._find_match(required, gfs.GFS_VARIABLES) for required in cls.rad_variables
+        )
 
     # ---------------------------
     # Common Methods & Properties

--- a/tests/unit/test_cocip.py
+++ b/tests/unit/test_cocip.py
@@ -1963,5 +1963,5 @@ def test_cocip_survival_fraction(fl: Flight, met: MetDataset, rad: MetDataset):
 def test_cocip_met_rad_variables_helper(
     mvs: tuple[MetVariable, ...], target: tuple[MetVariable, ...]
 ) -> None:
-    """Test met and rad variable helper properties."""
+    """Test met and rad variable helper methods."""
     assert mvs == target

--- a/tests/unit/test_cocip_grid.py
+++ b/tests/unit/test_cocip_grid.py
@@ -10,7 +10,7 @@ import pandas as pd
 import pytest
 import xarray as xr
 
-from pycontrails import GeoVectorDataset, MetDataset
+from pycontrails import GeoVectorDataset, MetDataset, MetVariable
 from pycontrails.core.aircraft_performance import AircraftPerformance, AircraftPerformanceGrid
 from pycontrails.models.cocip import Cocip
 from pycontrails.models.cocipgrid import CocipGrid
@@ -1011,3 +1011,21 @@ def test_cocip_grid_one_hour_dt_integration(
     # Sum the number of grid cells producing persistent contrails
     # Prior to v0.54.4, this was 0
     assert out.data["ef_per_m"].fillna(0.0).astype(bool).sum() == 526
+
+
+@pytest.mark.parametrize(
+    ("grid_mvs", "traj_mvs"),
+    [
+        (CocipGrid.generic_met_variables(), Cocip.generic_met_variables()),
+        (CocipGrid.generic_rad_variables(), Cocip.generic_rad_variables()),
+        (CocipGrid.ecmwf_met_variables(), Cocip.ecmwf_met_variables()),
+        (CocipGrid.ecmwf_rad_variables(), Cocip.ecmwf_rad_variables()),
+        (CocipGrid.gfs_met_variables(), Cocip.gfs_met_variables()),
+        (CocipGrid.gfs_rad_variables(), Cocip.gfs_rad_variables()),
+    ],
+)
+def test_cocip_grid_met_rad_variables_helper(
+    grid_mvs: tuple[MetVariable, ...], traj_mvs: tuple[MetVariable, ...]
+) -> None:
+    """Test met and rad variable helper properties."""
+    assert grid_mvs == traj_mvs

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -9,6 +9,7 @@ import numpy as np
 import pytest
 
 from pycontrails import Flight, MetDataArray, MetDataset, Model, ModelParams
+from pycontrails.core import models
 from pycontrails.core.met_var import AirTemperature, MetVariable, SpecificHumidity
 
 
@@ -461,3 +462,24 @@ def test_verify_met_when_met_none(flight_fake: Flight) -> None:
 
     out = model.eval(flight_fake)
     assert isinstance(out, Flight)
+
+
+def test_match_required_met_to_data_source() -> None:
+    """Test helper function for matching required met to data-source-specific options."""
+    assert models._find_match(required=AirTemperature, available=[]) == AirTemperature
+    assert (
+        models._find_match(required=[AirTemperature], available=[AirTemperature]) == AirTemperature
+    )
+    assert (
+        models._find_match(required=[AirTemperature, SpecificHumidity], available=[AirTemperature])
+        == AirTemperature
+    )
+    assert (
+        models._find_match(required=[AirTemperature], available=[AirTemperature, SpecificHumidity])
+        == AirTemperature
+    )
+
+    with pytest.raises(KeyError, match="None of"):
+        models._find_match(required=[AirTemperature], available=[])
+    with pytest.raises(KeyError, match="None of"):
+        models._find_match(required=[AirTemperature], available=[SpecificHumidity])


### PR DESCRIPTION
Changes in this PR allow code snippets like
```python
variables = (
   v[0] if isinstance(v, tuple) else v for v in Cocip.met_variables
)
met.standardize_variables(variables)
```
(frequently used to standardize ECMWF met variables, but broken as of the latest pycontrails release) to be replaced with
```python
met.standardize_variables(Cocip.ecmwf_met_variables)
```

## Changes

#### Features

- Add helper classmethods to `Model`, `Cocip`, and `CocipGrid` for generating lists of required variables from specific data sources.

## Tests

- [x] QC test passes locally (`make test`)
- [ ] CI tests pass

## Reviewer

> @zebengberg 
