### PR TITLE
Feature/beam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 - Make `pycontrails` compatible with `pandas 2.0` and `pandas 2.1`.
 - Avoid auto-promotion of float32 to float64 within the `Emissions` model run-time.
+- Add convenience `VectorDataset.lookup_constant` method.
 
 ## v0.54.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.54.7 (unreleased)
+## v0.54.7
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 
 - The `MetDataset.standardize_variables` method now returns a new `MetDataset` rather than modifying the existing dataset in place. To retain the previous behavior, use `MetDataset.standardize_variables(..., inplace=True)`.
 
+### Fixes
+
+- Change naming convention for eastward and northward wind fields in `AircraftPerformance` models for consistency with the `Cocip` and `DryAdvection` models. Fields on the `source` are now named `u_wind` and `v_wind` instead of `eastward_wind` and `northward_wind`. Under some paths of computation, this avoids a redundant interpolation.
+
 ### Internals
 
 - Make `pycontrails` compatible with `pandas 2.0` and `pandas 2.1`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Fixes
 
 - Change naming convention for eastward and northward wind fields in `AircraftPerformance` models for consistency with the `Cocip` and `DryAdvection` models. Fields on the `source` are now named `u_wind` and `v_wind` instead of `eastward_wind` and `northward_wind`. Under some paths of computation, this avoids a redundant interpolation.
+- Fix the `AircraftPerformance.ensure_true_airspeed_on_source` method in the case when the `met` attr is None and the `fill_with_groundspeed` parameter is enabled.
 
 ### Internals
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 ### Internals
 
 - Make `pycontrails` compatible with `pandas 2.0` and `pandas 2.1`.
+- Avoid auto-promotion of float32 to float64 within the `Emissions` model run-time.
 
 ## v0.54.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 
 - Make `pycontrails` compatible with `pandas 2.0` and `pandas 2.1`.
 - Avoid auto-promotion of float32 to float64 within the `Emissions` model run-time.
-- Add convenience `VectorDataset.lookup_constant` method.
+- Add convenience `VectorDataset.get_constant` method.
 
 ## v0.54.6
 

