### PR TITLE
Add flight ID to DryAdvection output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Output from the `DryAdvection` model will include a `flight_id` column if one is present in the model source.
+- Output from the `DryAdvection` model will include a `flight_id` column when run with a `Flight` or a `Fleet`.
 
 ## 0.54.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.54.10 (unreleased)
+
+### Features
+
+- Output from the `DryAdvection` model will include a `flight_id` column if once is present in the model source.
+
 ## 0.54.9
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Output from the `DryAdvection` model will include a `flight_id` column if once is present in the model source.
+- Output from the `DryAdvection` model will include a `flight_id` column if one is present in the model source.
 
 ## 0.54.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Output from the `DryAdvection` model will include a `flight_id` column when run with a `Flight` or a `Fleet`.
 
+### Internals
+
+- Fix errors in "See Also" sections of `Model` docstrings.
+
 ## 0.54.9
 
 ### Features

--- a/pycontrails/core/models.py
+++ b/pycontrails/core/models.py
@@ -543,7 +543,7 @@ class Model(ABC):
 
         See Also
         --------
-        - :meth:`eval`
+        eval
         """
         self.source = self._get_source(source)
 
@@ -744,8 +744,8 @@ class Model(ABC):
 
         See Also
         --------
-        - get_source_param
-        - GeoVectorDataset.get_data_or_attr
+        get_source_param
+        pycontrails.core.vector.GeoVectorDataset.get_data_or_attr
         """
         marker = self.__marker
 
@@ -805,8 +805,8 @@ class Model(ABC):
 
         See Also
         --------
-        - get_data_param
-        - GeoVectorDataset.get_data_or_attr
+        get_data_param
+        pycontrails.core.vector.GeoVectorDataset.get_data_or_attr
         """
         return self.get_data_param(self.source, key, default, set_attr=set_attr)
 

--- a/pycontrails/models/dry_advection.py
+++ b/pycontrails/models/dry_advection.py
@@ -217,6 +217,8 @@ class DryAdvection(models.Model):
         - ``age``: Age of plume.
         - ``waypoint``: Identifier for each waypoint.
 
+        If ``flight_id`` is present in :attr:`source`, it is retained.
+
         If `"azimuth"` is present in :attr:`source`, `source.attrs`, or :attr:`params`,
         the following variables will also be added:
 
@@ -236,6 +238,9 @@ class DryAdvection(models.Model):
         self.source.setdefault("waypoint", np.arange(self.source.size))
 
         columns = ["longitude", "latitude", "level", "time", "age", "waypoint"]
+        if "flight_id" in self.source:
+            columns.append("flight_id")
+
         azimuth = self.get_source_param("azimuth", set_attr=False)
         if azimuth is None:
             # Early exit for pointwise only simulation
@@ -540,6 +545,10 @@ def _evolve_one_step(
             "waypoint": vector["waypoint"],
         }
     )
+
+    flight_id = vector.get("flight_id")
+    if flight_id is not None:
+        out["flight_id"] = flight_id
 
     azimuth = vector.get("azimuth")
     if azimuth is None:

--- a/tests/unit/test_dry_advection.py
+++ b/tests/unit/test_dry_advection.py
@@ -75,7 +75,7 @@ def test_compare_dry_advection_to_cocip(
     assert df1["level"].notna().all()
     assert df1["time"].notna().all()
 
-    assert df1.shape == (208, 16)
+    assert df1.shape == (208, 17)
     df1_sl = df1.query("time == '2019-01-01T01:25'")
 
     model = Cocip(


### PR DESCRIPTION
Useful when running `DryAdvection` with a `Fleet`.

## Changes

> Description of changes in this PR.
> Use `make changelog` for starter.
> Should be copied and commit to `CHANGELOG.md`

#### Features

- Output from the `DryAdvection` model will include a `flight_id` column if one is present in the model source.

## Tests

- [x] QC test passes locally (`make test`)
- [x] CI tests pass

## Reviewer

> @zebengberg 
