### PR TITLE
support GOES-16 -> GOES-19 transition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
 
 - Fix errors in "See Also" sections of `Model` docstrings.
 
+### Fixes
+
+- GOES data download for GOES-East now supports the GOES-16 -> GOES-19 transition. The default GCS bucket is automatically selected based on the requested date (using 2025-04-04 as the cutoff). For pre-transition data, this change is backwards compatible with previous versions of pycontrails.
+- Pass the `GOES.fs` instance to the `gcs_goes_path` function from the `GOES.gcs_goes_path` method to avoid repeated GCS file system client instantiation.
+
 ## 0.54.9
 
 ### Features

--- a/pycontrails/datalib/goes.py
+++ b/pycontrails/datalib/goes.py
@@ -258,10 +258,10 @@ def gcs_goes_path(
     >>> pprint(paths)
     ['gcp-public-data-goes-16/ABI-L2-CMIPM/2023/093/02/OR_ABI-L2-CMIPM1-M6C01_G16_s20230930211249_e20230930211309_c20230930211386.nc']
 
-    >>> t = datetime.datetime(2025, 5, 4, 3, 2, 1)
+    >>> t = datetime.datetime(2025, 5, 4, 3, 2)
     >>> paths = gcs_goes_path(t, GOESRegion.M2, channels="C01")
     >>> pprint(paths)
-    ['gcp-public-data-goes-16/ABI-L2-CMIPM/2025/124/03/OR_ABI-L2-CMIPM2-M6C01_G19_s20251241210249_e20251241211309_c20251241211386.nc']
+    ['gcp-public-data-goes-19/ABI-L2-CMIPM/2025/124/03/OR_ABI-L2-CMIPM2-M6C01_G19_s20251240302557_e20251240303014_c20251240303092.nc']
 
     """
     time = _check_time_resolution(time, region)

--- a/tests/unit/test_goes.py
+++ b/tests/unit/test_goes.py
@@ -215,3 +215,20 @@ def test_goes_parallax_correct_opposite_side(goes_data: xr.DataArray) -> None:
     # it may miss the surface. This occurs for the first and last 12 points in this array.
     assert np.all(np.isfinite(lon1[~opposite_side][12:-12]))
     assert np.all(np.isfinite(lat1[~opposite_side][12:-12]))
+
+
+@pytest.mark.skipif(IS_WINDOWS, reason="cannot easily install h5py on windows")
+@pytest.mark.skipif(OFFLINE, reason="offline")
+def test_goes_19() -> None:
+    """Confirm that we can access GOES-19 data."""
+    downloader = goes.GOES(region="m1", cachestore=None, channels="C02")
+    assert downloader.cachestore is None
+
+    da = downloader.get("2025-04-15T15:34")
+    assert isinstance(da, xr.DataArray)
+
+    assert da.shape == (1, 2000, 2000)  # C02 has 0.5 km resolution
+    assert da.name == "CMI"
+    assert da.dims == ("band_id", "y", "x")
+    assert da.dtype == "float32"
+    assert da["band_id"].values.tolist() == [2]


### PR DESCRIPTION
### Fixes

- GOES data download for GOES-East now supports the GOES-16 -> GOES-19 transition. The default GCS bucket is automatically selected based on the requested date (using 2025-04-04 as the cutoff). For pre-transition data, this change is backwards compatible with previous versions of pycontrails.
- Pass the `GOES.fs` instance to the `gcs_goes_path` function from the `GOES.gcs_goes_path` method to avoid repeated GCS file system client instantiation.

## Tests

- [ ] QC test passes locally (`make test`)
- [ ] CI tests pass

## Reviewer

@itcojo 
