### PR TITLE
Feature/advection target time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,16 @@
 
 ## 0.54.11 (unreleased)
 
+### Features
+
+- Add new `target_time` parameter to the `DryAdvection` model. If provided, this parameter overrides the `max_age` parameter and allows the model to advect all waypoints to the specified time. This is useful for running advection simulations over a fixed time period rather than a fixed age. The `target_time` parameter is optional and defaults to `None`, in which case the model behaves as before.
+
 ### Fixes
 
 - Fix the `GOES` interface caching mechanism when a custom `goes_bucket` is provided. This allows users to cache both GOES-16 and GOES-18 data without conflicts.
 - Officially support the "scda" HRES stream (useful for forecast reference times 06Z and 18Z). Previously, this was implicitly assumed.
 - Fix an issue with how the `parse_atc_plan` method handles newline characters in the flightplan string.
+- Fix an issue with the `DryAdvection.eval` implementation in which a large temporal gap between waypoints caused the model to end prematurely.
 
 ### Internals
 

--- a/pycontrails/models/dry_advection.py
+++ b/pycontrails/models/dry_advection.py
@@ -40,8 +40,9 @@ class DryAdvectionParams(models.AdvectionBuffers):
     #: Max age of plume evolution.
     max_age: np.timedelta64 = np.timedelta64(20, "h")
 
-    #: The terminal time of the advection simulation. If provided, the ``max_age`` is
+    #: The terminal time of the advection simulation. If provided, the ``max_age`` parameter is
     #: ignored and the model advects all waypoints to cover this time.
+    #:
     #: .. versionadded:: 0.54.11
     target_time: np.datetime64 | None = None
 
@@ -176,9 +177,10 @@ class DryAdvection(models.Model):
         if target_time is not None:
             timesteps = np.arange(t0 + dt_integration, target_time + dt_integration, dt_integration)
         else:
-            t1 = source_time.max()
             timesteps = np.arange(
-                t0 + dt_integration, t1 + dt_integration + max_age, dt_integration
+                t0 + dt_integration,
+                source_time.max() + dt_integration + max_age,
+                dt_integration,
             )
 
         vector2 = GeoVectorDataset()

--- a/pycontrails/models/dry_advection.py
+++ b/pycontrails/models/dry_advection.py
@@ -177,6 +177,9 @@ class DryAdvection(models.Model):
         for t in timesteps:
             filt = (source_time < t) & (source_time >= t - dt_integration)
             vector1 = vector2 + self.source.filter(filt, copy=False)
+            if vector1.size == 0:
+                vector2 = GeoVectorDataset()
+                continue
 
             t0 = vector1["time"].min()
             t1 = vector1["time"].max()

--- a/pycontrails/models/dry_advection.py
+++ b/pycontrails/models/dry_advection.py
@@ -191,6 +191,7 @@ class DryAdvection(models.Model):
             if vector1.size == 0:
                 vector2 = GeoVectorDataset()
                 continue
+            evolved.append(vector1)  # NOTE: vector1 is mutated below (geometry and weather added)
 
             t0 = vector1["time"].min()
             t1 = vector1["time"].max()
@@ -206,7 +207,6 @@ class DryAdvection(models.Model):
                 verbose_outputs=verbose_outputs,
                 **interp_kwargs,
             )
-            evolved.append(vector1)
 
             filt = vector2.coords_intersect_met(self.met)
             if target_time is None:

--- a/pycontrails/physics/units.py
+++ b/pycontrails/physics/units.py
@@ -107,7 +107,7 @@ def m_to_T_isa(h: ArrayScalarLike) -> ArrayScalarLike:
 
 
 def _low_altitude_m_to_pl(h: npt.NDArray[np.floating]) -> npt.NDArray[np.floating]:
-    T_isa: np.ndarray = m_to_T_isa(h)
+    T_isa = m_to_T_isa(h)
     power_term = -constants.g / (constants.T_lapse_rate * constants.R_d)
     return (constants.p_surface * (T_isa / constants.T_msl) ** power_term) / 100.0
 

--- a/tests/unit/test_dry_advection.py
+++ b/tests/unit/test_dry_advection.py
@@ -219,5 +219,5 @@ def test_dry_advection_with_target_time(
         pd.Timestamp(target_time).ceil("5min"),
         freq="5min",
         inclusive="right",
-    ).to_numpy()
+    )[1:].to_numpy()  # the very first waypoint blows out of bounds, so it's not in the output
     np.testing.assert_array_equal(np.unique(out["time"]), expected_times)


### PR DESCRIPTION
#### Features

- Add new `target_time` parameter to the `DryAdvection` model. If provided, this parameter overrides the `max_age` parameter and allows the model to advect all waypoints to the specified time. This is useful for running advection simulations over a fixed time period rather than a fixed age. The `target_time` parameter is optional and defaults to `None`, in which case the model behaves as before.

#### Fixes

- Fix an issue with the `DryAdvection.eval` implementation in which a large temporal gap between waypoints caused the model to end prematurely.

## Tests

- [x] QC test passes locally (`make test`)
- [ ] CI tests pass

## Reviewer

@thabbott 
