### PR TITLE
Add utils and notebook converting ADS-B to Flight DF

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ END_COLOR = \033[0m
 # versions of python
 pip-install:
 	python -m pip install -U pip wheel
+	python -m pip install plotly
 	python -m pip install -e ".[complete]"
 
 	# open3d wheels not available for latest python versions; install manually

--- a/docs/flight.rst
+++ b/docs/flight.rst
@@ -9,5 +9,6 @@ Flight data
    :caption: Notebooks
 
    notebooks/Flight
+   notebooks/adsb-flight-loading
    notebooks/airports
    notebooks/flightplan

--- a/docs/notebooks/adsb-flight-loading.ipynb
+++ b/docs/notebooks/adsb-flight-loading.ipynb
@@ -1,0 +1,1685 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a45dac83",
+   "metadata": {},
+   "source": [
+    "# Load ADS-B Flight Data\n",
+    "\n",
+    "This notebook demonstrates how to fetch flight data from the contrails.org [ADS-B API](https://apidocs.contrails.org/notebooks/adsb_api.html), impute missing flight IDs, and structure the data into a [`pycontrails.Flight`](https://py.contrails.org/api/pycontrails.Flight.html) DataFrame."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b72bccce",
+   "metadata": {},
+   "source": [
+    "## Imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "724773d7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import asyncio\n",
+    "import io\n",
+    "import time\n",
+    "from datetime import date, datetime, timedelta\n",
+    "\n",
+    "import aiohttp\n",
+    "import pandas as pd\n",
+    "import plotly.graph_objects as go\n",
+    "\n",
+    "from pycontrails import Flight\n",
+    "from pycontrails.core import flight"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "09c3597a",
+   "metadata": {},
+   "source": [
+    "# Configuration\n",
+    "\n",
+    "Set the date for data retrieval and your contrails API key.\n",
+    "\n",
+    "Contact api@contrails.org if you need an API key."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1184851b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Replace with the desired date range. End date is inclusive.\n",
+    "START_DATE = date(2025, 1, 15)\n",
+    "END_DATE = date(2025, 1, 16)\n",
+    "\n",
+    "# Replace with your contrails.org API key\n",
+    "CONTRAILS_API_KEY = \"your key here\"  # @param {type:\\\"string\\\"}\n",
+    "\n",
+    "API_BASE_URL = \"https://api.contrails.org/v1/adsb/telemetry\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b288a2d1",
+   "metadata": {},
+   "source": [
+    "# Fetch global ADS-B asynchronously\n",
+    "\n",
+    "See API documentation: [https://apidocs.contrails.org/notebooks/adsb_api.html](https://apidocs.contrails.org/notebooks/adsb_api.html)\n",
+    "\n",
+    "Fetch data in hourly chunks for the target date concurrently using `asyncio` and `aiohttp`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "836919fa",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fetching data from 2025-01-15 to 2025-01-16\n",
+      "Fetching data for 2025-01-15\n",
+      "Total response size: 16494.38 MB\n",
+      "Fetching data for 2025-01-16\n",
+      "Total response size: 16225.12 MB\n",
+      "Flight data ingestion completed in 136.58s\n",
+      "Fetched 53055476 waypoints in total.\n",
+      "            timestamp   latitude   longitude collection_type  altitude_baro  \\\n",
+      "0 2025-01-15 00:59:59  44.242130  -93.978523     terrestrial           2550   \n",
+      "1 2025-01-15 00:59:59  41.310501 -112.014915     terrestrial           5000   \n",
+      "2 2025-01-15 00:59:59  40.158661  -80.841522     terrestrial          41000   \n",
+      "3 2025-01-15 00:59:59  34.386703  -82.267700     terrestrial           4250   \n",
+      "4 2025-01-15 00:59:59  33.856884  -84.697784     terrestrial          11625   \n",
+      "\n",
+      "   altitude_gnss icao_address                             flight_id callsign  \\\n",
+      "0            NaN       A3E5EA  c57f2c52-6c77-4025-89b8-58645c8af44b    MVK51   \n",
+      "1            NaN       A32A1E  d35885bc-221a-426b-8bb8-043fa907e8eb   N3027S   \n",
+      "2            NaN       A4C00D  190ffc48-fbd1-4c43-985f-bad3adbdf6ec   JRE405   \n",
+      "3            NaN       A67040  1e557528-404c-4c14-a5b9-26812706e5a2   N51390   \n",
+      "4            NaN       A2FAF0  65be145b-3514-433a-a5c8-5834b0384817     YEL1   \n",
+      "\n",
+      "  tail_number flight_number aircraft_type_icao airline_iata  \\\n",
+      "0      N350MK          None               P28A         None   \n",
+      "1      N3027S          None               P28A         None   \n",
+      "2      N405JS          None               GLF4         None   \n",
+      "3      N51390          None               C172         None   \n",
+      "4      N291TX          None               E55P         None   \n",
+      "\n",
+      "  departure_airport_icao departure_scheduled_time arrival_airport_icao  \\\n",
+      "0                   None                      NaT                 None   \n",
+      "1                   None                      NaT                 None   \n",
+      "2                   KPTK                      NaT                 KISO   \n",
+      "3                   None                      NaT                 None   \n",
+      "4                   None                      NaT                 None   \n",
+      "\n",
+      "  arrival_scheduled_time  nic  nacp  \n",
+      "0                    NaT  NaN   NaN  \n",
+      "1                    NaT  NaN   NaN  \n",
+      "2                    NaT  NaN   NaN  \n",
+      "3                    NaT  NaN   NaN  \n",
+      "4                    NaT  NaN   NaN  \n"
+     ]
+    }
+   ],
+   "source": [
+    "async def fetch_adsb_data_hour(\n",
+    "    session: aiohttp.ClientSession, dt_hour: datetime, api_key: str\n",
+    ") -> pd.DataFrame | None:\n",
+    "    \"\"\"Asynchronously fetch ADS-B data for a single hour.\"\"\"\n",
+    "    headers = {\"accept\": \"application/vnd.apache.parquet\", \"x-api-key\": api_key}\n",
+    "    # The /telemetry endpoint uses 'date' param for the start of the hour\n",
+    "    params = {\"date\": dt_hour.strftime(\"%Y-%m-%dT%H\")}\n",
+    "\n",
+    "    try:\n",
+    "        async with session.get(API_BASE_URL, headers=headers, params=params) as response:\n",
+    "            response.raise_for_status()\n",
+    "            content = await response.read()\n",
+    "            if not content:\n",
+    "                print(f\"No content received for {dt_hour}\")\n",
+    "                return None\n",
+    "            # Load Parquet from response content\n",
+    "            return pd.read_parquet(io.BytesIO(content))\n",
+    "    except aiohttp.ClientError as e:\n",
+    "        print(f\"Error fetching data for {dt_hour}: {e}\")\n",
+    "        return None\n",
+    "    except Exception as e:\n",
+    "        print(f\"Error processing data for {dt_hour}: {e}\")\n",
+    "        return None\n",
+    "\n",
+    "\n",
+    "async def fetch_all_day_data(target_date: date, api_key: str) -> pd.DataFrame:\n",
+    "    \"\"\"Fetch ADS-B data for the entire day asynchronously.\"\"\"\n",
+    "    start_datetime = datetime(target_date.year, target_date.month, target_date.day)\n",
+    "    tasks = []\n",
+    "\n",
+    "    async with aiohttp.ClientSession() as session:\n",
+    "        for hour in range(24):\n",
+    "            dt_hour = start_datetime + timedelta(hours=hour)\n",
+    "            tasks.append(fetch_adsb_data_hour(session, dt_hour, api_key))\n",
+    "\n",
+    "        results = await asyncio.gather(*tasks, return_exceptions=True)\n",
+    "\n",
+    "    dataframes = []\n",
+    "    total_resp_size = 0\n",
+    "    for res in results:\n",
+    "        if isinstance(res, pd.DataFrame) and not res.empty:\n",
+    "            dataframes.append(res)\n",
+    "            total_resp_size += res.memory_usage(deep=True).sum()\n",
+    "        elif isinstance(res, Exception):\n",
+    "            print(f\"An exception occurred during fetch: {res}\")\n",
+    "\n",
+    "    if not dataframes:\n",
+    "        raise ValueError(\"No data fetched. Check API key and date range.\")\n",
+    "\n",
+    "    print(f\"Total response size: {round(total_resp_size / 1000000, 2)} MB\")\n",
+    "    return pd.concat(dataframes, ignore_index=True)\n",
+    "\n",
+    "\n",
+    "# Asynchronously fetch waypoint data for given date range\n",
+    "all_raw_dfs = []\n",
+    "date_range = pd.date_range(start=START_DATE, end=END_DATE, freq=\"D\")\n",
+    "\n",
+    "print(f\"Fetching data from {START_DATE} to {END_DATE}\")\n",
+    "start_time = time.time()\n",
+    "\n",
+    "for target_date in date_range:\n",
+    "    print(f\"Fetching data for {target_date.date()}\")\n",
+    "    try:\n",
+    "        daily_df = await fetch_all_day_data(target_date.date(), CONTRAILS_API_KEY)\n",
+    "        if not daily_df.empty:\n",
+    "            all_raw_dfs.append(daily_df)\n",
+    "    except ValueError as e:\n",
+    "        print(f\"Error for {target_date.date()}: {e}\")\n",
+    "\n",
+    "if all_raw_dfs:\n",
+    "    raw_df = pd.concat(all_raw_dfs, ignore_index=True)\n",
+    "    total_time_taken = time.time() - start_time\n",
+    "    print(f\"Flight data ingestion completed in {total_time_taken:.2f}s\")\n",
+    "    print(f\"Fetched {len(raw_df)} waypoints in total.\")\n",
+    "    print(raw_df.head())\n",
+    "else:\n",
+    "    raw_df = pd.DataFrame()  # Initialize empty DataFrame\n",
+    "    print(\"No data fetched for the specified date range.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "09630b43",
+   "metadata": {},
+   "source": [
+    "# Data Cleaning and Preparation\n",
+    "\n",
+    "Ensure correct data types and sort the data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9cec5d45",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cleaned DataFrame has 53055476 waypoints.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>time</th>\n",
+       "      <th>latitude</th>\n",
+       "      <th>longitude</th>\n",
+       "      <th>collection_type</th>\n",
+       "      <th>altitude</th>\n",
+       "      <th>icao</th>\n",
+       "      <th>flight_id</th>\n",
+       "      <th>tail_number</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2025-01-15 00:59:59+00:00</td>\n",
+       "      <td>44.242130</td>\n",
+       "      <td>-93.978523</td>\n",
+       "      <td>terrestrial</td>\n",
+       "      <td>2550</td>\n",
+       "      <td>A3E5EA</td>\n",
+       "      <td>c57f2c52-6c77-4025-89b8-58645c8af44b</td>\n",
+       "      <td>N350MK</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2025-01-15 00:59:59+00:00</td>\n",
+       "      <td>41.310501</td>\n",
+       "      <td>-112.014915</td>\n",
+       "      <td>terrestrial</td>\n",
+       "      <td>5000</td>\n",
+       "      <td>A32A1E</td>\n",
+       "      <td>d35885bc-221a-426b-8bb8-043fa907e8eb</td>\n",
+       "      <td>N3027S</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2025-01-15 00:59:59+00:00</td>\n",
+       "      <td>40.158661</td>\n",
+       "      <td>-80.841522</td>\n",
+       "      <td>terrestrial</td>\n",
+       "      <td>41000</td>\n",
+       "      <td>A4C00D</td>\n",
+       "      <td>190ffc48-fbd1-4c43-985f-bad3adbdf6ec</td>\n",
+       "      <td>N405JS</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2025-01-15 00:59:59+00:00</td>\n",
+       "      <td>34.386703</td>\n",
+       "      <td>-82.267700</td>\n",
+       "      <td>terrestrial</td>\n",
+       "      <td>4250</td>\n",
+       "      <td>A67040</td>\n",
+       "      <td>1e557528-404c-4c14-a5b9-26812706e5a2</td>\n",
+       "      <td>N51390</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>2025-01-15 00:59:59+00:00</td>\n",
+       "      <td>33.856884</td>\n",
+       "      <td>-84.697784</td>\n",
+       "      <td>terrestrial</td>\n",
+       "      <td>11625</td>\n",
+       "      <td>A2FAF0</td>\n",
+       "      <td>65be145b-3514-433a-a5c8-5834b0384817</td>\n",
+       "      <td>N291TX</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                       time   latitude   longitude collection_type  altitude  \\\n",
+       "0 2025-01-15 00:59:59+00:00  44.242130  -93.978523     terrestrial      2550   \n",
+       "1 2025-01-15 00:59:59+00:00  41.310501 -112.014915     terrestrial      5000   \n",
+       "2 2025-01-15 00:59:59+00:00  40.158661  -80.841522     terrestrial     41000   \n",
+       "3 2025-01-15 00:59:59+00:00  34.386703  -82.267700     terrestrial      4250   \n",
+       "4 2025-01-15 00:59:59+00:00  33.856884  -84.697784     terrestrial     11625   \n",
+       "\n",
+       "     icao                             flight_id tail_number  \n",
+       "0  A3E5EA  c57f2c52-6c77-4025-89b8-58645c8af44b      N350MK  \n",
+       "1  A32A1E  d35885bc-221a-426b-8bb8-043fa907e8eb      N3027S  \n",
+       "2  A4C00D  190ffc48-fbd1-4c43-985f-bad3adbdf6ec      N405JS  \n",
+       "3  A67040  1e557528-404c-4c14-a5b9-26812706e5a2      N51390  \n",
+       "4  A2FAF0  65be145b-3514-433a-a5c8-5834b0384817      N291TX  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "def clean_adsb_df(df: pd.DataFrame) -> pd.DataFrame:\n",
+    "    \"\"\"Clean and prepare the raw ADS-B DataFrame.\"\"\"\n",
+    "    if df.empty:\n",
+    "        return df\n",
+    "    df = df.copy()\n",
+    "\n",
+    "    # Rename columns to match pycontrails expectations\n",
+    "    # The API returns 'altitude_baro', 'icao_address', and 'timestamp'\n",
+    "    # Pycontrails expects 'altitude', 'icao', and 'time'\n",
+    "    rename_map = {\n",
+    "        \"altitude_baro\": \"altitude\",\n",
+    "        \"icao_address\": \"icao\",\n",
+    "        \"timestamp\": \"time\",\n",
+    "    }\n",
+    "    df = df.rename(columns=rename_map)\n",
+    "\n",
+    "    # Ensure time is datetime object\n",
+    "    df[\"time\"] = pd.to_datetime(df[\"time\"], utc=True)\n",
+    "\n",
+    "    # Select necessary columns\n",
+    "    columns = [\n",
+    "        \"time\",\n",
+    "        \"latitude\",\n",
+    "        \"longitude\",\n",
+    "        \"altitude\",\n",
+    "        \"icao\",\n",
+    "        \"flight_id\",\n",
+    "        \"tail_number\",\n",
+    "        \"collection_type\",\n",
+    "    ]\n",
+    "    # Keep only columns that exist in the dataframe\n",
+    "    return df[df.columns.intersection(columns)]\n",
+    "\n",
+    "\n",
+    "if not raw_df.empty:\n",
+    "    cleaned_df = clean_adsb_df(raw_df)\n",
+    "    print(f\"Cleaned DataFrame has {len(cleaned_df)} waypoints.\")\n",
+    "    display(cleaned_df.head())\n",
+    "else:\n",
+    "    cleaned_df = pd.DataFrame()\n",
+    "    print(\"Skipping cleaning, no data loaded.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6e85d880",
+   "metadata": {},
+   "source": [
+    "# Create Flights from grouped waypoints\n",
+    "\n",
+    "Create a dataframe of flights grouped by Flight ID. Imput missing `flight_id` values based on temporal proximity for the same ICAO address.\n",
+    "\n",
+    "**Methodology:**\n",
+    "\n",
+    "1. Group waypoints by `icao`.\n",
+    "2. Identify segments where `flight_id` is missing\n",
+    "3. Group consecutive missing `flight_id` waypoints if the time gap is less than `MAX_GAP_SECONDS`.\n",
+    "4. For each group of missing IDs, look for a known `flight_id` within `LOOKUP_WINDOW_SECONDS` before the start or after the end of the group.\n",
+    "5. If multiple known IDs are found, use the chronologically closest one.\n",
+    "6. If no known ID is found, generate a new unique `flight_id` for that segment.\n",
+    "\n",
+    "**On flight ID generation:**\n",
+    "\n",
+    "Flight IDs are generated based on the flight's start and end timestamps and its ICAO address. All IDs are prefixed with SPIRE-INFERRED-{icao_address}-. The rest of the ID depends on the time of day:\n",
+    "\n",
+    "1. Midnight Rollover/Holdover: Special formatting is applied if the flight period crosses midnight within a certain threshold (midnight_threshold_mins).\n",
+    "\n",
+    "* If the flight ends just after midnight (a \"holdover\"), the ID includes the dates of the day before the start and the start date, formatted as: {start_date - 1 day}-rollover-{start_date}.\n",
+    "* If the flight starts just before midnight (a \"rollover\"), the ID includes the start date and the day after the end date, formatted as: {start_date}-rollover-{end_date + 1 day}.\n",
+    "2. Standard: If the flight period doesn't cross the midnight threshold, the ID is generated using the Unix timestamp (in seconds) of the start and end times: {int(start_timestamp)}-{int(end_timestamp)}.\n",
+    "\n",
+    "Examples:\n",
+    "\n",
+    "* Holdover: `SPIRE-INFERRED-ABC123-2026-02-03-rollover-2026-02-04`\n",
+    "* Rollover: `SPIRE-INFERRED-ABC123-2026-02-04-rollover-2026-02-05`\n",
+    "* Standard: `SPIRE-INFERRED-ABC123-1760035200-1760042400`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "76706996",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/google/home/jocelinl/git/pycontrails/pycontrails/core/flight.py:265: UserWarning: Sorting Flight data by time.\n",
+      "  warnings.warn(\"Sorting Flight data by time.\")\n",
+      "/usr/local/google/home/jocelinl/git/pycontrails/pycontrails/core/flight.py:244: UserWarning: Flight altitude is high for flight fb2e1605-4163-4ad3-8b3b-9d22764f6231. Expected altitude unit is meters. Found waypoint with altitude 43025 m.\n",
+      "  warnings.warn(\n",
+      "/usr/local/google/home/jocelinl/git/pycontrails/pycontrails/core/flight.py:244: UserWarning: Flight altitude is high for flight 7d666254-1de2-4d97-a662-96f89540d89a. Expected altitude unit is meters. Found waypoint with altitude 27275 m.\n",
+      "  warnings.warn(\n",
+      "/usr/local/google/home/jocelinl/git/pycontrails/pycontrails/core/flight.py:244: UserWarning: Flight altitude is high for flight 0bd7e4db-9207-4ccf-b0ea-7a4b52bbcce1. Expected altitude unit is meters. Found waypoint with altitude 43975 m.\n",
+      "  warnings.warn(\n",
+      "/usr/local/google/home/jocelinl/git/pycontrails/pycontrails/core/flight.py:244: UserWarning: Flight altitude is high for flight ab0fc799-aa23-447f-9836-c7d7d505f946. Expected altitude unit is meters. Found waypoint with altitude 33000 m.\n",
+      "  warnings.warn(\n",
+      "/usr/local/google/home/jocelinl/git/pycontrails/pycontrails/core/flight.py:244: UserWarning: Flight altitude is high for flight a448aed7-1a66-4cca-9bd9-48eb8a53b266. Expected altitude unit is meters. Found waypoint with altitude 41950 m.\n",
+      "  warnings.warn(\n",
+      "/usr/local/google/home/jocelinl/git/pycontrails/pycontrails/core/flight.py:244: UserWarning: Flight altitude is high for flight c3c8aa73-94fc-4e27-803e-230eebc24c22. Expected altitude unit is meters. Found waypoint with altitude 43700 m.\n",
+      "  warnings.warn(\n",
+      "/usr/local/google/home/jocelinl/git/pycontrails/pycontrails/core/flight.py:244: UserWarning: Flight altitude is high for flight cc9bb585-1b37-414d-b81a-3653df4d3013. Expected altitude unit is meters. Found waypoint with altitude 34575 m.\n",
+      "  warnings.warn(\n",
+      "/usr/local/google/home/jocelinl/git/pycontrails/pycontrails/core/flight.py:244: UserWarning: Flight altitude is high for flight 99b71ebe-3f18-469d-ad0c-d89994f87662. Expected altitude unit is meters. Found waypoint with altitude 16625 m.\n",
+      "  warnings.warn(\n",
+      "/usr/local/google/home/jocelinl/git/pycontrails/pycontrails/core/flight.py:244: UserWarning: Flight altitude is high for flight 854e2301-e0d0-4f46-a1d5-3426e0145602. Expected altitude unit is meters. Found waypoint with altitude 42875 m.\n",
+      "  warnings.warn(\n",
+      "/usr/local/google/home/jocelinl/git/pycontrails/pycontrails/core/flight.py:244: UserWarning: Flight altitude is high for flight 1d2744b9-2d63-42c3-85fb-0d25a29d6761. Expected altitude unit is meters. Found waypoint with altitude 36025 m.\n",
+      "  warnings.warn(\n",
+      "/usr/local/google/home/jocelinl/git/pycontrails/pycontrails/core/flight.py:244: UserWarning: Flight altitude is high for flight ff3ac9e3-1502-452b-8a79-db1c6f0c202e. Expected altitude unit is meters. Found waypoint with altitude 31550 m.\n",
+      "  warnings.warn(\n",
+      "/usr/local/google/home/jocelinl/git/pycontrails/pycontrails/core/flight.py:244: UserWarning: Flight altitude is high for flight 6a802e13-8350-48cb-af79-e84ffca0f994. Expected altitude unit is meters. Found waypoint with altitude 40300 m.\n",
+      "  warnings.warn(\n",
+      "/usr/local/google/home/jocelinl/git/pycontrails/pycontrails/core/flight.py:244: UserWarning: Flight altitude is high for flight d595e111-7f11-4e7f-9b66-146fed749f9f. Expected altitude unit is meters. Found waypoint with altitude 43000 m.\n",
+      "  warnings.warn(\n",
+      "/usr/local/google/home/jocelinl/git/pycontrails/pycontrails/core/flight.py:244: UserWarning: Flight altitude is high for flight fc25a18b-0aad-4c47-82fe-ba9491391e5f. Expected altitude unit is meters. Found waypoint with altitude 40025 m.\n",
+      "  warnings.warn(\n",
+      "/usr/local/google/home/jocelinl/git/pycontrails/pycontrails/core/flight.py:244: UserWarning: Flight altitude is high for flight 1ffc3f71-8b4a-4b13-b0b4-cb2028455620. Expected altitude unit is meters. Found waypoint with altitude 35775 m.\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Created 23 Flight objects.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Run imputation and create Flight objects\n",
+    "if not cleaned_df.empty:\n",
+    "    imputed_df = flight.impute_flight_ids(cleaned_df)\n",
+    "\n",
+    "    # Group into pycontrails Flight objects\n",
+    "    # We limit to a few flights for the demonstration to save memory\n",
+    "    unique_ids = imputed_df[\"flight_id\"].unique()[:100]\n",
+    "    flights_data = []\n",
+    "    for fid in unique_ids:\n",
+    "        f_df = imputed_df[imputed_df[\"flight_id\"] == fid]\n",
+    "        if len(f_df) > 200:  # Only keep flights with enough points\n",
+    "            try:\n",
+    "                flights_data.append(Flight(f_df, flight_id=fid))\n",
+    "            except Exception as e:\n",
+    "                print(f\"Error creating Flight object for {fid}: {e}\")\n",
+    "\n",
+    "    print(f\"Created {len(flights_data)} Flight objects.\")\n",
+    "else:\n",
+    "    flights_data = []"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "58318558",
+   "metadata": {},
+   "source": [
+    "# Example: Accessing Data for a Flight"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "101f1424",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/google/home/jocelinl/python/pycontrails-env/lib/python3.13/site-packages/lark/parse_tree_builder.py:152: RuntimeWarning:\n",
+      "\n",
+      "coroutine 'fetch_all_day_data' was never awaited\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "hovertext": [
+          "00:10:35",
+          "00:10:55",
+          "00:11:03",
+          "00:11:56",
+          "00:12:28",
+          "00:12:55",
+          "00:13:00",
+          "00:13:59",
+          "00:14:03",
+          "00:14:56",
+          "00:15:00",
+          "00:15:55",
+          "00:16:03",
+          "00:16:59",
+          "00:17:03",
+          "00:17:56",
+          "00:18:00",
+          "00:18:59",
+          "00:19:03",
+          "00:19:59",
+          "00:20:11",
+          "00:20:56",
+          "00:21:00",
+          "00:21:55",
+          "00:22:00",
+          "00:22:56",
+          "00:23:03",
+          "00:23:56",
+          "00:24:00",
+          "00:24:56",
+          "00:25:00",
+          "00:25:56",
+          "00:26:03",
+          "00:26:56",
+          "00:27:00",
+          "00:27:56",
+          "00:28:00",
+          "00:28:56",
+          "00:29:03",
+          "00:29:59",
+          "00:30:04",
+          "00:30:59",
+          "00:31:05",
+          "00:31:57",
+          "00:32:02",
+          "00:32:59",
+          "00:33:06",
+          "00:33:58",
+          "00:34:03",
+          "00:34:55",
+          "00:35:02",
+          "00:35:58",
+          "00:36:07",
+          "00:36:58",
+          "00:37:15",
+          "00:37:53",
+          "00:38:00",
+          "00:38:58",
+          "00:39:05",
+          "00:39:45",
+          "00:40:02",
+          "00:40:57",
+          "00:41:01",
+          "00:41:58",
+          "00:42:01",
+          "00:42:49",
+          "00:43:09",
+          "00:43:52",
+          "00:44:05",
+          "00:44:59",
+          "00:45:07",
+          "00:45:59",
+          "00:46:04",
+          "00:46:56",
+          "00:47:00",
+          "00:47:59",
+          "00:48:04",
+          "00:48:55",
+          "00:49:00",
+          "00:49:56",
+          "00:50:00",
+          "00:50:56",
+          "00:51:04",
+          "00:51:56",
+          "00:52:00",
+          "00:52:59",
+          "00:53:04",
+          "00:53:52",
+          "00:54:00",
+          "00:54:52",
+          "00:55:00",
+          "00:55:56",
+          "00:56:00",
+          "00:56:56",
+          "00:57:04",
+          "00:57:56",
+          "00:58:00",
+          "00:58:59",
+          "00:59:04",
+          "00:59:59",
+          "01:00:04",
+          "01:00:59",
+          "01:01:04",
+          "01:01:52",
+          "01:02:00",
+          "01:02:56",
+          "01:03:00",
+          "01:03:56",
+          "01:04:08",
+          "01:04:56",
+          "01:05:00",
+          "01:05:56",
+          "01:06:00",
+          "01:06:56",
+          "01:07:00",
+          "01:07:58",
+          "01:08:01",
+          "01:08:59",
+          "01:09:05",
+          "01:09:56",
+          "01:10:00",
+          "01:10:59",
+          "01:11:04",
+          "01:11:54",
+          "01:12:00",
+          "01:12:59",
+          "01:13:02",
+          "01:13:32",
+          "01:14:13",
+          "01:14:56",
+          "01:15:01",
+          "01:15:56",
+          "01:16:33",
+          "01:16:48",
+          "01:17:04",
+          "01:17:44",
+          "01:18:03",
+          "01:18:40",
+          "01:19:14",
+          "01:19:56",
+          "01:20:44",
+          "01:20:50",
+          "01:21:04",
+          "01:21:59",
+          "01:22:09",
+          "01:22:57",
+          "01:23:04",
+          "01:23:59",
+          "01:24:05",
+          "01:24:57",
+          "01:25:09",
+          "01:25:57",
+          "01:26:04",
+          "01:26:52",
+          "01:27:00",
+          "01:27:57",
+          "01:28:09",
+          "01:28:57",
+          "01:29:02",
+          "01:29:56",
+          "01:30:00",
+          "01:30:48",
+          "01:31:01",
+          "01:31:37",
+          "01:32:30",
+          "01:32:57",
+          "01:33:25",
+          "01:33:40",
+          "01:34:34",
+          "01:34:58",
+          "01:35:04",
+          "01:35:58",
+          "01:36:04",
+          "01:36:43",
+          "01:37:25",
+          "01:37:43",
+          "01:38:40",
+          "01:38:55",
+          "01:39:01",
+          "01:39:53",
+          "01:40:05",
+          "01:40:59",
+          "01:41:03",
+          "01:41:59",
+          "01:42:05",
+          "01:42:59",
+          "01:43:08",
+          "01:43:51",
+          "01:44:00",
+          "01:44:59",
+          "01:45:03",
+          "01:45:59",
+          "01:46:03",
+          "01:46:47",
+          "01:47:04",
+          "01:47:59",
+          "01:48:02",
+          "01:48:56",
+          "01:49:00",
+          "01:49:56",
+          "01:50:03",
+          "01:50:55",
+          "01:51:04",
+          "01:51:59",
+          "01:52:02",
+          "01:52:55",
+          "01:53:00",
+          "01:53:55",
+          "01:54:00",
+          "01:54:59",
+          "01:55:03",
+          "01:55:51",
+          "01:56:00",
+          "01:56:59",
+          "01:57:07",
+          "01:57:52",
+          "01:58:00",
+          "01:58:55",
+          "01:59:00",
+          "01:59:56"
+         ],
+         "lat": {
+          "bdata": "Vz1gHjKZQUBeZAJ+jZhBQPXb14FzmEFA2ZQrvMuXQUCLbyh8tpZBQFAcQL/vlUFAY2TJHMuVQUB6bwwBwJNBQD/mAwKdk0FATfVk/tGRQUBhjh6/t5FBQOs56X3jj0FAuOaO/pePQUD8pUV9ko1BQIzbaABvjUFA32+044aLQUACu5o8ZYtBQGiR7Xw/iUFAUkZcABqJQUAtCOV9HIdBQEewcf27hkFA3eukviyFQUBagoyACoVBQCsyOiAJg0FACDnv/+OCQUAgfv578IBBQJnzjH3JgEFAkgiNYON+QUCfsMQDyn5BQNV2E3zTfEFAmu0KfbB8QUB/h6JAn3pBQLgHISBfekFAIuF7f4N4QUCM2CeAYnhBQDdQ4J18dkFAqtTsgVZ2QUA5m44AbnRBQG9L5IIzdEFA9s/TgEFyQUBmZ9E7FXJBQPZgUnx8cEFAflTDfk9wQUDrNqj91m5BQEIKnkKubkFA/aIE/YVsQUB3EhH+RWxBQDNTWn9LakFAEqW9wRdqQUCdSgaAKmhBQL06x4DsZ0FA8KXwoNllQUDEQxg/jWVBQOkMjLysY0FAK4nsgyxjQUB2/YLdsGFBQBuciH5tYUFASRCugEJfQUAuAmN9A19BQH+EYcCSXUFAdy0hH/RcQUB4flGC/lpBQGgkQiPYWkFAxXO2gNBYQUBO7KF9rFhBQDY+k/3zVkFA499nXDhWQUAHDJI+rVRBQKSMuAA0VEFA9PkoIy5SQUBM++b+6lFBQL8Qct7/T0FAj+TyH9JPQUBPyw9c5U1BQFIQPL69TUFAXeLIA5FLQUA9uaZAZktBQIZ1492RSUFAyy4YXHNJQUBPWOIBZUdBQPWB5J1DR0FA9ntinSpFQUAtd2aC4URBQP8Iw4AlQ0FA1IIXfQVDQUDaOc0C7UBBQJRNucK7QEFA6kKs/gg/QUAKLev+sT5BQM4AF2TLPEFA0J1g/3U8QUBmoDL+fTpBQG/W4H1VOkFAQtE8gEU4QUAWwJSBAzhBQI1BJ4QONkFA6znpfeM1QUAGD9O+uTNBQF5nQ/6ZM0FA7iHhe38xQUD9FMeBVzFBQFJGXAAaL0FAklm9w+0uQUAFb0ijAi1BQGSsNv+vLEFA0O6QYoAqQUAaFM0DWCpBQPfJUYAoKEFAa5p3nKInQUBJSQ9DqyVBQNtOWyOCJUFA6brwg/MjQUCmKQKc3iNBQFzHuOLiIkFARDF5A8wiQUDU7lcBviFBQFd2weCaIUFA6DBfXoAfQUCGkzR/TB9BQI/8wcBzHUFALV+X4T8dQUAHRfMAFhtBQB75g4HnGkFAjsni/iMZQUDRWzy85xhBQFU01v7OFkFAOX09X7MWQUABaf8DrBVBQHDQXn08FEFAbr4R3bMSQUD04VmCjBJBQKIpO/2gEEFAO+P74lIPQUDK372jxg5BQG9L5IIzDkFA3bJD/MMMQUD/BYIAGQxBQGHij6LOCkFAfGMIAI4JQUB0YDlCBghBQNjTDn9NBkFAJET5ghYGQUCpaKz9nQVBQJcaoZ+pA0FAshNeglMDQUC/KEF/oQFBQMU3FD5bAUFABdzz/Gn/QEAi/IugMf9AQC3qk9xh/UBAzZGVXwb9QEBhVb38TvtAQBiT/l4K+0BAHJYGflT5QEDiBnx+GPlAQNEDH4MV90BA5e5zfLT2QEBjuDoA4vRAQNwtyQG79EBA2uIan8nyQEBdaoR+pvJAQMUENXwL8UBA/B2KAn3wQEDQCaGDLu9AQBsRjINL7UBAjdKlf0nsQEAyVpv/V+tAQFhVL7/T6kBAxHk4genoQEA0vFmD9+dAQIXSF0LO50BACTauf9flQECvJeSDnuVAQJI+raI/5EBA3C3JAbviQEBosn+eBuJAQHA/4IEB4EBATg00n3PfQECp+wCkNt9AQJD2P8Ba3UBAxHk4gencQEAuAmN9A9tAQPLtXYO+2kBABwySPq3YQEBy/bs+c9hAQF7ZBYNr1kBAJ2vUQzTWQECXOzPBcNRAQPqZet0i1EBA4ng+A+rRQEAKMCx/vtFAQNY5BmSvz0BAx2Rx/5HPQEAteqcC7s1AQNGUnX5QzUBAo4/5gEDLQEBGmKJcGstAQIGWrmAbyUBA275H/fXIQECE1VjC2sZAQMAlAP+UxkBAU14robvEQED+nIL8bMRAQIgOgSOBwkBAQ61p3nHCQEBApN++DsJAQJDAH37+wUBAdhvUfmvBQEAROX09X8FAQLoQqz/CwEBAI72o3a/AQEAIHt/eNcBAQNEGYAMiwEBAsaTcfY6/QEBd3EYDeL9AQAc/cQD9vkBAg4qqX+m+QEAd5PVgUr5AQEjCvp1EvkBA3CqIga69QEA=",
+          "dtype": "f8"
+         },
+         "line": {
+          "color": "red",
+          "width": 2
+         },
+         "lon": {
+          "bdata": "Gof6XdhJVMAtCyb+KEpUwChEwCFUSlTAP49RnnlLVMDqP2t+/EtUwB+6oL5lTFTAlj50QX1MVMBC6Qsh501UwBmQvd79TVTAP62iPzRPVMDc8Sa/RU9UwDvFqkGYUFTAVoLF4cxQVMDiWu1hL1JUwPmiPV5IUlTAuOaO/pdTVMDcKoiBrlNUwF980R4vVVTAn3HhQEhVVMAziXrBp1ZUwMMrSZ7rVlTAuB/wwABYVMC+FvTeGFhUwD+PUZ55WVTAtcU1PpNZVMC9OseA7FpUwNjxXyAIW1TAS+ZY3lVcVMC06QjgZlxUwOIhjJ/GXVTAoDiAft9dVMB4YADhQ19UwErs2t5uX1TAbO7of7lgVMDWxAJf0WBUwOJXrOEiYlTAz77yID1iVMBmo3N+imNUwBWNtb+zY1TAI/PIHwxlVMDBOo4fKmVUwHx+GCE8ZlTAGHjuPVxmVMD129eBc2dUwGnEzD6PZ1TAwF5hwf1oVMCdSgaAKmlUwGKCGr6FalTAuwopP6lqVMCCjevf9WtUwINpGD4ibFTAjbRU3o5tVMChgO1gxG1UwL4Ts14Mb1TAzHnGvmRvVMDiOVtAaHBUwDBl4ICWcFTAFsPVARByVMApPj4hO3JUwCwOZ341c1TANlmjHqJzVMA5X+y9+HRUwDhlbr4RdVTAdmwE4nV2VMA0g/jAjnZUwIif/x68d1TAX38Snzt4VMDVsrW+SHlUwIbGE0GceVTAfm/Tn/16VMCKq8q+K3tUwEs9C0J5fFTAO8WqQZh8VMD356Ih431UwD2ARX79fVTAED//PXh/VMCVRPZBln9UwKNWmL7XgFTAzosTX+2AVMDytPzAVYJUwLDL8J9uglTA9+RhodaDVMCMogc+BoRUwN3rpL4shVTACCEgX0KFVMD7rgj+t4ZUwBSWeEDZhlTAJPCHn/+HVMAB323eOIhUwLngDP5+iVTAWp2cobiJVMA90XXhB4tUwBGo/kEki1TAbjMV4pGMVMCCrn0BvYxUwNTTR+APjlTArptSXiuOVMATtwpioI9UwCtNSkG3j1TA6Ugu/yGRVMDaHr3hPpFUwIBgjh6/klTADFcHQNySVMBnuAGfH5RUwPFmDd5XlFTAdQZGXtaVVMBbfAqA8ZVUwLDL8J9ul1TAWVLuPseXVMBntcAeE5lUwI8aE2IumVTAa/RqgNKaVMAWvVMB95pUwDOMu0G0nFTAp3fxftycVMC1FmahnZ5UwKhuLv62nlTArvIEwk6gVMBkzcggd6BUwHQJh97ioVTAv2GiQQqiVMAIWoEhq6NUwFU01v7Oo1TAg2xZvi6lVMCbVgqBXKVUwM/ZAkLrplTAHv8FggCnVMChgy7h0KdUwKCJsOHpqFTAZJRnXg6qVMC5+xwfLapUwCHqPgCpq1TA3/qw3qisVMBsJAnCFa1UwPexgt+GrVTAKSZvgJmuVMC214LeG69UwDaVRWEXsFTANpIE4QqxVMCAnDBhNLJUwLngDP5+s1TAA+s4fqizVMDgMNEgBbRUwKuwGeCCtVTAs9E5P8W1VMCUMqmhDbdUwH5Rgv5Ct1TA3C3JAbu4VMCdaFch5bhUwNLfS+FBulTAJQLVP4i6VMCSBUzg1rtUwGvT2F4LvFTAgnUcP1S9VMDiP91Agb1UwA+BI4EGv1TA7pOjAFG/VMAdzCbAsMBUwFU01v7OwFTAVHB4QUTCVMCaCBueXsJUwB7GpL+Xw1TAOrAcIQPEVMAOMPMd/MRUwG8qUmFsxlTAufscHy3HVMBYWHA/4MdUwImxTL9EyFTAcy1agLbJVMBA2v8Aa8pUwDBinwCKylTAmFDB4QXMVMAXnMHfL8xUwCntDb4wzVTAJ/bQPlbOVMDDKAge385UwPG3PUFi0FTA95MxPszQVMBorz4e+tBUwFIoC19f0lTAuw1qv7XSVMDFWKZfItRUwPK0/MBV1FTA8nhafuDVVMDusfShC9ZUwKuzWmCP11TA6l28H7fXVMC78lmeB9lUwICfceFA2VTA7lpCPujaVMBsIchBCdtUwK7UsyCU3FTADksDP6rcVMBUOlj/591UwPSHZp5c3lTAwVjfwOTfVMC4H/DAAOBUwOl+TkF+4VTABTbn4JnhVMCHinH+JuNUwMaFAyFZ41TAJuFCHsHkVMAZkL3e/eRUwErs2t5u5lTAcQM+P4zmVMCbIOo+AOhUwGrcm98w6FTAwytJnuvpVMC/ZOPBFupUwDRlpx/U61TAEqJ8QQvsVMC9AWa+g+1UwHxCdt7G7VTAd0gxQKLvVMBBmxw+6e9UwPK0/MBV8VTAmBQfn5DxVMBHyECeXfNUwDihEAGH81TAe4SaIVX1VMA=",
+          "dtype": "f8"
+         },
+         "marker": {
+          "color": "blue",
+          "size": 5
+         },
+         "mode": "lines+markers",
+         "name": "Flight 1e557528-404c-4c14-a5b9-26812706e5a2",
+         "type": "scattergeo"
+        }
+       ],
+       "layout": {
+        "geo": {
+         "landcolor": "#E5ECF6",
+         "lataxis": {
+          "showgrid": true
+         },
+         "lonaxis": {
+          "showgrid": true
+         },
+         "oceancolor": "#f9f9f9",
+         "projection": {
+          "rotation": {
+           "lat": 34.31097693636364,
+           "lon": -82.4284497090909,
+           "roll": 0
+          },
+          "scale": 20,
+          "type": "orthographic"
+         },
+         "showcoastlines": true,
+         "showcountries": true,
+         "showland": true,
+         "showocean": true
+        },
+        "height": 600,
+        "margin": {
+         "b": 0,
+         "l": 0,
+         "r": 0,
+         "t": 40
+        },
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermap": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermap"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "#E5ECF6",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "white"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "#E5ECF6",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "radialaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "yaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "zaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "caxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "title": {
+         "text": "Trajectory for Flight ID: 1e557528-404c-4c14-a5b9-26812706e5a2 (Zoom: 20.000x)"
+        }
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "def plot_flight_on_globe(flight: Flight):\n",
+    "    \"\"\"Plot a pycontrails Flight object on a 3D Plotly globe centered and zoomed on the trajectory.\"\"\"\n",
+    "    df = flight.dataframe\n",
+    "    # Access flight_id from the attributes dictionary\n",
+    "    fid = flight.attrs.get(\"flight_id\", \"Unknown\")\n",
+    "\n",
+    "    # Calculate center point for the camera\n",
+    "    center_lat = df[\"latitude\"].mean()\n",
+    "    center_lon = df[\"longitude\"].mean()\n",
+    "\n",
+    "    # Calculate the spread to determine zoom level\n",
+    "    lat_range = df[\"latitude\"].max() - df[\"latitude\"].min()\n",
+    "    lon_range = df[\"longitude\"].max() - df[\"longitude\"].min()\n",
+    "    max_range = max(lat_range, lon_range, 0.1)\n",
+    "\n",
+    "    # Heuristic for projection scale: 1.0 is the full globe (~180 degrees)\n",
+    "    # We scale such that the trajectory occupies a significant part of the frame.\n",
+    "    # Adjusted from 120.0 to 100.0 to zoom out slightly more.\n",
+    "    zoom_scale = 1.0 / (max_range / 100.0)\n",
+    "    zoom_scale = max(1.0, min(zoom_scale, 20.0))  # Limit zoom to stay within reasonable bounds\n",
+    "\n",
+    "    fig = go.Figure()\n",
+    "\n",
+    "    # Add the flight path\n",
+    "    fig.add_trace(\n",
+    "        go.Scattergeo(\n",
+    "            lat=df[\"latitude\"],\n",
+    "            lon=df[\"longitude\"],\n",
+    "            mode=\"lines+markers\",\n",
+    "            line=dict(width=2, color=\"red\"),\n",
+    "            marker=dict(size=5, color=\"blue\"),\n",
+    "            name=f\"Flight {fid}\",\n",
+    "            hovertext=df[\"time\"].dt.strftime(\"%H:%M:%S\"),\n",
+    "        )\n",
+    "    )\n",
+    "\n",
+    "    # Configure the globe layout and center/zoom it\n",
+    "    fig.update_geos(\n",
+    "        projection_type=\"orthographic\",\n",
+    "        projection_rotation=dict(lon=center_lon, lat=center_lat, roll=0),\n",
+    "        projection_scale=zoom_scale,\n",
+    "        showcountries=True,\n",
+    "        showcoastlines=True,\n",
+    "        showland=True,\n",
+    "        landcolor=\"#E5ECF6\",\n",
+    "        showocean=True,\n",
+    "        oceancolor=\"#f9f9f9\",\n",
+    "        lataxis_showgrid=True,\n",
+    "        lonaxis_showgrid=True,\n",
+    "    )\n",
+    "\n",
+    "    fig.update_layout(\n",
+    "        height=600,\n",
+    "        margin={\"r\": 0, \"t\": 40, \"l\": 0, \"b\": 0},\n",
+    "        title=f\"Trajectory for Flight ID: {fid} (Zoom: {zoom_scale:.3f}x)\",\n",
+    "    )\n",
+    "\n",
+    "    fig.show()\n",
+    "\n",
+    "\n",
+    "# Example: Plot the first flight in the list\n",
+    "if flights_data:\n",
+    "    plot_flight_on_globe(flights_data[0])\n",
+    "else:\n",
+    "    print(\"No flights available to plot.\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/pycontrails/core/flight.py
+++ b/pycontrails/core/flight.py
@@ -6,6 +6,7 @@ import enum
 import logging
 import sys
 import warnings
+from datetime import datetime
 from typing import TYPE_CHECKING, Any, NoReturn, Self
 
 if sys.version_info >= (3, 12):
@@ -2188,3 +2189,251 @@ def _antimeridian_shift(lon: npt.NDArray[np.floating]) -> float | None:
         msg = "Cannot handle flight that spans more than 360 degrees longitude"
         raise ValueError(msg)
     return (shift_min + shift_max) / 2.0
+
+
+def generate_flight_id(
+    start_timestamp: datetime,
+    end_timestamp: datetime,
+    icao_address: str,
+    midnight_threshold_mins: int,
+) -> str:
+    """Generate a flight ID for a flight waypoint based on timestamp and ICAO address.
+
+    Flight IDs are generated based on the flight's start and end timestamps and its
+    ICAO address. All IDs are prefixed with SPIRE-INFERRED-{icao_address}-.
+    The rest of the ID depends on the time of day:
+
+        1. Midnight Rollover/Holdover: Special formatting is applied if the flight
+        period crosses midnight within a certain threshold (midnight_threshold_mins).
+            * If the flight ends just after midnight (a "holdover"), the ID includes
+            the dates of the day before the start and the start date, formatted as:
+            {start_date - 1 day}-rollover-{start_date}.
+            * If the flight starts just before midnight (a "rollover"), the ID
+            includes the start date and the day after the end date, formatted as:
+            {start_date}-rollover-{end_date + 1 day}.
+
+        2. Standard: If the flight period doesn't cross the midnight threshold, the
+        ID is generated using the Unix timestamp (in seconds) of the start and end
+        times: {int(start_timestamp)}-{int(end_timestamp)}.
+
+    Parameters
+    ----------
+    start_timestamp : datetime
+        The start timestamp of the waypoint group.
+    end_timestamp : datetime
+        The end timestamp of the waypoint group.
+    icao_address : str
+        The ICAO address of the flight.
+    midnight_threshold_mins : int
+        The number of minutes before/after midnight to consider for generating
+        a rollover/holdover ID.
+
+    Returns
+    -------
+    str
+        The generated flight ID.
+
+    Examples
+    --------
+    Holdover: SPIRE-INFERRED-ABC123-2026-02-03-rollover-2026-02-04
+    Rollover: SPIRE-INFERRED-ABC123-2026-02-04-rollover-2026-02-05
+    Standard: SPIRE-INFERRED-ABC123-1760035200-1760042400
+    """
+    is_rollover = (
+        start_timestamp.time()
+        >= (pd.to_datetime("23:59:59") - pd.Timedelta(minutes=midnight_threshold_mins)).time()
+    )
+    is_holdover = (
+        end_timestamp.time()
+        <= (pd.to_datetime("00:00:00") + pd.Timedelta(minutes=midnight_threshold_mins)).time()
+    )
+    if is_holdover:
+        generated_id = (
+            f"SPIRE-INFERRED-{icao_address}-"
+            f"{start_timestamp.date() - pd.Timedelta(days=1)}-rollover-"
+            f"{start_timestamp.date()}"
+        )
+    elif is_rollover:
+        generated_id = (
+            f"SPIRE-INFERRED-{icao_address}-"
+            f"{start_timestamp.date()}-rollover-"
+            f"{end_timestamp.date() + pd.Timedelta(days=1)}"
+        )
+    else:
+        generated_id = (
+            f"SPIRE-INFERRED-{icao_address}-"
+            f"{int(start_timestamp.timestamp())}-{int(end_timestamp.timestamp())}"
+        )
+
+    return generated_id
+
+
+def impute_flight_ids(
+    df: pd.DataFrame,
+    time_threshold_mins: int = 20,
+    midnight_threshold_mins: int = 20,
+) -> pd.DataFrame:
+    """Impute missing flight IDs for ADS-B waypoints.
+
+    There is no guarantee that incoming waypoints have a flight ID. To properly
+    group waypoints into flights we want to ensure all waypoints have flight ID.
+
+    We thus impute missing flight ID waypoints following these methods:
+
+        - First, group waypoints w/ missing flight IDs by ICAO address and timestamp.
+        Each waypoint in the group is at most [waypoint_ground_threshold_mins]
+        minutes from its temporal neighbor.
+
+        - For each group, check for a terrestrial waypoint that has a flight ID within
+        [time_threshold_mins] minutes. If one such waypoint exists, backfill/
+        forward-fill flight ID using that waypoint.
+        If multiple qualifying waypoints exist *before* and *after* the group, use
+        the one that's temporally closest.
+
+        - Otherwise, impute a custom flight ID based on the group's start + end
+        timestamp and the ICAO address.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Flight formatted dataframe of waypoints
+    time_threshold_mins : int
+        A group of NULL-flight ID waypoints is considered
+        temporally "linked" to a waypoint with a flight ID if the latter is
+        within `time_threshold_mins` of the former.
+    midnight_threshold_mins : int
+        If a group of NULL-flight ID waypoints *starts* or
+        *ends* within `midnight_threshold_mins` of midnight, *and* an inferred ID
+        has to be generated (rather than derived from waypoints with flight IDs),
+        use a custom 'rollover' flight ID rather than deriving from timestamps.
+
+    Returns
+    -------
+    pd.Dataframe
+        A pandas DataFrame with missing flight IDs imputed.
+    """
+    # Early return if there are no missing flight IDs (no need to impute).
+    if not df["flight_id"].isna().any():
+        return df
+
+    # Drop:
+    # - Duplicated waypoints
+    # - Waypoints without an ICAO address or timestamp (precautionary step).
+    df_imputed = df.copy()
+    df_imputed = df_imputed.drop_duplicates()
+    df_imputed = df_imputed.dropna(subset=["icao_address", "timestamp"])
+    df_imputed = df_imputed.reset_index()
+
+    df_missing = df_imputed[df_imputed["flight_id"].isna()].sort_values(
+        ["icao_address", "timestamp"]
+    )
+    df_valid = df_imputed[~df_imputed["flight_id"].isna()].sort_values("timestamp")
+
+    # Group missing flight ID waypoints by ICAO and timestamps.
+    is_new_group = (df_missing["icao_address"] != df_missing["icao_address"].shift()) | (
+        df_missing["timestamp"].diff() > pd.Timedelta(minutes=20)
+    )
+    df_missing["group_id"] = is_new_group.cumsum()
+    groups = (
+        df_missing.groupby("group_id")
+        .agg(
+            icao_address=("icao_address", "first"),
+            group_start=("timestamp", "min"),
+            group_end=("timestamp", "max"),
+        )
+        .reset_index()
+    )
+
+    # Search for waypoints with a non-null ID that are:
+    # - In between the start/end timestamp of the group.
+    # - Within time_threshold_mins of the start/end of the group.
+    start_group = groups.sort_values("group_start")
+    internal_match = pd.merge_asof(
+        start_group,
+        df_valid[["timestamp", "flight_id", "icao_address"]],
+        left_on="group_start",
+        right_on="timestamp",
+        by="icao_address",
+        direction="forward",
+        suffixes=("", "_internal"),
+    )
+    backward_match = pd.merge_asof(
+        start_group,
+        df_valid[["timestamp", "flight_id", "icao_address"]],
+        left_on="group_start",
+        right_on="timestamp",
+        by="icao_address",
+        direction="backward",
+        suffixes=("", "_prev"),
+    )
+    forward_match = pd.merge_asof(
+        groups.sort_values("group_end"),
+        df_valid[["timestamp", "flight_id", "icao_address"]],
+        left_on="group_end",
+        right_on="timestamp",
+        by="icao_address",
+        direction="forward",
+        suffixes=("", "_next"),
+    )
+
+    # Align all merges on group_id for comparison.
+    groups = groups.set_index("group_id")
+    internal_match = internal_match.set_index("group_id")
+    backward_match = backward_match.set_index("group_id")
+    forward_match = forward_match.set_index("group_id")
+
+    groups["internal_id"] = internal_match["flight_id"]
+    groups["internal_ts"] = internal_match["timestamp"]
+    groups["prev_id"] = backward_match["flight_id"]
+    groups["prev_ts"] = backward_match["timestamp"]
+    groups["next_id"] = forward_match["flight_id"]
+    groups["next_ts"] = forward_match["timestamp"]
+
+    # Check if a group has a waypoint inside its start/end timestamp range with
+    # a valid flight ID (since if it does, we want to use it).
+    has_internal = groups["internal_ts"] <= groups["group_end"]
+
+    groups["dist_prev"] = (groups["group_start"] - groups["prev_ts"]).abs()
+    groups["dist_next"] = (groups["next_ts"] - groups["group_end"]).abs()
+    groups["valid_prev"] = groups["dist_prev"] <= pd.Timedelta(minutes=time_threshold_mins)
+    groups["valid_next"] = groups["dist_next"] <= pd.Timedelta(minutes=time_threshold_mins)
+
+    # Begin assigning flight IDs.
+    groups["final_flight_id"] = pd.Series(np.nan, index=groups.index, dtype=object)
+    groups.loc[has_internal, "final_flight_id"] = groups.loc[has_internal, "internal_id"]
+    # If no internal IDs, use the chronologically closest ID within 20m of the
+    # start/end range.
+    missing_mask = groups["final_flight_id"].isna()
+
+    if missing_mask.any():
+        sub = groups.loc[missing_mask]
+        use_prev = sub["valid_prev"] & (~sub["valid_next"] | (sub["dist_prev"] <= sub["dist_next"]))
+        use_next = sub["valid_next"] & (~sub["valid_prev"] | (sub["dist_next"] < sub["dist_prev"]))
+        groups.loc[sub.index[use_prev], "final_flight_id"] = sub.loc[use_prev, "prev_id"]
+        groups.loc[sub.index[use_next], "final_flight_id"] = sub.loc[use_next, "next_id"]
+
+    # For groups that have neither internal waypoints nor waypoints within
+    # time_threshold_mins with a non-null ID, generate an ID for the
+    # group.
+    needs_gen_mask = groups["final_flight_id"].isna()
+    if needs_gen_mask.any():
+        generated_ids = groups[needs_gen_mask].apply(
+            lambda row: generate_flight_id(
+                row["group_start"],
+                row["group_end"],
+                row["icao_address"],
+                midnight_threshold_mins,
+            ),
+            axis=1,
+        )
+        groups.loc[needs_gen_mask, "final_flight_id"] = generated_ids
+    df_missing["flight_id"] = df_missing["group_id"].map(groups["final_flight_id"])
+    df_imputed.loc[df_missing.index, "flight_id"] = df_missing["flight_id"]
+
+    num_not_imputed = len(df_imputed[df_imputed["flight_id"].isna()])
+    if num_not_imputed > 0:
+        raise ValueError(
+            f"Unexpected error; {num_not_imputed} waypoint(s) without flight IDs"
+            " were not imputed despite running impute_flight_ids."
+        )
+    return df_imputed

--- a/tests/unit/test_flight.py
+++ b/tests/unit/test_flight.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import datetime
 import json
+import math
 import warnings
 from typing import Any
+from unittest import mock
 
 import matplotlib.axes
 import numpy as np
@@ -49,6 +52,38 @@ def random_flight_list(rng: np.random.Generator) -> list[Flight]:
         )
 
     return [_random_flight() for _ in range(100)]
+
+
+@pytest.fixture(scope="module")
+def adsb_waypoints() -> pd.DataFrame:
+    df = pd.DataFrame(
+        {
+            "timestamp": [datetime.datetime(2025, 1, 24, 0, 0, 0, 0)],
+            "latitude": [32.405804],
+            "longitude": [-110.98243],
+            "collection_type": ["terrestrial"],
+            "altitude_baro": [15675],
+            "altitude_gnss": [math.nan],
+            "icao_address": ["A00537"],
+            "flight_id": ["0e781b4b-4ae6-4a7d-ba58-9dab71185127"],
+            "callsign": ["N100FF"],
+            "tail_number": ["N100FF"],
+            "flight_number": [None],
+            "aircraft_type_icao": ["E50P"],
+            "airline_iata": [None],
+            "departure_airport_icao": ["KTUS"],
+            "departure_scheduled_time": [None],
+            "arrival_airport_icao": ["KDVT"],
+            "arrival_scheduled_time": [None],
+            "nic": [None],
+            "nacp": [12],
+        }
+    )
+    # In practice Contrails.org's timestamp is in microseconds, not nanoseconds.
+    df["timestamp"] = df["timestamp"].astype("datetime64[us]")
+    df["latitude"] = df["latitude"].astype("float64")
+    df["longitude"] = df["longitude"].astype("float64")
+    return df
 
 
 ##########
@@ -1407,6 +1442,182 @@ def test_rocd_hydrostatic_equation() -> None:
     np.testing.assert_array_almost_equal(
         rocd_corr[:-1], [1005.8, 1932.4, 2751.9, 3014.3], decimal=1
     )
+
+
+def test_does_not_impute_if_all_ids_filled_out(adsb_waypoints: pd.DataFrame) -> None:
+    df = adsb_waypoints.copy()
+    new_row = df.iloc[0].copy()
+    df = pd.concat([pd.DataFrame([new_row]), df], ignore_index=True)
+    with mock.patch.object(flight, "generate_flight_id", autospec=True) as mock_generate_flight_id:
+        flight.impute_flight_ids(df)
+        mock_generate_flight_id.assert_not_called()
+
+
+def test_impute_backfills_if_temporal_alignment(adsb_waypoints: pd.DataFrame) -> None:
+    df = adsb_waypoints.copy()
+    new_row = df.iloc[0].copy()
+    new_row.collection_type = "satellite"
+    new_row.flight_id = None
+    new_row.timestamp -= pd.Timedelta(minutes=20)
+    df = pd.concat([pd.DataFrame([new_row]), df], ignore_index=True)
+
+    df = flight.impute_flight_ids(df)
+
+    assert df.iloc[0]["flight_id"] == df.iloc[1]["flight_id"]
+
+
+def test_impute_handles_rollover_flights(adsb_waypoints: pd.DataFrame) -> None:
+    df = adsb_waypoints.copy()
+    df["collection_type"] = "satellite"
+    df["flight_id"] = None
+    df["timestamp"] = datetime.datetime(2025, 1, 24, 23, 59, 59, 0)
+
+    df = flight.impute_flight_ids(df)
+
+    assert (
+        df.iloc[0]["flight_id"]
+        == f"SPIRE-INFERRED-{df.iloc[0]['icao_address']}-2025-01-24-rollover-2025-01-25"
+    )
+
+
+def test_imput_handles_rollover_missing_terrestrial_flight_id(adsb_waypoints: pd.DataFrame) -> None:
+    df = adsb_waypoints.copy()
+    df["collection_type"] = "terrestrial"
+    df["flight_id"] = None
+    df["timestamp"] = datetime.datetime(2025, 1, 24, 23, 59, 59, 0)
+
+    df = flight.impute_flight_ids(df)
+
+    assert (
+        df.iloc[0]["flight_id"]
+        == f"SPIRE-INFERRED-{df.iloc[0]['icao_address']}-2025-01-24-rollover-2025-01-25"
+    )
+
+
+def test_impute_handles_holdover_flights(adsb_waypoints: pd.DataFrame) -> None:
+    df = adsb_waypoints.copy()
+    df["collection_type"] = "satellite"
+    df["flight_id"] = None
+    df["timestamp"] = datetime.datetime(2025, 1, 24, 0, 0, 1, 0)
+
+    df = flight.impute_flight_ids(df)
+
+    assert (
+        df.iloc[0]["flight_id"]
+        == f"SPIRE-INFERRED-{df.iloc[0]['icao_address']}-2025-01-23-rollover-2025-01-24"
+    )
+
+
+def test_impute_generates_on_icao_and_timestamp(adsb_waypoints: pd.DataFrame) -> None:
+    df = adsb_waypoints.copy()
+    df = pd.concat([pd.DataFrame([df.iloc[0].copy()]), df], ignore_index=True)
+    df["collection_type"] = "satellite"
+    df["flight_id"] = None
+    df.loc[1, "timestamp"] += pd.Timedelta(minutes=15)
+
+    df = flight.impute_flight_ids(df)
+
+    assert df.iloc[0]["flight_id"] == df.iloc[1]["flight_id"]
+    assert (
+        df.iloc[1]["flight_id"]
+        == f"SPIRE-INFERRED-{df.iloc[0]['icao_address']}-2025-01-23-rollover-2025-01-24"
+    )
+
+
+def test_impute_generates_if_no_temporal_alignment(adsb_waypoints: pd.DataFrame) -> None:
+    df = adsb_waypoints.copy()
+    new_row = df.iloc[0].copy()
+    new_row.collection_type = "satellite"
+    new_row.flight_id = None
+    new_row.timestamp -= pd.Timedelta(hours=20)
+    df = pd.concat([pd.DataFrame([new_row]), df], ignore_index=True)
+
+    df = flight.impute_flight_ids(df)
+
+    assert (
+        df.iloc[0]["flight_id"] == f"SPIRE-INFERRED-{df.iloc[0]['icao_address']}-"
+        f"{int(new_row.timestamp.timestamp())}-"
+        f"{int(new_row.timestamp.timestamp())}"
+    )
+    assert df.iloc[1]["flight_id"] == "0e781b4b-4ae6-4a7d-ba58-9dab71185127"
+
+
+def test_impute_prioritizes_waypoints_inside_group_range(adsb_waypoints: pd.DataFrame) -> None:
+    df = adsb_waypoints.copy()
+    df = pd.concat(
+        [
+            pd.DataFrame(
+                [
+                    df.iloc[0].copy(),
+                    df.iloc[0].copy(),
+                    df.iloc[0].copy(),
+                    df.iloc[0].copy(),
+                    df.iloc[0].copy(),
+                ]
+            ),
+            df,
+        ],
+        ignore_index=True,
+    )
+    df["collection_type"] = "satellite"
+    df["flight_id"] = None
+    df.loc[1, "timestamp"] += pd.Timedelta(minutes=15)
+    df.loc[2, "timestamp"] += pd.Timedelta(minutes=30)
+    df.loc[2, "collection_type"] = "terrestrial"
+    df.loc[2, "flight_id"] = "0e781b4b-4ae6-4a7d-ba58-9dab71185127"
+    df.loc[3, "timestamp"] += pd.Timedelta(minutes=45)
+    df.loc[4, "timestamp"] += pd.Timedelta(minutes=60)
+    df.loc[4, "collection_type"] = "terrestrial"
+    df.loc[4, "flight_id"] = "should-not-be-used"
+    df = flight.impute_flight_ids(df)
+    assert df.iloc[0]["flight_id"] == "0e781b4b-4ae6-4a7d-ba58-9dab71185127"
+    assert df.iloc[0]["flight_id"] == df.iloc[1]["flight_id"]
+    assert df.iloc[1]["flight_id"] == df.iloc[3]["flight_id"]
+
+
+def test_impute_handles_multiple_distinct_satellite_groups(adsb_waypoints: pd.DataFrame) -> None:
+    df = adsb_waypoints.copy()
+    df = pd.concat(
+        [
+            pd.DataFrame(
+                [
+                    df.iloc[0].copy(),
+                    df.iloc[0].copy(),
+                    df.iloc[0].copy(),
+                    df.iloc[0].copy(),
+                    df.iloc[0].copy(),
+                ]
+            ),
+            df,
+        ],
+        ignore_index=True,
+    )
+    df["collection_type"] = "satellite"
+    df["flight_id"] = None
+    # 0 and 1 should be generated due to temporal non-proximity to 2.
+    df.loc[1, "timestamp"] += pd.Timedelta(minutes=15)
+    # 2 is terrestrial and should remain untouched.
+    df.loc[2, "collection_type"] = "terrestrial"
+    df.loc[2, "flight_id"] = "0e781b4b-4ae6-4a7d-ba58-9dab71185127"
+    df.loc[2, "timestamp"] += pd.Timedelta(minutes=60)
+    # 3, 4 and 5 should be overwritten due to temporal proximity to 2.
+    # The update type should not matter.
+    df.loc[3, "timestamp"] += pd.Timedelta(minutes=80)
+    df.loc[4, "timestamp"] += pd.Timedelta(minutes=90)
+    df.loc[5, "timestamp"] += pd.Timedelta(minutes=100)
+    df.loc[5, "collection_type"] = "terrestrial"
+
+    df = flight.impute_flight_ids(df)
+
+    assert (
+        df.iloc[0]["flight_id"]
+        == f"SPIRE-INFERRED-{df.iloc[0]['icao_address']}-2025-01-23-rollover-2025-01-24"
+    )
+    assert df.iloc[0]["flight_id"] == df.iloc[1]["flight_id"]
+    assert df.iloc[2]["flight_id"] == "0e781b4b-4ae6-4a7d-ba58-9dab71185127"
+    assert df.iloc[2]["flight_id"] == df.iloc[3]["flight_id"]
+    assert df.iloc[3]["flight_id"] == df.iloc[4]["flight_id"]
+    assert df.iloc[4]["flight_id"] == df.iloc[5]["flight_id"]
 
 
 class TestLoadFactorEstimates:


### PR DESCRIPTION
## Changes

* Add utility functions for imputing flight IDs into flight.py. 
* Add notebook demo-ing ADS-B fetching and flight loading end-to-end.

## Tests

Affected tests pass, however some failures from `pycontrails/datalib/google_forecast.py` which is outside scope of these changes.

- [] QC test passes locally (`make test`)
- [] CI tests pass

## Reviewer

@nickmasson

As part of open sourcing as much of the attributions code, here's the first part which is flight loading and flight ID assignment. Added util functions to Flight.py as it seemed the best match, but feel free to let me know if you would like it in its own separate file.
