### PR TITLE
Update authorship from Breakthrough Energy to Contrails.org in documentation

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-Copyright (c) 2021-present Breakthrough Energy
+Copyright (c) 2021-present Contrails.org and the Breakthrough Energy Foundation
 
 
 Attribution

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,9 +15,11 @@ import pycontrails
 # -- Project information -----------------------------------------------------
 
 project = "pycontrails"
-copyright = f"2021-{datetime.datetime.now().year}, Breakthrough Energy"
+copyright = (
+    f"2021-{datetime.datetime.now().year}, Contrails.org and the Breakthrough Energy Foundation"
+)
 
-author = "Breakthrough Energy"
+author = "Contrails.org"
 version = pycontrails.__version__
 release = pycontrails.__version__
 

--- a/pycontrails/__init__.py
+++ b/pycontrails/__init__.py
@@ -1,7 +1,7 @@
 """
 ``pycontrails`` public API.
 
-Copyright 2021-present Breakthrough Energy
+Copyright 2021-present Contrails.org and the Breakthrough Energy Foundation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pycontrails"
-authors = [{ name = "Breakthrough Energy", email = "py@contrails.org" }]
+authors = [{ name = "Contrails.org", email = "py@contrails.org" }]
 description = "Python library for modeling aviation climate impacts"
 keywords = ["contrails", "climate", "aviation", "geospatial"]
 # https://pypi.org/classifiers/


### PR DESCRIPTION


## Changes

#### Internals

- Small update to change legal designations from Breakthrough Energy to "Contrails.org and the Breakthrough Energy Foundation"