--- a/pycontrails/core/aircraft_performance.py
+++ b/pycontrails/core/aircraft_performance.py
@@ -664,28 +664,3 @@ def _fill_low_altitude_with_isa_temperature(vector: GeoVectorDataset, met_level_
 
     t_isa = vector.T_isa()
     air_temperature[cond] = t_isa[cond]
-
-
-def _fill_low_altitude_tas_with_true_groundspeed(fl: Flight, met_level_max: float) -> None:
-    """Fill low-altitude NaN values in ``true_airspeed`` with ground speed.
-
-    The ``true_airspeed`` param is assumed to have been computed by
-    interpolating against a gridded wind field that did not necessarily
-    extend to the surface. This function fills points below the lowest
-    altitude in the gridded data with ground speed values.
-
-    This function operates in-place and modifies the ``true_airspeed`` field.
-
-    Parameters
-    ----------
-    fl : Flight
-        Flight instance associated with the ``true_airspeed`` data.
-    met_level_max : float
-        The maximum level in the met data, [:math:`hPa`].
-    """
-    tas = fl["true_airspeed"]
-    is_nan = np.isnan(tas)
-    low_alt = fl.level > met_level_max
-    cond = is_nan & low_alt
-
-    tas[cond] = fl.segment_groundspeed()[cond]

--- a/pycontrails/core/aircraft_performance.py
+++ b/pycontrails/core/aircraft_performance.py
@@ -509,7 +509,8 @@ class AircraftPerformance(Model):
             tas[cond] = self.source.segment_groundspeed()[cond]
             return tas
 
-        wind_available = ("eastward_wind" in self.source and "northward_wind" in self.source) or (
+        # Use current cocip convention: eastward_wind on met, u_wind on source
+        wind_available = ("u_wind" in self.source and "v_wind" in self.source) or (
             self.met is not None and "eastward_wind" in self.met and "northward_wind" in self.met
         )
 
@@ -526,8 +527,8 @@ class AircraftPerformance(Model):
             )
             raise ValueError(msg)
 
-        u = interpolate_met(self.met, self.source, "eastward_wind", **self.interp_kwargs)
-        v = interpolate_met(self.met, self.source, "northward_wind", **self.interp_kwargs)
+        u = interpolate_met(self.met, self.source, "eastward_wind", "u_wind", **self.interp_kwargs)
+        v = interpolate_met(self.met, self.source, "northward_wind", "v_wind", **self.interp_kwargs)
 
         if fill_with_groundspeed:
             met_level_max = self.met.data["level"][-1].item()  # type: ignore[union-attr]

--- a/pycontrails/core/vector.py
+++ b/pycontrails/core/vector.py
@@ -509,7 +509,7 @@ class VectorDataset:
 
         See Also
         --------
-        lookup_constant
+        get_constant
         """
         marker = self.__marker
 
@@ -1047,13 +1047,13 @@ class VectorDataset:
         Examples
         --------
         >>> vector = VectorDataset({"a": [1, 1, 1], "b": [2, 2, 3]})
-        >>> vector.lookup_constant("a")
+        >>> vector.get_constant("a")
         np.int64(1)
-        >>> vector.lookup_constant("b")
+        >>> vector.get_constant("b")
         Traceback (most recent call last):
         ...
         KeyError: "A constant key 'b' not found in attrs or data"
-        >>> vector.lookup_constant("b", 3)
+        >>> vector.get_constant("b", 3)
         3
 
         See Also

--- a/pycontrails/core/vector.py
+++ b/pycontrails/core/vector.py
@@ -1016,7 +1016,7 @@ class VectorDataset:
         )
         self.broadcast_attrs(numeric_attrs, overwrite)
 
-    def lookup_constant(self, key: str, default: Any = __marker) -> Any:
+    def get_constant(self, key: str, default: Any = __marker) -> Any:
         """Get a constant value from :attr:`attrs` or :attr:`data`.
 
         - If ``key`` is found in :attr:`attrs`, the value is returned.

--- a/pycontrails/models/emissions/black_carbon.py
+++ b/pycontrails/models/emissions/black_carbon.py
@@ -458,11 +458,11 @@ def number_emissions_index_fractal_aggregates(
     nvpm_ei_m: npt.NDArray[np.floating],
     gmd: npt.NDArray[np.floating],
     *,
-    gsd: float | np.float32 | npt.NDArray[np.floating] = np.float32(1.80),  # avoid promotion
-    rho_bc: float | np.float32 = np.float32(1770.0),
-    k_tem: float | np.float32 = np.float32(1.621e-5),
-    d_tem: float | np.float32 = np.float32(0.39),
-    d_fm: float | np.float32 = np.float32(2.76),
+    gsd: float | np.floating | npt.NDArray[np.floating] = np.float32(1.80),  # avoid promotion
+    rho_bc: float | np.floating = np.float32(1770.0),
+    k_tem: float | np.floating = np.float32(1.621e-5),
+    d_tem: float | np.floating = np.float32(0.39),
+    d_fm: float | np.floating = np.float32(2.76),
 ) -> npt.NDArray[np.floating]:
     """
     Estimate the black carbon number emission index using the fractal aggregates (FA) model.

--- a/pycontrails/models/emissions/black_carbon.py
+++ b/pycontrails/models/emissions/black_carbon.py
@@ -98,7 +98,7 @@ def flame_temperature(t_3: ArrayScalarLike) -> ArrayScalarLike:
     ArrayScalarLike
         Flame temperature at the combustion chamber, [:math:`K`]
     """
-    return 0.9 * t_3 + 2120
+    return 0.9 * t_3 + 2120.0
 
 
 def bc_mass_concentration_fox(
@@ -125,7 +125,11 @@ def bc_mass_concentration_fox(
     npt.NDArray[np.floating]:
         Black carbon mass concentration for ground conditions, [:math:`mg m^{-3}`]
     """
-    return fuel_flow * (356 * np.exp(-6390 / t_fl) - 608 * afr * np.exp(-19778 / t_fl))
+    # avoid float32 -> float64 promotion
+    coeff = 356.0 * np.exp(np.float32(-6390.0) / t_fl) - 608.0 * afr * np.exp(
+        np.float32(-19778.0) / t_fl
+    )
+    return fuel_flow * coeff
 
 
 def bc_mass_concentration_cruise_fox(
@@ -209,7 +213,7 @@ def dopelheuer_lecht_scaling_factor(
     ----------
     - :cite:`dopelheuerInfluenceEnginePerformance1998`
     """
-    exp_term = np.exp(20000 / t_fl_cru) / np.exp(20000 / t_fl_ref)
+    exp_term = np.exp(20000.0 / t_fl_cru - 20000.0 / t_fl_ref)
     return (afr_ref / afr_cru) ** 2.5 * (p_3_cru / p_3_ref) ** 1.35 * exp_term
 
 
@@ -295,7 +299,7 @@ def turbine_inlet_temperature_imfox(afr: npt.NDArray[np.floating]) -> npt.NDArra
     ----------
     - :cite:`abrahamsonPredictiveModelDevelopment2016`
     """
-    return 490 + 42266 / afr
+    return 490.0 + 42266.0 / afr
 
 
 def bc_mass_concentration_imfox(
@@ -325,9 +329,10 @@ def bc_mass_concentration_imfox(
     npt.NDArray[np.floating]
         Black carbon mass concentration, [:math:`mg m^{-3}`]
     """
-    exp_term = np.exp(13.6 - fuel_hydrogen)
-    formation_term = 295 * np.exp(-6390 / t_4)
-    oxidation_term = 608 * afr * np.exp(-19778 / t_4)
+    # avoid float32 -> float64 promotion
+    exp_term = np.exp(np.float32(13.6) - fuel_hydrogen)
+    formation_term = 295.0 * np.exp(np.float32(-6390.0) / t_4)
+    oxidation_term = 608.0 * afr * np.exp(np.float32(-19778.0) / t_4)
     return fuel_flow_per_engine * exp_term * (formation_term - oxidation_term)
 
 
@@ -453,11 +458,11 @@ def number_emissions_index_fractal_aggregates(
     nvpm_ei_m: npt.NDArray[np.floating],
     gmd: npt.NDArray[np.floating],
     *,
-    gsd: float | npt.NDArray[np.floating] = 1.80,
-    rho_bc: float = 1770,
-    k_tem: float = 1.621e-5,
-    d_tem: float = 0.39,
-    d_fm: float = 2.76,
+    gsd: float | np.float32 | npt.NDArray[np.floating] = np.float32(1.80),  # avoid promotion
+    rho_bc: float | np.float32 = np.float32(1770.0),
+    k_tem: float | np.float32 = np.float32(1.621e-5),
+    d_tem: float | np.float32 = np.float32(0.39),
+    d_fm: float | np.float32 = np.float32(2.76),
 ) -> npt.NDArray[np.floating]:
     """
     Estimate the black carbon number emission index using the fractal aggregates (FA) model.
@@ -494,9 +499,9 @@ def number_emissions_index_fractal_aggregates(
     - ``rho_bc``: :cite:`parkMeasurementInherentMaterial2004`
     - ``k_tem``, ``d_tem``: :cite:`dastanpourObservationsCorrelationPrimary2014`
     """
-    phi = 3 * d_tem + (1 - d_tem) * d_fm
+    phi = 3.0 * d_tem + (1.0 - d_tem) * d_fm
     exponential_term = np.exp(0.5 * phi**2 * np.log(gsd) ** 2)
-    denom = rho_bc * (np.pi / 6) * k_tem ** (3 - d_fm) * gmd**phi * exponential_term
+    denom = rho_bc * (np.pi / 6.0) * k_tem ** (3.0 - d_fm) * gmd**phi * exponential_term
     return nvpm_ei_m / denom
 
 

--- a/pycontrails/models/emissions/emissions.py
+++ b/pycontrails/models/emissions/emissions.py
@@ -192,7 +192,7 @@ class Emissions(Model):
             try:
                 edb_gaseous = self.edb_engine_gaseous[engine_uid]  # type: ignore[index]
             except KeyError:
-                self.source["thrust_setting"] = np.full(shape=len(self.source), fill_value=np.nan)
+                self.source["thrust_setting"] = np.full(len(self.source), np.nan, dtype=np.float32)
             else:
                 self.source["thrust_setting"] = get_thrust_setting(
                     edb_gaseous,
@@ -297,9 +297,9 @@ class Emissions(Model):
         """
         self.source.attrs["gaseous_data_source"] = "Constant"
 
-        nox_ei = np.full(shape=len(self.source), fill_value=15.14)
-        co_ei = np.full(shape=len(self.source), fill_value=3.61)
-        hc_ei = np.full(shape=len(self.source), fill_value=0.520)
+        nox_ei = np.full(shape=len(self.source), fill_value=15.14, dtype=np.float32)
+        co_ei = np.full(shape=len(self.source), fill_value=3.61, dtype=np.float32)
+        hc_ei = np.full(shape=len(self.source), fill_value=0.520, dtype=np.float32)
 
         self.source["nox_ei"] = nox_ei * 1e-3  # g-NOx/kg-fuel to kg-NOx/kg-fuel
         self.source["co_ei"] = co_ei * 1e-3  # g-CO/kg-fuel to kg-CO/kg-fuel
@@ -493,8 +493,8 @@ class Emissions(Model):
         - :cite:`schumannDehydrationEffectsContrails2015`
         """
         nvpm_data_source = "Constant"
-        nvpm_ei_m = np.full(shape=len(self.source), fill_value=(0.088 * 1e-3))  # g to kg
-        nvpm_ei_n = np.full(shape=len(self.source), fill_value=self.params["default_nvpm_ei_n"])
+        nvpm_ei_m = np.full(len(self.source), 0.088 * 1e-3, dtype=np.float32)  # g to kg
+        nvpm_ei_n = np.full(len(self.source), self.params["default_nvpm_ei_n"], dtype=np.float32)
         return nvpm_data_source, nvpm_ei_m, nvpm_ei_n
 
     def _total_pollutant_emissions(self) -> None:
@@ -916,7 +916,7 @@ def get_thrust_setting(
     )
 
     thrust_setting = fuel_flow_per_engine / edb_gaseous.ff_100
-    thrust_setting.clip(0.03, 1, out=thrust_setting)  # clip in place
+    thrust_setting.clip(0.03, 1.0, out=thrust_setting)  # clip in place
     return thrust_setting
 
 

--- a/pycontrails/models/emissions/emissions.py
+++ b/pycontrails/models/emissions/emissions.py
@@ -169,7 +169,7 @@ class Emissions(Model):
             )
 
         if "n_engine" not in self.source.attrs:
-            aircraft_type = self.source.lookup_constant("aircraft_type", None)
+            aircraft_type = self.source.get_constant("aircraft_type", None)
             self.source.attrs["n_engine"] = self.default_engines.at[aircraft_type, "n_engine"]
 
         try:

--- a/pycontrails/models/emissions/emissions.py
+++ b/pycontrails/models/emissions/emissions.py
@@ -169,7 +169,7 @@ class Emissions(Model):
             )
 
         if "n_engine" not in self.source.attrs:
-            aircraft_type = self.source.attrs.get("aircraft_type")
+            aircraft_type = self.source.lookup_constant("aircraft_type", None)
             self.source.attrs["n_engine"] = self.default_engines.at[aircraft_type, "n_engine"]
 
         try:

--- a/pycontrails/models/ps_model/ps_model.py
+++ b/pycontrails/models/ps_model/ps_model.py
@@ -121,7 +121,7 @@ class PSFlight(AircraftPerformance):
     def eval_flight(self, fl: Flight) -> Flight:
         # Ensure aircraft type is available
         try:
-            aircraft_type = fl.attrs["aircraft_type"]
+            aircraft_type = fl.lookup_constant("aircraft_type")
         except KeyError as exc:
             msg = "`aircraft_type` required on flight attrs"
             raise KeyError(msg) from exc

--- a/pycontrails/models/ps_model/ps_model.py
+++ b/pycontrails/models/ps_model/ps_model.py
@@ -121,7 +121,7 @@ class PSFlight(AircraftPerformance):
     def eval_flight(self, fl: Flight) -> Flight:
         # Ensure aircraft type is available
         try:
-            aircraft_type = fl.lookup_constant("aircraft_type")
+            aircraft_type = fl.get_constant("aircraft_type")
         except KeyError as exc:
             msg = "`aircraft_type` required on flight attrs"
             raise KeyError(msg) from exc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -268,4 +268,4 @@ fixture-parentheses = true
 # Relevant for RUF009
 # https://docs.astral.sh/ruff/settings/#lint_flake8-bugbear_extend-immutable-calls
 [tool.ruff.lint.flake8-bugbear]
-extend-immutable-calls = ["numpy.timedelta64", "os.path.join"]
+extend-immutable-calls = ["numpy.timedelta64", "numpy.float32", "os.path.join"]

--- a/tests/unit/test_cocip_grid_parity.py
+++ b/tests/unit/test_cocip_grid_parity.py
@@ -102,7 +102,7 @@ def test_parity(
 
     # source data has been copied on eval
     assert len(fl.data) == 16
-    assert len(cocip.source.data) == 68
+    assert len(cocip.source.data) == 66
     downwash1 = cocip._downwash_contrail.dataframe.set_index("waypoint")
 
     cg = CocipGrid(


### PR DESCRIPTION
### Fixes

- Change naming convention for eastward and northward wind fields in `AircraftPerformance` models for consistency with the `Cocip` and `DryAdvection` models. Fields on the `source` are now named `u_wind` and `v_wind` instead of `eastward_wind` and `northward_wind`. Under some paths of computation, this avoids a redundant interpolation.
- Fix the `AircraftPerformance.ensure_true_airspeed_on_source` method in the case when the `met` attr is None and the `fill_with_groundspeed` parameter is enabled.

### Internals

- Avoid auto-promotion of float32 to float64 within the `Emissions` model run-time.
- Add convenience `VectorDataset.lookup_constant` method.

## Tests

- [ ] QC test passes locally (`make test`)
- [ ] CI tests pass

## Reviewer

@thabbott ignore the name of this branch -- this PR just has some prep work for a beam-pipeline I'm making for Roger.
