### PR TITLE
Update flightplan.py

### DIFF
--- a/pycontrails/core/flightplan.py
+++ b/pycontrails/core/flightplan.py
@@ -97,8 +97,8 @@ def parse_atc_plan(atc_plan: str) -> dict[str, str]:
     --------
     :func:`to_atc_plan`
     """
-    atc_plan = atc_plan.replace("\r", "")
-    atc_plan = atc_plan.replace("\n", "")
+    atc_plan = atc_plan.replace("\r", " ")
+    atc_plan = atc_plan.replace("\n", " ")
     atc_plan = atc_plan.upper()
     atc_plan = atc_plan.strip()
 


### PR DESCRIPTION
When parsing a flightplan string, replaces newlines and carriage returns with spaces instead of empty strings. Fixes issue where successive route points get concatenated together, causing the Skyvector API to ignore those points.

- [ ] QC test passes locally (`make test`) (note: no changes in test results before vs after change)
- [ ] CI tests pass

## Reviewer

