### PR TITLE
Expose convective velocity scale as a user-configurable parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Experimental: Integrate alternative contrail parametric radiative forcing model (Schumann, 2025) into the CoCiP workflow: The original parametric RF model assumes a near-linear dependence of contrail RF on the contrail and natural cirrus optical depth and provides the best fit to the libRadtran dataset with the minimum number of model coefficients. This alternative model provides a stronger non-linear dependence to the contrail and natural cirrus optical depth, consistent with the ECMWF ecRad model, but yields a slightly weaker fit to the libRadtran dataset. This new parameterization can be enabled within the `Cocip` and `CocipGrid` models via the `parametric_rf_model_s2025` parameter.
 - Add new `GeoVectorDataset.intersect_met_cross_section` method which can be used create curtain plots of meteorological variables along a flight track. See the [Google Forecast notebook](https://py.contrails.org/integrations/GoogleForecast.html) for an example of this method in use.
-- Make the convective velocity scale used to calculate vertical diffusivity (`w_N'` in Equation 35 of Schumann et al 2012) a user-configurable parameter.
+- Make the convective velocity scale used to calculate vertical diffusivity (`w_N'` in Equation 35 of [Schumann 2012](https://doi.org/10.5194/gmd-5-543-2012)) a user-configurable parameter.
 
 ### Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Experimental: Integrate alternative contrail parametric radiative forcing model (Schumann, 2025) into the CoCiP workflow: The original parametric RF model assumes a near-linear dependence of contrail RF on the contrail and natural cirrus optical depth and provides the best fit to the libRadtran dataset with the minimum number of model coefficients. This alternative model provides a stronger non-linear dependence to the contrail and natural cirrus optical depth, consistent with the ECMWF ecRad model, but yields a slightly weaker fit to the libRadtran dataset. This new parameterization can be enabled within the `Cocip` and `CocipGrid` models via the `parametric_rf_model_s2025` parameter.
 - Add new `GeoVectorDataset.intersect_met_cross_section` method which can be used create curtain plots of meteorological variables along a flight track. See the [Google Forecast notebook](https://py.contrails.org/integrations/GoogleForecast.html) for an example of this method in use.
-- Make the convective velocity scale used to calculate vertical diffusivity (`w_N'` in Equation 35 of [Schumann 2012](https://doi.org/10.5194/gmd-5-543-2012)) a user-configurable parameter.
+- Make the turbulent vertical velocity scale used to calculate vertical diffusivity (`w_N'` in Equation 35 of [Schumann 2012](https://doi.org/10.5194/gmd-5-543-2012)) a user-configurable parameter.
 
 ### Breaking changes
 
@@ -14,7 +14,7 @@
 - Integrate the [Dray et al. (2024) cargo load factor database](https://doi.org/10.1016/j.jairtraman.2024.102692), which provides the 2019 annual mean origin-destination specific cargo load factors in the passenger hold and dedicated freighters. Discontinue the use of the IATA cargo load factor database, as it does not distinguish between freight carried in the passenger hold and dedicated freighters.
 - Provide reference values for the number of seats for each passenger aircraft type to improve payload estimates.
 - Remove `DEFAULT_LOAD_FACTOR` and `jet.aircraft_load_factor`. Passenger aircraft and cargo aircraft load factors are now handled separately.
-- Fix a bug in the vertical diffusivity calculation. Vertical diffusivity is now correctly diagnosed based on the square of the convective velocity scale. This changes default behavior only when the convective velocity scale is itself diagnosed based on differential radiative heating at the top and bottom of the contrail (`radiative_heating_effects = True`).
+- Fix a bug in the vertical diffusivity calculation. Vertical diffusivity is now correctly diagnosed based on the square of the turbulent vertical velocity scale. This changes default behavior only when the turbulent vertical velocity scale is itself diagnosed based on differential radiative heating at the top and bottom of the contrail (`radiative_heating_effects = True`).
 
 ## 0.60.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,15 @@
 
 - Experimental: Integrate alternative contrail parametric radiative forcing model (Schumann, 2025) into the CoCiP workflow: The original parametric RF model assumes a near-linear dependence of contrail RF on the contrail and natural cirrus optical depth and provides the best fit to the libRadtran dataset with the minimum number of model coefficients. This alternative model provides a stronger non-linear dependence to the contrail and natural cirrus optical depth, consistent with the ECMWF ecRad model, but yields a slightly weaker fit to the libRadtran dataset. This new parameterization can be enabled within the `Cocip` and `CocipGrid` models via the `parametric_rf_model_s2025` parameter.
 - Add new `GeoVectorDataset.intersect_met_cross_section` method which can be used create curtain plots of meteorological variables along a flight track. See the [Google Forecast notebook](https://py.contrails.org/integrations/GoogleForecast.html) for an example of this method in use.
+- Make the convective velocity scale used to calculate vertical diffusivity (`w_N'` in Equation 35 of Schumann et al 2012) a user-configurable parameter.
 
 ### Breaking changes
 
-- Replace the previous methodology for estimating aircraft mass (based on load factor) with a new approach that estimates payload mass based on passanger seat count aircraft and cargo capacity.Evaluated against the Brazilian ANAC dataset, this refinement improves takeoff mass accuracy by 5 - 10%. Aircraft performance models (`PSFlight` and `BADAFlight`) have been updated to integrate this new approach.
-  - Integrate the [Dray et al. (2024) cargo load factor database](https://doi.org/10.1016/j.jairtraman.2024.102692), which provides the 2019 annual mean origin-destination specific cargo load factors in the passenger hold and dedicated freighters. Discontinue the use of the IATA cargo load factor database, as it does not distinguish between freight carried in the passenger hold and dedicated freighters.
-  - Provide reference values for the number of seats for each passenger aircraft type to improve payload estimates.
-  - Remove `DEFAULT_LOAD_FACTOR` and `jet.aircraft_load_factor`. Passenger aircraft and cargo aircraft load factors are now handled separately.
+- Replace the previous methodology for estimating aircraft mass (based on load factor) with a new approach that estimates payload mass based on passanger seat count aircraft and cargo capacity. Evaluated against the Brazilian ANAC dataset, this refinement improves takeoff mass accuracy by 5 - 10%. Aircraft performance models (`PSFlight` and `BADAFlight`) have been updated to integrate this new approach.
+- Integrate the [Dray et al. (2024) cargo load factor database](https://doi.org/10.1016/j.jairtraman.2024.102692), which provides the 2019 annual mean origin-destination specific cargo load factors in the passenger hold and dedicated freighters. Discontinue the use of the IATA cargo load factor database, as it does not distinguish between freight carried in the passenger hold and dedicated freighters.
+- Provide reference values for the number of seats for each passenger aircraft type to improve payload estimates.
+- Remove `DEFAULT_LOAD_FACTOR` and `jet.aircraft_load_factor`. Passenger aircraft and cargo aircraft load factors are now handled separately.
+- Fix a bug in the vertical diffusivity calculation. Vertical diffusivity is now correctly diagnosed based on the square of the convective velocity scale. This changes default behavior only when the convective velocity scale is itself diagnosed based on differential radiative heating at the top and bottom of the contrail (`radiative_heating_effects = True`).
 
 ## 0.60.5
 

--- a/pycontrails/models/cocip/cocip.py
+++ b/pycontrails/models/cocip/cocip.py
@@ -1100,7 +1100,7 @@ class Cocip(Model):
             self._downwash_contrail,
             self.params["effective_vertical_resolution"],
             self.params["wind_shear_enhancement_exponent"],
-            self.params["convective_velocity_scale"],
+            self.params["turbulent_vertical_velocity_scale"],
             self.params["sedimentation_impact_factor"],
             self.params["radiative_heating_effects"],
             self.params["max_horizontal_diffusivity"],
@@ -1177,7 +1177,7 @@ class Cocip(Model):
                 latest_contrail,
                 self.params["effective_vertical_resolution"],
                 self.params["wind_shear_enhancement_exponent"],
-                self.params["convective_velocity_scale"],
+                self.params["turbulent_vertical_velocity_scale"],
                 self.params["sedimentation_impact_factor"],
                 self.params["radiative_heating_effects"],
                 self.params["max_horizontal_diffusivity"],
@@ -2312,7 +2312,7 @@ def calc_contrail_properties(
     contrail: GeoVectorDataset,
     effective_vertical_resolution: float | npt.NDArray[np.floating],
     wind_shear_enhancement_exponent: float | npt.NDArray[np.floating],
-    convective_velocity_scale: float | npt.NDArray[np.floating],
+    turbulent_vertical_velocity_scale: float | npt.NDArray[np.floating],
     sedimentation_impact_factor: float | npt.NDArray[np.floating],
     radiative_heating_effects: bool,
     max_horizontal_diffusivity: float | None,
@@ -2346,7 +2346,7 @@ def calc_contrail_properties(
         Passed into :func:`wind_shear.wind_shear_enhancement_factor`.
     wind_shear_enhancement_exponent : float | npt.NDArray[np.floating]
         Passed into :func:`wind_shear.wind_shear_enhancement_factor`.
-    convective_velocity_scale: float | npt.NDArray[np.floating]
+    turbulent_vertical_velocity_scale: float | npt.NDArray[np.floating]
         Passed into `contrail_properties.vertical_diffusivity`.
     sedimentation_impact_factor: float | npt.NDArray[np.floating]
         Passed into `contrail_properties.vertical_diffusivity`.
@@ -2459,7 +2459,7 @@ def calc_contrail_properties(
         dT_dz=dT_dz,
         depth_eff=depth_eff,
         terminal_fall_speed=terminal_fall_speed,
-        convective_velocity_scale=convective_velocity_scale,
+        turbulent_vertical_velocity_scale=turbulent_vertical_velocity_scale,
         sedimentation_impact_factor=sedimentation_impact_factor,
         eff_heat_rate=eff_heat_rate,
         max_vertical_diffusivity=max_vertical_diffusivity,
@@ -2698,7 +2698,7 @@ def calc_timestep_contrail_evolution(
         contrail_2,
         params["effective_vertical_resolution"],
         params["wind_shear_enhancement_exponent"],
-        params["convective_velocity_scale"],
+        params["turbulent_vertical_velocity_scale"],
         params["sedimentation_impact_factor"],
         params["radiative_heating_effects"],
         params["max_horizontal_diffusivity"],

--- a/pycontrails/models/cocip/cocip.py
+++ b/pycontrails/models/cocip/cocip.py
@@ -1100,6 +1100,7 @@ class Cocip(Model):
             self._downwash_contrail,
             self.params["effective_vertical_resolution"],
             self.params["wind_shear_enhancement_exponent"],
+            self.params["convective_velocity_scale"],
             self.params["sedimentation_impact_factor"],
             self.params["radiative_heating_effects"],
             self.params["max_horizontal_diffusivity"],
@@ -1176,6 +1177,7 @@ class Cocip(Model):
                 latest_contrail,
                 self.params["effective_vertical_resolution"],
                 self.params["wind_shear_enhancement_exponent"],
+                self.params["convective_velocity_scale"],
                 self.params["sedimentation_impact_factor"],
                 self.params["radiative_heating_effects"],
                 self.params["max_horizontal_diffusivity"],
@@ -2310,6 +2312,7 @@ def calc_contrail_properties(
     contrail: GeoVectorDataset,
     effective_vertical_resolution: float | npt.NDArray[np.floating],
     wind_shear_enhancement_exponent: float | npt.NDArray[np.floating],
+    convective_velocity_scale: float | npt.NDArray[np.floating],
     sedimentation_impact_factor: float | npt.NDArray[np.floating],
     radiative_heating_effects: bool,
     max_horizontal_diffusivity: float | None,
@@ -2343,6 +2346,8 @@ def calc_contrail_properties(
         Passed into :func:`wind_shear.wind_shear_enhancement_factor`.
     wind_shear_enhancement_exponent : float | npt.NDArray[np.floating]
         Passed into :func:`wind_shear.wind_shear_enhancement_factor`.
+    convective_velocity_scale: float | npt.NDArray[np.floating]
+        Passed into `contrail_properties.vertical_diffusivity`.
     sedimentation_impact_factor: float | npt.NDArray[np.floating]
         Passed into `contrail_properties.vertical_diffusivity`.
     radiative_heating_effects: bool
@@ -2454,6 +2459,7 @@ def calc_contrail_properties(
         dT_dz=dT_dz,
         depth_eff=depth_eff,
         terminal_fall_speed=terminal_fall_speed,
+        convective_velocity_scale=convective_velocity_scale,
         sedimentation_impact_factor=sedimentation_impact_factor,
         eff_heat_rate=eff_heat_rate,
         max_vertical_diffusivity=max_vertical_diffusivity,
@@ -2692,6 +2698,7 @@ def calc_timestep_contrail_evolution(
         contrail_2,
         params["effective_vertical_resolution"],
         params["wind_shear_enhancement_exponent"],
+        params["convective_velocity_scale"],
         params["sedimentation_impact_factor"],
         params["radiative_heating_effects"],
         params["max_horizontal_diffusivity"],

--- a/pycontrails/models/cocip/cocip_params.py
+++ b/pycontrails/models/cocip/cocip_params.py
@@ -178,6 +178,13 @@ class CocipParams(AdvectionBuffers):
     #: Denoted :math:`C_{D0}` in eq (14) in :cite:`schumannContrailCirrusPrediction2012`.
     initial_wake_vortex_depth: float = 0.5
 
+    #: Convective velocity scale, [:math:`m s^{-1}`]. Equivalent to :math:`\sqrt{c_V} w_N'`
+    #: in eq. (35) of :cite:`schumannContrailCirrusPrediction2012`.
+    #: The default value is based on :cite:`schumannAviationinducedCirrusRadiation2013`
+    #: and is higher than the value derived from :math:`c_V = 0.2` and :math:`w_N' = 0.1` m s^{-1}
+    #: in the original publication.
+    convective_velocity_scale: float = 0.1
+
     #: Sedimentation impact factor. Denoted by :math:`f_{T}` in eq. (35) of
     #: :cite:`schumannContrailCirrusPrediction2012`.
     #: Schumann describes this as "an important adjustable parameter", and sets

--- a/pycontrails/models/cocip/cocip_params.py
+++ b/pycontrails/models/cocip/cocip_params.py
@@ -178,12 +178,12 @@ class CocipParams(AdvectionBuffers):
     #: Denoted :math:`C_{D0}` in eq (14) in :cite:`schumannContrailCirrusPrediction2012`.
     initial_wake_vortex_depth: float = 0.5
 
-    #: Convective velocity scale, [:math:`m s^{-1}`]. Equivalent to :math:`\sqrt{c_V} w_N'`
+    #: Turbulent vertical velocity scale, [:math:`m s^{-1}`]. Equivalent to :math:`\sqrt{c_V} w_N'`
     #: in eq. (35) of :cite:`schumannContrailCirrusPrediction2012`.
     #: The default value is based on :cite:`schumannAviationinducedCirrusRadiation2013`
     #: and is higher than the value derived from :math:`c_V = 0.2` and :math:`w_N' = 0.1` m s^{-1}
     #: in the original publication.
-    convective_velocity_scale: float = 0.1
+    turbulent_vertical_velocity_scale: float = 0.1
 
     #: Sedimentation impact factor. Denoted by :math:`f_{T}` in eq. (35) of
     #: :cite:`schumannContrailCirrusPrediction2012`.

--- a/pycontrails/models/cocip/contrail_properties.py
+++ b/pycontrails/models/cocip/contrail_properties.py
@@ -885,6 +885,7 @@ def vertical_diffusivity(
     dT_dz: npt.NDArray[np.floating],
     depth_eff: npt.NDArray[np.floating],
     terminal_fall_speed: npt.NDArray[np.floating] | float,
+    convective_velocity_scale: npt.NDArray[np.floating] | float,
     sedimentation_impact_factor: npt.NDArray[np.floating] | float,
     eff_heat_rate: npt.NDArray[np.floating] | None,
     max_vertical_diffusivity: float | None,
@@ -904,6 +905,8 @@ def vertical_diffusivity(
         Effective depth of the contrail plume, [:math:`m`]
     terminal_fall_speed : npt.NDArray[np.floating] | float
         Terminal fall speed of contrail ice particles, [:math:`m s^{-1}`]
+    convective_velocity_scale : npt.NDArray[np.floating] | float
+        Convective velocity scale, [:math:`m s^{-1}`] equivalent to `sqrt()`
     sedimentation_impact_factor : npt.NDArray[np.floating] | float
         Enhancement parameter denoted by `f_T` in eq. (35) Schumann (2012).
     eff_heat_rate: npt.NDArray[np.floating] | None
@@ -930,13 +933,14 @@ def vertical_diffusivity(
     See eq. (35) of :cite:`schumannContrailCirrusPrediction2012`.
 
     The first term in Eq. (35) of :cite:`schumannContrailCirrusPrediction2012` is
-    (c_V * w'_N^2 / N_BV, where c_V = 0.2 and w'_N^2 = 0.1) is different
-    than outlined below. Here, a constant of 0.01 is used when radiative
-    heating effects are not activated. This update comes from
-    :cite:`schumannAviationinducedCirrusRadiation2013`
-    , which found that the original formulation estimated thinner
-    contrails relative to satellite observations. The vertical diffusivity
-    was enlarged so that the simulated contrails are more consistent with observations.
+    (c_V * w'_N^2 / N_BV, where c_V = 0.2 and w'_N = 0.1 m s-1) is different
+    than outlined below. Here, a convective velocity scale (provided as input) is used
+    directly (without scaling by c_V) when radiative heating effects are not activated
+    We currently recommend setting the convective velocity scale to 0.1 m s^{-1} based
+    on guidance from :cite:`schumannAviationinducedCirrusRadiation2013`,
+    which found that the original formulation estimated thinner
+    contrails relative to satellite observations. The recommended value produces
+    simulated contrails are more consistent with observations.
 
     The maximum vertical diffusivity can be limited to 10.0 m^{2} s^{-1}, see Section 2.2 of
     Schumann & Seifert (2025), https://doi.org/10.5194/acp-25-18571-2025
@@ -949,9 +953,9 @@ def vertical_diffusivity(
         cvs = radiative_heating.convective_velocity_scale(depth_eff, eff_heat_rate, air_temperature)
         cvs.clip(min=0.01, out=cvs)
     else:
-        cvs = 0.01
+        cvs = convective_velocity_scale
 
-    d_v = cvs / n_bv + sedimentation_impact_factor * terminal_fall_speed * depth_eff
+    d_v = cvs**2 / n_bv + sedimentation_impact_factor * terminal_fall_speed * depth_eff
 
     if max_vertical_diffusivity is not None:
         d_v = np.minimum(d_v, max_vertical_diffusivity)

--- a/pycontrails/models/cocip/contrail_properties.py
+++ b/pycontrails/models/cocip/contrail_properties.py
@@ -885,7 +885,7 @@ def vertical_diffusivity(
     dT_dz: npt.NDArray[np.floating],
     depth_eff: npt.NDArray[np.floating],
     terminal_fall_speed: npt.NDArray[np.floating] | float,
-    convective_velocity_scale: npt.NDArray[np.floating] | float,
+    turbulent_vertical_velocity_scale: npt.NDArray[np.floating] | float,
     sedimentation_impact_factor: npt.NDArray[np.floating] | float,
     eff_heat_rate: npt.NDArray[np.floating] | None,
     max_vertical_diffusivity: float | None,
@@ -905,7 +905,7 @@ def vertical_diffusivity(
         Effective depth of the contrail plume, [:math:`m`]
     terminal_fall_speed : npt.NDArray[np.floating] | float
         Terminal fall speed of contrail ice particles, [:math:`m s^{-1}`]
-    convective_velocity_scale : npt.NDArray[np.floating] | float
+    turbulent_vertical_velocity_scale : npt.NDArray[np.floating] | float
         Convective velocity scale, [:math:`m s^{-1}`]
     sedimentation_impact_factor : npt.NDArray[np.floating] | float
         Enhancement parameter denoted by `f_T` in eq. (35) Schumann (2012).
@@ -934,9 +934,9 @@ def vertical_diffusivity(
 
     The first term in Eq. (35) of :cite:`schumannContrailCirrusPrediction2012` is
     (c_V * w'_N^2 / N_BV, where c_V = 0.2 and w'_N = 0.1 m s-1) is different
-    than outlined below. Here, a convective velocity scale (provided as input) is used
+    than outlined below. Here, a turbulent vertical velocity scale (provided as input) is used
     directly (without scaling by c_V) when radiative heating effects are not activated
-    We currently recommend setting the convective velocity scale to 0.1 m s^{-1} based
+    We currently recommend setting the turbulent vertical velocity scale to 0.1 m s^{-1} based
     on guidance from :cite:`schumannAviationinducedCirrusRadiation2013`,
     which found that the original formulation estimated thinner
     contrails relative to satellite observations. The recommended value produces
@@ -948,14 +948,16 @@ def vertical_diffusivity(
     n_bv = thermo.brunt_vaisala_frequency(air_pressure, air_temperature, dT_dz)
     n_bv.clip(min=0.001, out=n_bv)
 
-    cvs: npt.NDArray[np.floating] | float
+    w_prime: npt.NDArray[np.floating] | float
     if eff_heat_rate is not None:
-        cvs = radiative_heating.convective_velocity_scale(depth_eff, eff_heat_rate, air_temperature)
-        cvs.clip(min=0.01, out=cvs)
+        w_prime = radiative_heating.convective_velocity_scale(
+            depth_eff, eff_heat_rate, air_temperature
+        )
+        w_prime.clip(min=0.01, out=w_prime)
     else:
-        cvs = convective_velocity_scale
+        w_prime = turbulent_vertical_velocity_scale
 
-    d_v = cvs**2 / n_bv + sedimentation_impact_factor * terminal_fall_speed * depth_eff
+    d_v = w_prime**2 / n_bv + sedimentation_impact_factor * terminal_fall_speed * depth_eff
 
     if max_vertical_diffusivity is not None:
         d_v = np.minimum(d_v, max_vertical_diffusivity)

--- a/pycontrails/models/cocip/contrail_properties.py
+++ b/pycontrails/models/cocip/contrail_properties.py
@@ -906,7 +906,7 @@ def vertical_diffusivity(
     terminal_fall_speed : npt.NDArray[np.floating] | float
         Terminal fall speed of contrail ice particles, [:math:`m s^{-1}`]
     convective_velocity_scale : npt.NDArray[np.floating] | float
-        Convective velocity scale, [:math:`m s^{-1}`] equivalent to `sqrt()`
+        Convective velocity scale, [:math:`m s^{-1}`]
     sedimentation_impact_factor : npt.NDArray[np.floating] | float
         Enhancement parameter denoted by `f_T` in eq. (35) Schumann (2012).
     eff_heat_rate: npt.NDArray[np.floating] | None

--- a/pycontrails/models/cocipgrid/cocip_grid.py
+++ b/pycontrails/models/cocipgrid/cocip_grid.py
@@ -1588,7 +1588,7 @@ def find_initial_persistent_contrails(
         persistent_contrail,
         effective_vertical_resolution=effective_vertical_resolution,
         wind_shear_enhancement_exponent=wind_shear_enhancement_exponent,
-        turbuent_vertical_velocity_scale=turbulent_vertical_velocity_scale,
+        turbulent_vertical_velocity_scale=turbulent_vertical_velocity_scale,
         sedimentation_impact_factor=sedimentation_impact_factor,
         radiative_heating_effects=False,  # Not yet supported in CocipGrid
         max_horizontal_diffusivity=params["max_horizontal_diffusivity"],

--- a/pycontrails/models/cocipgrid/cocip_grid.py
+++ b/pycontrails/models/cocipgrid/cocip_grid.py
@@ -1578,8 +1578,8 @@ def find_initial_persistent_contrails(
     wind_shear_enhancement_exponent = persistent_contrail.get(
         "wind_shear_enhancement_exponent", params["wind_shear_enhancement_exponent"]
     )
-    convective_velocity_scale = persistent_contrail.get(
-        "convective_velocity_scale", params["convective_velocity_scale"]
+    turbulent_vertical_velocity_scale = persistent_contrail.get(
+        "turbulent_vertical_velocity_scale", params["turbulent_vertical_velocity_scale"]
     )
     sedimentation_impact_factor = persistent_contrail.get(
         "sedimentation_impact_factor", params["sedimentation_impact_factor"]
@@ -1588,7 +1588,7 @@ def find_initial_persistent_contrails(
         persistent_contrail,
         effective_vertical_resolution=effective_vertical_resolution,
         wind_shear_enhancement_exponent=wind_shear_enhancement_exponent,
-        convective_velocity_scale=convective_velocity_scale,
+        turbuent_vertical_velocity_scale=turbulent_vertical_velocity_scale,
         sedimentation_impact_factor=sedimentation_impact_factor,
         radiative_heating_effects=False,  # Not yet supported in CocipGrid
         max_horizontal_diffusivity=params["max_horizontal_diffusivity"],
@@ -1718,7 +1718,7 @@ def calc_evolve_one_step(
         next_contrail,
         effective_vertical_resolution=params["effective_vertical_resolution"],
         wind_shear_enhancement_exponent=params["wind_shear_enhancement_exponent"],
-        convective_velocity_scale=params["convective_velocity_scale"],
+        turbulent_vertical_velocity_scale=params["turbulent_vertical_velocity_scale"],
         sedimentation_impact_factor=params["sedimentation_impact_factor"],
         radiative_heating_effects=False,  # Not yet supported in CocipGrid
         max_horizontal_diffusivity=params["max_horizontal_diffusivity"],

--- a/pycontrails/models/cocipgrid/cocip_grid.py
+++ b/pycontrails/models/cocipgrid/cocip_grid.py
@@ -1578,6 +1578,9 @@ def find_initial_persistent_contrails(
     wind_shear_enhancement_exponent = persistent_contrail.get(
         "wind_shear_enhancement_exponent", params["wind_shear_enhancement_exponent"]
     )
+    convective_velocity_scale = persistent_contrail.get(
+        "convective_velocity_scale", params["convective_velocity_scale"]
+    )
     sedimentation_impact_factor = persistent_contrail.get(
         "sedimentation_impact_factor", params["sedimentation_impact_factor"]
     )
@@ -1585,6 +1588,7 @@ def find_initial_persistent_contrails(
         persistent_contrail,
         effective_vertical_resolution=effective_vertical_resolution,
         wind_shear_enhancement_exponent=wind_shear_enhancement_exponent,
+        convective_velocity_scale=convective_velocity_scale,
         sedimentation_impact_factor=sedimentation_impact_factor,
         radiative_heating_effects=False,  # Not yet supported in CocipGrid
         max_horizontal_diffusivity=params["max_horizontal_diffusivity"],
@@ -1714,6 +1718,7 @@ def calc_evolve_one_step(
         next_contrail,
         effective_vertical_resolution=params["effective_vertical_resolution"],
         wind_shear_enhancement_exponent=params["wind_shear_enhancement_exponent"],
+        convective_velocity_scale=params["convective_velocity_scale"],
         sedimentation_impact_factor=params["sedimentation_impact_factor"],
         radiative_heating_effects=False,  # Not yet supported in CocipGrid
         max_horizontal_diffusivity=params["max_horizontal_diffusivity"],

--- a/pycontrails/models/dry_advection.py
+++ b/pycontrails/models/dry_advection.py
@@ -476,7 +476,7 @@ def _calc_geometry(
         dT_dz,
         depth_eff,
         terminal_fall_speed=0.0,
-        convective_velocity_scale=0.1,
+        turbulent_vertical_velocity_scale=0.1,
         sedimentation_impact_factor=0.0,
         eff_heat_rate=None,
         max_vertical_diffusivity=None,  # Not yet supported in DryAdvection

--- a/pycontrails/models/dry_advection.py
+++ b/pycontrails/models/dry_advection.py
@@ -476,6 +476,7 @@ def _calc_geometry(
         dT_dz,
         depth_eff,
         terminal_fall_speed=0.0,
+        convective_velocity_scale=0.1,
         sedimentation_impact_factor=0.0,
         eff_heat_rate=None,
         max_vertical_diffusivity=None,  # Not yet supported in DryAdvection

--- a/tests/unit/test_cocip.py
+++ b/tests/unit/test_cocip.py
@@ -1684,14 +1684,14 @@ def test_radiative_heating_effects_param(fl: Flight, met: MetDataset, rad: MetDa
 
     # Pretty massive difference in EF
     assert fl1["ef"].sum() == pytest.approx(7.3e12, rel=0.1)
-    assert fl2["ef"].sum() == pytest.approx(13.8e12, rel=0.1)
+    assert fl2["ef"].sum() == pytest.approx(3.8e12, rel=0.1)
 
     # Not nonzero in the same places!
     filt1 = fl1["ef"] != 0
     filt2 = fl2["ef"] != 0
     assert np.all(filt1 >= filt2)
     assert filt1.sum() == 10
-    assert filt2.sum() == 7
+    assert filt2.sum() == 9
 
 
 def test_radiative_heating_effects():


### PR DESCRIPTION
## Changes

This was requested by a user to support some sensitivity studies.

The changes are mostly straightforward. The only complication (which is why I'm asking Roger to review as well) is that I found a bug in the vertical diffusivity calculation, which (incorrectly) diagnoses vertical diffusivity based on the ratio of the convective velocity scale to the Brunt-Vaisala frequency rather than the *square* of the convective velocity scale. This isn't really an issue when running CoCiP in its default configuration, since the default value of 0.01 is consistent with the *square* of the convective velocity scale suggested by [Schumann and Graf (2013)](https://agupubs.onlinelibrary.wiley.com/doi/10.1002/jgrd.50184). It does produce changes when diagnosing the convective velocity scale based contrail radiative heating, though, because the value returned by [`radiative_heating.convective_velocity_scale`](https://github.com/contrailcirrus/pycontrails/blob/2da8cd34a9487ce7b4dfd4807805069ca14e6e8f/pycontrails/models/cocip/radiative_heating.py#L100) is used without squaring.

### Breaking changes

- Fix a bug in the vertical diffusivity calculation. Vertical diffusivity is now correctly diagnosed based on the square of the convective velocity scale. This changes default behavior only when the convective velocity scale is itself diagnosed based on differential radiative heating at the top and bottom of the contrail (`radiative_heating_effects = True`).

### Features

- Make the convective velocity scale used to calculate vertical diffusivity (similar to `w_N'` in Equation 35 of Schumann et al 2012) a user-configurable parameter.

## Tests

- [x] QC test passes locally (`make test`)
- [x] CI tests pass

## Reviewer

> @zebengberg, @roger-teoh 
