### PR TITLE
Update missing data error messages in GOES datalib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.59.0 (unreleased)
+
+### Breaking changes
+
+- Updated error handling in `goes.gcs_goes_path` to raise a `FileNotFoundError` if any of the requested bands are not available. Previous versions raised a `RuntimeError` only in cases where no requested bands were available.
+
 ## 0.58.0
 
 ### Features

--- a/pycontrails/datalib/goes.py
+++ b/pycontrails/datalib/goes.py
@@ -308,9 +308,14 @@ def gcs_goes_path(
     fs = fs or gcsfs.GCSFileSystem(token="anon")
     rpaths = fs.glob(rpath)
 
-    out = [r for r in rpaths if _extract_band_from_rpath(r) in bands]
-    if not out:
-        raise RuntimeError(f"No data found for {time} in {region} for bands {bands}")
+    out = []
+    for r in rpaths:
+        if (band := _extract_band_from_rpath(r)) in bands:
+            out.append(r)
+            bands.remove(band)
+
+    if bands:
+        raise FileNotFoundError(f"No data found for {time} in {region} for bands {bands}")
     return out
 
 


### PR DESCRIPTION
Closes #347 

With these changes, code snippets from #347 behave as expected.
```python
from pycontrails.datalib import goes
handler = goes.GOES(region="F")
handler.get("2025-10-20 16:10")
```
produces a `FileNotFoundError` regardless of the state of the local cache, and
```python
from pycontrails.datalib import goes
handler = goes.GOES(region="F")
handler.get("2025-10-20 16:10")
```
produces a `FileNotFoundError` rather than returning a DataArray with channel 11 missing.

The error handling is tested at the end of `test_goes.py`, but the test will break if the data gap in channel 11 at 2025/10/20 16:10 is filled. We could keep it for now and see if it becomes a problem, or we could point the test to a custom GOES bucket instead, or we could just get rid of that test.

## Changes

#### Breaking changes

- Updated error handling in `goes.gcs_goes_path` to raise a `FileNotFoundError` if any of the requested bands are not available. Previous versions raised a `RuntimeError` only in cases where no requested bands were available.

## Tests

- [x] QC test passes locally (`make test`)
- [ ] CI tests pass

## Reviewer

> @zebengberg 
