### PR TITLE
Feature/parametric_rf_v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.61.0 [unreleased]
+
+### Features
+
+- Experimental: Integrate alternative contrail parametric radiative forcing model (Schumann, 2025) into the CoCiP workflow: The original parametric RF model assumes a near-linear dependence of contrail RF on the contrail and natural cirrus optical depth and provides the best fit to the libRadtran dataset with the minimum number of model coefficients. This alternative model provides a stronger non-linear dependence to the contrail and natural cirrus optical depth, consistent with the ECMWF ecRad model, but yields a slightly weaker fit to the libRadtran dataset. This new parameterization can be enabled within the `Cocip` and `CocipGrid` models via the `parametric_rf_model_s2025` parameter.
+
 ## 0.60.5
 
 ### Breaking changes

--- a/pycontrails/models/cocip/cocip.py
+++ b/pycontrails/models/cocip/cocip.py
@@ -2872,7 +2872,7 @@ def _contrail_contrail_overlapping(
         min_altitude_m=params["min_altitude_m"],
         max_altitude_m=params["max_altitude_m"],
         dz_overlap_m=params["dz_overlap_m"],
-        rf_model_s2025=params["parametric_rf_model_s2025"]
+        rf_model_s2025=params["parametric_rf_model_s2025"],
     )
 
     contrail.update(

--- a/pycontrails/models/cocip/cocip.py
+++ b/pycontrails/models/cocip/cocip.py
@@ -2280,12 +2280,20 @@ def calc_radiative_properties(contrail: GeoVectorDataset, params: dict[str, Any]
     habit_weights = radiative_forcing.habit_weights(
         r_vol_um, params["habit_distributions"], params["radius_threshold_um"]
     )
-    rf_lw = radiative_forcing.longwave_radiative_forcing(
-        r_vol_um, olr, air_temperature, tau_contrail, tau_cirrus_, habit_weights
-    )
-    rf_sw = radiative_forcing.shortwave_radiative_forcing(
-        r_vol_um, sdr, rsr, sd0, tau_contrail, tau_cirrus_, habit_weights
-    )
+    if params["parametric_rf_model_s2025"]:
+        rf_lw = radiative_forcing.longwave_radiative_forcing_s2025(
+            r_vol_um, olr, air_temperature, tau_contrail, tau_cirrus_, habit_weights
+        )
+        rf_sw = radiative_forcing.shortwave_radiative_forcing_s2025(
+            r_vol_um, sdr, rsr, sd0, tau_contrail, tau_cirrus_, habit_weights
+        )
+    else:
+        rf_lw = radiative_forcing.longwave_radiative_forcing(
+            r_vol_um, olr, air_temperature, tau_contrail, tau_cirrus_, habit_weights
+        )
+        rf_sw = radiative_forcing.shortwave_radiative_forcing(
+            r_vol_um, sdr, rsr, sd0, tau_contrail, tau_cirrus_, habit_weights
+        )
 
     # scale RF by enhancement factors
     rf_lw_scaled = rf_lw * params["rf_lw_enhancement_factor"]
@@ -2864,6 +2872,7 @@ def _contrail_contrail_overlapping(
         min_altitude_m=params["min_altitude_m"],
         max_altitude_m=params["max_altitude_m"],
         dz_overlap_m=params["dz_overlap_m"],
+        rf_model_s2025=params["parametric_rf_model_s2025"]
     )
 
     contrail.update(

--- a/pycontrails/models/cocip/cocip_params.py
+++ b/pycontrails/models/cocip/cocip_params.py
@@ -274,6 +274,21 @@ class CocipParams(AdvectionBuffers):
         Particle(type=ParticleType.AMBIENT, gmd=30.0e-9, gsd=2.3, kappa=0.5, n_ambient=600.0e6),
     )
 
+    #: Experimental. Alternative contrail parametric radiative forcing model.
+    #: The original parametric RF model (Schumann et al., 2012) assumes a near-linear dependence of
+    #: contrail RF on the contrail and natural cirrus optical depth. However, the ECMWF ecRad model
+    #: suggests a stronger nonlinear dependence. Schumann (2025) introduces an alternative
+    #: formulation to allow for stronger RF non-linearity. The original formulation remains the
+    #: best fit to the libRadtran dataset with the minimum number of model coefficients, while the
+    #: alternative formulation yields a slightly weaker regression fit.
+    #:
+    #: See the Schumann (2025) `<https://doi.org/10.5281/zenodo.17241725>`_, `mo_rf.f90` in
+    #: Schumann (2025) `<https://doi.org/10.5281/zenodo.17581102>`_, and Figure 8 of Schumann &
+    #: Seifert (2025), `<https://doi.org/10.5194/acp-25-18571-2025>`_.
+    #:
+    #:  .. versionadded:: 0.61.0
+    parametric_rf_model_s2025: bool = False
+
     #: Experimental. Radiative effects due to contrail-contrail overlapping
     #: Account for change in local contrail shortwave and longwave radiative forcing
     #: due to contrail-contrail overlapping.

--- a/pycontrails/models/cocip/radiative_forcing.py
+++ b/pycontrails/models/cocip/radiative_forcing.py
@@ -887,7 +887,7 @@ def effective_tau_cirrus(
 @dataclasses.dataclass(frozen=True)
 class RFConstantsS2025:
     """
-    Constants that are used to calculate the local contrail radiative forcing (V2).
+    Constants that are used to calculate the local contrail radiative forcing (Schumann, 2025).
 
     Each coefficient has 8 elements, one corresponding to each contrail ice particle habit (shape)::
 
@@ -926,64 +926,64 @@ class RFConstantsS2025:
     # -----
     # Variables/coefficients used to calculate the local contrail longwave radiative forcing.
     # -----
-    AK = np.array([3.23595, 3.25723, 3.23853, 3.20214, 3.22151, 3.20444, 4.00515, 3.24338])
+    ak = np.array([3.23595, 3.25723, 3.23853, 3.20214, 3.22151, 3.20444, 4.00515, 3.24338])
 
-    SIGMA = np.array(
+    sigma = np.array(
         [3.35993e-06, 3.00607e-06, 3.33420e-06, 4.09619e-06,
          3.67116e-06, 4.02626e-06, 4.94882e-08,3.21650e-06]
     )
 
-    DELTA = np.array(
+    delta = np.array(
         [0.874430, 0.776886, 0.713890, 0.657861, 0.716007, 0.687059, 0.842696, 0.769347])
 
-    QLW = np.array([0.312496, 0.386529, 0.370883, 0.297256, 0.218414, 1.97702, 0.252445, 0.248097])
+    qlw = np.array([0.312496, 0.386529, 0.370883, 0.297256, 0.218414, 1.97702, 0.252445, 0.248097])
 
-    cDTAUCI = np.array(
+    c_dtauci = np.array(
         [0.200662, 0.174288, 0.148988, 0.0944375, 0.197152, 0.146475, 0.235398, 0.135923]
     )
 
-    tauexpLW = np.array(
+    tau_exp_lw = np.array(
         [0.941626, 0.921358, 0.924119, 0.929786, 0.931181, 0.927095, 0.856405, 0.924699]
     )
 
     # -----
     # Variables/coefficients used to calculate the local contrail shortwave radiative forcing.
     # -----
-    GAMMA = np.array([9.06419, 5.45276, 6.61548, 5.49484, 6.66096, 7.96645, 6.15650, 6.69045])
+    gamma = np.array([9.06419, 5.45276, 6.61548, 5.49484, 6.66096, 7.96645, 6.15650, 6.69045])
 
-    GAMMAS = np.array([40.5364, 16.8060, 22.3319, 16.9001, 25.5195, 7.61456, 9.75937, 9.33121])
+    gammas = np.array([40.5364, 16.8060, 22.3319, 16.9001, 25.5195, 7.61456, 9.75937, 9.33121])
 
-    TT = np.array([0.879304, 0.901417, 0.881617, 0.898850, 0.879667, 0.883407, 0.898837, 1.00788])
+    tt = np.array([0.879304, 0.901417, 0.881617, 0.898850, 0.879667, 0.883407, 0.898837, 1.00788])
 
-    GALBS = np.array(
+    galbs = np.array(
         [0.432165, 0.874683, 0.647569, 0.897522, 0.712315, 0.720927, 0.815349, 0.932811]
     )
 
-    ACTH = np.array(
+    acth = np.array(
         [0.0129326, 0.0249145, 0.0190486, 0.0245007, 0.0201106, 0.0394534, 0.0325837, 0.0590863]
     )
 
-    BCTH = np.array([1.41410, 1.37992, 1.56329, 1.40405, 1.38461, 1.58401, 1.34064, 1.45445])
+    bcth = np.array([1.41410, 1.37992, 1.56329, 1.40405, 1.38461, 1.58401, 1.34064, 1.45445])
 
-    CCTH = np.array(
+    ccth = np.array(
         [0.174603, 0.312233, 0.336866, 0.331776, 0.174517, 0.246677, 0.224502, 0.338728]
     )
 
-    DCTH = np.array(
+    dcth = np.array(
         [0.838433, 0.680409, 0.665093, 0.625401, 0.795688, 0.500001, 0.452205, 0.807171]
     )
 
-    FRSW = np.array([0.930169, 0.918669, 1.00763, 0.742713, 0.945019, 3.40950, 1.37480, 1.39646])
+    frsw = np.array([0.930169, 0.918669, 1.00763, 0.742713, 0.945019, 3.40950, 1.37480, 1.39646])
 
-    RADDSW = np.array([5.99100, 37.5521, 39.3959, 121.831, 20.5531, 16.8181, 156.619, 163.951])
+    raddsw = np.array([5.99100, 37.5521, 39.3959, 121.831, 20.5531, 16.8181, 156.619, 163.951])
 
-    QSW = np.array([1.90758, 3.15424, 3.15424, 1.63419, 2.70324, 1.66234, 1.88483, 1.88483])
+    qsw = np.array([1.90758, 3.15424, 3.15424, 1.63419, 2.70324, 1.66234, 1.88483, 1.88483])
 
-    EXALB = np.array(
+    exalb = np.array(
         [0.155310, 0.142510, 0.165978, 0.149808, 0.165641, 0.167064, 0.172320, 0.212536]
     )
 
-    cDTAUCISW = np.array(
+    c_dtauci_sw = np.array(
         [0.224998, 0.195919, 0.242060, 0.206488, 0.238648, 0.261965, 0.245360, 0.300703]
     )
 
@@ -1051,12 +1051,12 @@ def longwave_radiative_forcing_s2025(
     idx0, idx1 = np.nonzero(habit_weight_mask)
 
     # Convert parametric coefficients for vectorized operations
-    AK = RF_CONST_S2025.AK[idx1]
-    SIGMA = RF_CONST_S2025.SIGMA[idx1]
-    DELTA = RF_CONST_S2025.DELTA[idx1]
-    QLW = RF_CONST_S2025.QLW[idx1]
-    cDTAUCI = RF_CONST_S2025.cDTAUCI[idx1]
-    tauexpLW = RF_CONST_S2025.tauexpLW[idx1]
+    ak = RF_CONST_S2025.ak[idx1]
+    sigma = RF_CONST_S2025.sigma[idx1]
+    delta = RF_CONST_S2025.delta[idx1]
+    qlw = RF_CONST_S2025.qlw[idx1]
+    c_dtauci = RF_CONST_S2025.c_dtauci[idx1]
+    tau_exp_lw = RF_CONST_S2025.tau_exp_lw[idx1]
 
     olr_h = olr[idx0]
     tau_cirrus_h = tau_cirrus[idx0]
@@ -1078,10 +1078,10 @@ def longwave_radiative_forcing_s2025(
 
     # Longwave radiation calculations: Calculate the RF LW per habit type
     rf_lw_per_habit = (
-        (olr_h - SIGMA * (air_temperature_h ** AK))
-        * (1.0 - np.exp(-DELTA * np.exp(np.log(tau_contrail_h) * tauexpLW)))
-        * (1.0 - np.exp(-QLW * r_eff_um_h))
-        * np.exp(-cDTAUCI * tau_cirrus_h)
+        (olr_h - sigma * (air_temperature_h ** ak))
+        * (1.0 - np.exp(-delta * np.exp(np.log(tau_contrail_h) * tau_exp_lw)))
+        * (1.0 - np.exp(-qlw * r_eff_um_h))
+        * np.exp(-c_dtauci * tau_cirrus_h)
     )
     rf_lw_per_habit.clip(min=0.0, out=rf_lw_per_habit)
 
@@ -1164,19 +1164,19 @@ def shortwave_radiative_forcing_s2025(
     idx0, idx1 = np.nonzero(habit_weight_mask)
 
     # Convert parametric coefficients for vectorized operations
-    GAMMA = RF_CONST_S2025.GAMMA[idx1]
-    GAMMAS = RF_CONST_S2025.GAMMAS[idx1]
-    TT = RF_CONST_S2025.TT[idx1]
-    GALBS = RF_CONST_S2025.GALBS[idx1]
-    ACTH = RF_CONST_S2025.ACTH[idx1]
-    BCTH = RF_CONST_S2025.BCTH[idx1]
-    CCTH = RF_CONST_S2025.CCTH[idx1]
-    DCTH = RF_CONST_S2025.DCTH[idx1]
-    FRSW = RF_CONST_S2025.FRSW[idx1]
-    RADDSW = RF_CONST_S2025.RADDSW[idx1]
-    QSW = RF_CONST_S2025.QSW[idx1]
-    EXALB = RF_CONST_S2025.EXALB[idx1]
-    cDTAUCISW = RF_CONST_S2025.cDTAUCISW[idx1]
+    gamma = RF_CONST_S2025.gamma[idx1]
+    gammas = RF_CONST_S2025.gammas[idx1]
+    tt = RF_CONST_S2025.tt[idx1]
+    galbs = RF_CONST_S2025.galbs[idx1]
+    acth = RF_CONST_S2025.acth[idx1]
+    bcth = RF_CONST_S2025.bcth[idx1]
+    ccth = RF_CONST_S2025.ccth[idx1]
+    dcth = RF_CONST_S2025.dcth[idx1]
+    frsw = RF_CONST_S2025.frsw[idx1]
+    raddsw = RF_CONST_S2025.raddsw[idx1]
+    qsw = RF_CONST_S2025.qsw[idx1]
+    exalb = RF_CONST_S2025.exalb[idx1]
+    c_dtaucisw = RF_CONST_S2025.c_dtauci_sw[idx1]
 
     sdr_h = sdr[idx0]
     rsr_h = rsr[idx0]
@@ -1201,22 +1201,22 @@ def shortwave_radiative_forcing_s2025(
         r_eff_um_h = r_eff_um[idx0]
 
     # Local contrail shortwave radiative forcing calculations
-    ABK = ACTH / (0.5 ** (BCTH + CCTH))
-    LOGCTH = np.log(mue)
-    LOG1mCTH = np.log(1 - mue)
-    CTHF = np.exp(LOG1mCTH * BCTH) * np.exp(LOGCTH * CCTH) * ABK - ACTH
-    QCTH = 1.0 / (mue + 1.0e-6)
-    TAUCTH = tau_contrail_h * QCTH
+    abk = acth / (0.5 ** (bcth + ccth))
+    log_mue = np.log(mue)
+    log_one_minus_mue = np.log(1 - mue)
+    cthf = np.exp(log_one_minus_mue * bcth) * np.exp(log_mue * ccth) * abk - acth
+    qcth = 1.0 / (mue + 1.0e-6)
+    taucth = tau_contrail_h * qcth
 
     # calculate the RF SW per habit type
     rf_sw_per_habit = -(
         sdr_h
-        * ((TT - albedo_) ** 2)
-        * (TAUCTH / (GAMMA + TAUCTH))
-        * (DCTH + CTHF * (GAMMAS + tau_contrail_h * GALBS) / (1.0 + tau_contrail_h * GALBS))
-        * (1.0 + FRSW * np.exp(-r_eff_um_h / RADDSW))
-        * (1.0 - np.exp(-QSW * r_eff_um_h))
-        * np.exp((cDTAUCISW - EXALB * QCTH) * tau_cirrus_h)
+        * ((tt - albedo_) ** 2)
+        * (taucth / (gamma + taucth))
+        * (dcth + cthf * (gammas + tau_contrail_h * galbs) / (1.0 + tau_contrail_h * galbs))
+        * (1.0 + frsw * np.exp(-r_eff_um_h / raddsw))
+        * (1.0 - np.exp(-qsw * r_eff_um_h))
+        * np.exp((c_dtaucisw - exalb * qcth) * tau_cirrus_h)
     )
     rf_sw_per_habit.clip(max=0.0, out=rf_sw_per_habit)
 

--- a/pycontrails/models/cocip/radiative_forcing.py
+++ b/pycontrails/models/cocip/radiative_forcing.py
@@ -257,6 +257,7 @@ class RFConstantsV2:
 
 # create a new constants class to use within module
 RF_CONST = RFConstants()
+RF_CONST_V2 = RFConstantsV2()
 
 
 # ----------
@@ -987,6 +988,239 @@ def effective_tau_cirrus(
     tau_cirrus_eff = tau_cirrus / (mue + 1e-6)
     return np.exp(tau_cirrus * delta_sc_aps - tau_cirrus_eff * delta_sc)
 
+
+# -----------------------------
+# Parametric RF model (V2)
+# -----------------------------
+# TODO: Cite zenodo repository
+
+def longwave_radiative_forcing_v2(
+    r_vol_um: npt.NDArray[np.floating],
+    olr: npt.NDArray[np.floating],
+    air_temperature: npt.NDArray[np.floating],
+    tau_contrail: npt.NDArray[np.floating],
+    tau_cirrus: npt.NDArray[np.floating],
+    habit_weights_: npt.NDArray[np.floating],
+    r_eff_um: npt.NDArray[np.floating] | None = None,
+) -> npt.NDArray[np.floating]:
+    r"""
+    Calculate the local contrail longwave radiative forcing (:math:`RF_{LW}`).
+
+    All returned values are positive.
+
+    Parameters
+    ----------
+    r_vol_um : npt.NDArray[np.floating]
+        Contrail ice particle volume mean radius, [:math:`\mu m`]
+    olr : npt.NDArray[np.floating]
+        Outgoing longwave radiation at each waypoint, [:math:`W m^{-2}`]
+    air_temperature : npt.NDArray[np.floating]
+        Ambient temperature at each waypoint, [:math:`K`]
+    tau_contrail : npt.NDArray[np.floating]
+        Contrail optical depth at each waypoint
+    tau_cirrus : npt.NDArray[np.floating]
+        Optical depth of numerical weather prediction (NWP) cirrus above the
+        contrail at each waypoint
+    habit_weights_ : npt.NDArray[np.floating]
+        Weights to different ice particle habits for each waypoint,
+        ``n_waypoints x 8`` (habit) columns, [:math:`[0 - 1]`]
+    r_eff_um : npt.NDArray[np.floating] | None, optional
+        Provide effective radius corresponding to elements in ``r_vol_um``, [:math:`\mu m`].
+        Defaults to None, which means the effective radius will be calculated using ``r_vol_um``
+        and habit types in :func:`effective_radius_by_habit`.
+
+    Returns
+    -------
+    npt.NDArray[np.floating]
+        Local contrail longwave radiative forcing (positive), [:math:`W m^{-2}`]
+
+    Raises
+    ------
+    ValueError
+        If `r_eff_um` and `olr` have different shapes.
+
+    References
+    ----------
+    - :cite:`schumannParametricRadiativeForcing2012`
+    """
+    # get list of habit weight indexs where the weights > 0
+    # this is a tuple of (np.array[waypoint index], np.array[habit type index])
+    habit_weight_mask = habit_weights_ > 0.0
+    idx0, idx1 = np.nonzero(habit_weight_mask)
+
+    # Convert parametric coefficients for vectorized operations
+    AK = RF_CONST_V2.AK[idx1]
+    SIGMA = RF_CONST_V2.SIGMA[idx1]
+    DELTA = RF_CONST_V2.DELTA[idx1]
+    QLW = RF_CONST_V2.QLW[idx1]
+    cDTAUCI = RF_CONST_V2.cDTAUCI[idx1]
+    tauexpLW = RF_CONST_V2.tauexpLW[idx1]
+
+    olr_h = olr[idx0]
+    tau_cirrus_h = tau_cirrus[idx0]
+    tau_contrail_h = tau_contrail[idx0]
+    air_temperature_h = air_temperature[idx0]
+
+    # effective radius
+    if r_eff_um is None:
+        r_vol_um_h = r_vol_um[idx0]
+        r_eff_um_h = effective_radius_by_habit(r_vol_um_h, idx1)
+    else:
+        if r_eff_um.shape != olr.shape:
+            raise ValueError(
+                "User provided effective radius (`r_eff_um`) must have the same shape as `olr`"
+                f" {olr.shape}"
+            )
+
+        r_eff_um_h = r_eff_um[idx0]
+
+    # Longwave radiation calculations: Calculate the RF LW per habit type
+    rf_lw_per_habit = (
+        (olr_h - SIGMA * (air_temperature_h ** AK))
+        * (1.0 - np.exp(-DELTA * np.exp(np.log(tau_contrail_h) * tauexpLW)))
+        * (1.0 - np.exp(-QLW * r_eff_um_h))
+        * np.exp(-cDTAUCI * tau_cirrus_h)
+    )
+    rf_lw_per_habit.clip(min=0.0, out=rf_lw_per_habit)
+
+    # Weight and sum the RF contributions of each habit type according the habit weight
+    # regime at the waypoint
+    # see eqn (12) in :cite:`schumannParametricRadiativeForcing2012`
+    # use fancy indexing to re-assign values to 2d array of waypoint x habit type
+    rf_lw_weighted = np.zeros_like(habit_weights_)
+    rf_lw_weighted[idx0, idx1] = rf_lw_per_habit * habit_weights_[habit_weight_mask]
+    return np.sum(rf_lw_weighted, axis=1)
+
+
+def shortwave_radiative_forcing_v2(
+    r_vol_um: npt.NDArray[np.floating],
+    sdr: npt.NDArray[np.floating],
+    rsr: npt.NDArray[np.floating],
+    sd0: npt.NDArray[np.floating],
+    tau_contrail: npt.NDArray[np.floating],
+    tau_cirrus: npt.NDArray[np.floating],
+    habit_weights_: npt.NDArray[np.floating],
+    r_eff_um: npt.NDArray[np.floating] | None = None,
+) -> npt.NDArray[np.floating]:
+    r"""
+    Calculate the local contrail shortwave radiative forcing (:math:`RF_{SW}`).
+
+    All returned values are negative.
+
+    Parameters
+    ----------
+    r_vol_um : npt.NDArray[np.floating]
+        Contrail ice particle volume mean radius, [:math:`\mu m`]
+    sdr : npt.NDArray[np.floating]
+        Solar direct radiation, [:math:`W m^{-2}`]
+    rsr : npt.NDArray[np.floating]
+        Reflected solar radiation, [:math:`W m^{-2}`]
+    sd0 : npt.NDArray[np.floating]
+        Solar constant, [:math:`W m^{-2}`]
+    tau_contrail : npt.NDArray[np.floating]
+        Contrail optical depth for each waypoint
+    tau_cirrus : npt.NDArray[np.floating]
+        Optical depth of numerical weather prediction (NWP) cirrus above the
+        contrail for each waypoint.
+    habit_weights_ : npt.NDArray[np.floating]
+        Weights to different ice particle habits for each waypoint,
+        ``n_waypoints x 8`` (habit) columns, [:math:`[0 - 1]`]
+    r_eff_um : npt.NDArray[np.floating] | None, optional
+        Provide effective radius corresponding to elements in ``r_vol_um``, [:math:`\mu m`].
+        Defaults to None, which means the effective radius will be calculated using ``r_vol_um``
+        and habit types in :func:`effective_radius_by_habit`.
+
+    Returns
+    -------
+    npt.NDArray[np.floating]
+        Local contrail shortwave radiative forcing (negative), [:math:`W m^{-2}`]
+
+    Raises
+    ------
+    ValueError
+        If `r_eff_um` and `sdr` have different shapes.
+
+    References
+    ----------
+    - :cite:`schumannParametricRadiativeForcing2012`
+    """
+    # create mask for daytime (sdr > 0)
+    day = sdr > 0.0
+
+    # short circuit if no waypoints occur during the day
+    if not day.any():
+        return np.zeros_like(sdr)
+
+    # get list of habit weight indexs where the weights > 0
+    # this is a tuple of (np.array[waypoint index], np.array[habit type index])
+    habit_weight_mask = day.reshape(day.size, 1) & (habit_weights_ > 0.0)
+    idx0, idx1 = np.nonzero(habit_weight_mask)
+
+    # Convert parametric coefficients for vectorized operations
+    GAMMA = RF_CONST_V2.GAMMA[idx1]
+    GAMMAS = RF_CONST_V2.GAMMAS[idx1]
+    TT = RF_CONST_V2.TT[idx1]
+    GALBS = RF_CONST_V2.GALBS[idx1]
+    ACTH = RF_CONST_V2.ACTH[idx1]
+    BCTH = RF_CONST_V2.BCTH[idx1]
+    CCTH = RF_CONST_V2.CCTH[idx1]
+    DCTH = RF_CONST_V2.DCTH[idx1]
+    FRSW = RF_CONST_V2.FRSW[idx1]
+    RADDSW = RF_CONST_V2.RADDSW[idx1]
+    QSW = RF_CONST_V2.QSW[idx1]
+    EXALB = RF_CONST_V2.EXALB[idx1]
+    cDTAUCISW = RF_CONST_V2.cDTAUCISW[idx1]
+
+    sdr_h = sdr[idx0]
+    rsr_h = rsr[idx0]
+    sd0_h = sd0[idx0]
+    tau_contrail_h = tau_contrail[idx0]
+    tau_cirrus_h = tau_cirrus[idx0]
+
+    albedo_ = albedo(sdr_h, rsr_h)
+    mue = np.minimum(sdr_h / sd0_h, 1.0)
+
+    # effective radius
+    if r_eff_um is None:
+        r_vol_um_h = r_vol_um[idx0]
+        r_eff_um_h = effective_radius_by_habit(r_vol_um_h, idx1)
+    else:
+        if r_eff_um.shape != sdr.shape:
+            raise ValueError(
+                "User provided effective radius (`r_eff_um`) must have the same shape as `sdr`"
+                f" {sdr.shape}"
+            )
+
+        r_eff_um_h = r_eff_um[idx0]
+
+    # Local contrail shortwave radiative forcing calculations
+    ABK = ACTH / (0.5 ** (BCTH + CCTH))
+    LOGCTH = np.log(mue)
+    LOG1mCTH = np.log(1 - mue)
+    CTHF = np.exp(LOG1mCTH * BCTH) * np.exp(LOGCTH * CCTH) * ABK - ACTH
+    QCTH = 1.0 / (mue + 1.0e-6)
+    TAUCTH = tau_contrail * QCTH
+
+    # calculate the RF SW per habit type
+    rf_sw_per_habit = -(
+        sdr_h
+        * ((TT - albedo_) ** 2)
+        * (TAUCTH / (GAMMA + TAUCTH))
+        * (DCTH + CTHF * (GAMMAS + tau_contrail_h * GALBS) / (1.0 + tau_contrail_h * GALBS))
+        * (1.0 + FRSW * np.exp(-r_eff_um_h / RADDSW))
+        * (1.0 - np.exp(-QSW * r_eff_um_h))
+        * np.exp((cDTAUCISW - EXALB * QCTH) * tau_cirrus_h)
+    )
+    rf_sw_per_habit.clip(max=0.0, out=rf_sw_per_habit)
+
+    # Weight and sum the RF contributions of each habit type according the
+    # habit weight regime at the waypoint
+    # see eqn (12) in :cite:`schumannParametricRadiativeForcing2012`
+    # use fancy indexing to re-assign values to 2d array of waypoint x habit type
+    rf_sw_weighted = np.zeros_like(habit_weights_)
+    rf_sw_weighted[idx0, idx1] = rf_sw_per_habit * habit_weights_[habit_weight_mask]
+
+    return np.sum(rf_sw_weighted, axis=1)
 
 # -----------------------------
 # Contrail-contrail overlapping

--- a/pycontrails/models/cocip/radiative_forcing.py
+++ b/pycontrails/models/cocip/radiative_forcing.py
@@ -916,6 +916,11 @@ class RFConstantsV2:
     References
     ----------
     - `mo_rf.f90` in Schumann (2025), https://doi.org/10.5281/zenodo.17581103
+    - Figure 8 of Schumann et al. (2025), https://doi.org/10.5194/acp-25-18571-2025
+
+    Notes
+    -----
+    - Coefficients obtained directly from the algorithm of Schumann (2025).
     """
 
     # -----
@@ -1034,6 +1039,11 @@ def longwave_radiative_forcing_v2(
     References
     ----------
     - `mo_rf.f90` in Schumann (2025), https://doi.org/10.5281/zenodo.17581103
+    - Figure 8 of Schumann et al. (2025), https://doi.org/10.5194/acp-25-18571-2025
+
+    Notes
+    -----
+    - Equations obtained directly from the algorithm of Schumann (2025).
     """
     # get list of habit weight indexs where the weights > 0
     # this is a tuple of (np.array[waypoint index], np.array[habit type index])
@@ -1135,6 +1145,11 @@ def shortwave_radiative_forcing_v2(
     References
     ----------
     - `mo_rf.f90` in Schumann (2025), https://doi.org/10.5281/zenodo.17581103
+    - Figure 8 of Schumann et al. (2025), https://doi.org/10.5194/acp-25-18571-2025
+
+    Notes
+    -----
+    - Equations obtained directly from the algorithm of Schumann (2025).
     """
     # create mask for daytime (sdr > 0)
     day = sdr > 0.0
@@ -1191,7 +1206,7 @@ def shortwave_radiative_forcing_v2(
     LOG1mCTH = np.log(1 - mue)
     CTHF = np.exp(LOG1mCTH * BCTH) * np.exp(LOGCTH * CCTH) * ABK - ACTH
     QCTH = 1.0 / (mue + 1.0e-6)
-    TAUCTH = tau_contrail * QCTH
+    TAUCTH = tau_contrail_h * QCTH
 
     # calculate the RF SW per habit type
     rf_sw_per_habit = -(

--- a/pycontrails/models/cocip/radiative_forcing.py
+++ b/pycontrails/models/cocip/radiative_forcing.py
@@ -22,7 +22,7 @@ from pycontrails.physics import geo
 
 
 @dataclasses.dataclass(frozen=True)
-class RFConstants:
+class RFConstantsS2012:
     """
     Constants that are used to calculate the local contrail radiative forcing.
 
@@ -148,7 +148,7 @@ class RFConstants:
 
 
 # create a new constants class to use within module
-RF_CONST = RFConstants()
+RF_CONST_S2012 = RFConstantsS2012()
 
 
 # ----------
@@ -504,11 +504,11 @@ def longwave_radiative_forcing(
     idx0, idx1 = np.nonzero(habit_weight_mask)
 
     # Convert parametric coefficients for vectorized operations
-    delta_t = RF_CONST.delta_t[idx1]
-    delta_lc = RF_CONST.delta_lc[idx1]
-    delta_lr = RF_CONST.delta_lr[idx1]
-    k_t = RF_CONST.k_t[idx1]
-    T_0 = RF_CONST.T_0[idx1]
+    delta_t = RF_CONST_S2012.delta_t[idx1]
+    delta_lc = RF_CONST_S2012.delta_lc[idx1]
+    delta_lr = RF_CONST_S2012.delta_lr[idx1]
+    k_t = RF_CONST_S2012.k_t[idx1]
+    T_0 = RF_CONST_S2012.T_0[idx1]
 
     olr_h = olr[idx0]
     tau_cirrus_h = tau_cirrus[idx0]
@@ -615,16 +615,16 @@ def shortwave_radiative_forcing(
     idx0, idx1 = np.nonzero(habit_weight_mask)
 
     # Convert parametric coefficients for vectorized operations
-    t_a = RF_CONST.t_a[idx1]
-    A_mu = RF_CONST.A_mu[idx1]
-    B_mu = RF_CONST.B_mu[idx1]
-    C_mu = RF_CONST.C_mu[idx1]
-    delta_sr = RF_CONST.delta_sr[idx1]
-    F_r = RF_CONST.F_r[idx1]
-    gamma_lower = RF_CONST.gamma_lower[idx1]
-    gamma_upper = RF_CONST.gamma_upper[idx1]
-    delta_sc = RF_CONST.delta_sc[idx1]
-    delta_sc_aps = RF_CONST.delta_sc_aps[idx1]
+    t_a = RF_CONST_S2012.t_a[idx1]
+    A_mu = RF_CONST_S2012.A_mu[idx1]
+    B_mu = RF_CONST_S2012.B_mu[idx1]
+    C_mu = RF_CONST_S2012.C_mu[idx1]
+    delta_sr = RF_CONST_S2012.delta_sr[idx1]
+    F_r = RF_CONST_S2012.F_r[idx1]
+    gamma_lower = RF_CONST_S2012.gamma_lower[idx1]
+    gamma_upper = RF_CONST_S2012.gamma_upper[idx1]
+    delta_sc = RF_CONST_S2012.delta_sc[idx1]
+    delta_sc_aps = RF_CONST_S2012.delta_sc_aps[idx1]
 
     sdr_h = sdr[idx0]
     rsr_h = rsr[idx0]
@@ -880,12 +880,12 @@ def effective_tau_cirrus(
     return np.exp(tau_cirrus * delta_sc_aps - tau_cirrus_eff * delta_sc)
 
 
-# ----------------------------------------------------------
-# Parametric radiative forcing model (V2): Schumann (2025)
-# ----------------------------------------------------------
+# ---------------------------------------------------
+# Parametric radiative forcing model: Schumann (2025)
+# ---------------------------------------------------
 
 @dataclasses.dataclass(frozen=True)
-class RFConstantsV2:
+class RFConstantsS2025:
     """
     Constants that are used to calculate the local contrail radiative forcing (V2).
 
@@ -988,10 +988,10 @@ class RFConstantsV2:
     )
 
 
-RF_CONST_V2 = RFConstantsV2()
+RF_CONST_S2025 = RFConstantsS2025()
 
 
-def longwave_radiative_forcing_v2(
+def longwave_radiative_forcing_s2025(
     r_vol_um: npt.NDArray[np.floating],
     olr: npt.NDArray[np.floating],
     air_temperature: npt.NDArray[np.floating],
@@ -1051,12 +1051,12 @@ def longwave_radiative_forcing_v2(
     idx0, idx1 = np.nonzero(habit_weight_mask)
 
     # Convert parametric coefficients for vectorized operations
-    AK = RF_CONST_V2.AK[idx1]
-    SIGMA = RF_CONST_V2.SIGMA[idx1]
-    DELTA = RF_CONST_V2.DELTA[idx1]
-    QLW = RF_CONST_V2.QLW[idx1]
-    cDTAUCI = RF_CONST_V2.cDTAUCI[idx1]
-    tauexpLW = RF_CONST_V2.tauexpLW[idx1]
+    AK = RF_CONST_S2025.AK[idx1]
+    SIGMA = RF_CONST_S2025.SIGMA[idx1]
+    DELTA = RF_CONST_S2025.DELTA[idx1]
+    QLW = RF_CONST_S2025.QLW[idx1]
+    cDTAUCI = RF_CONST_S2025.cDTAUCI[idx1]
+    tauexpLW = RF_CONST_S2025.tauexpLW[idx1]
 
     olr_h = olr[idx0]
     tau_cirrus_h = tau_cirrus[idx0]
@@ -1094,7 +1094,7 @@ def longwave_radiative_forcing_v2(
     return np.sum(rf_lw_weighted, axis=1)
 
 
-def shortwave_radiative_forcing_v2(
+def shortwave_radiative_forcing_s2025(
     r_vol_um: npt.NDArray[np.floating],
     sdr: npt.NDArray[np.floating],
     rsr: npt.NDArray[np.floating],
@@ -1164,19 +1164,19 @@ def shortwave_radiative_forcing_v2(
     idx0, idx1 = np.nonzero(habit_weight_mask)
 
     # Convert parametric coefficients for vectorized operations
-    GAMMA = RF_CONST_V2.GAMMA[idx1]
-    GAMMAS = RF_CONST_V2.GAMMAS[idx1]
-    TT = RF_CONST_V2.TT[idx1]
-    GALBS = RF_CONST_V2.GALBS[idx1]
-    ACTH = RF_CONST_V2.ACTH[idx1]
-    BCTH = RF_CONST_V2.BCTH[idx1]
-    CCTH = RF_CONST_V2.CCTH[idx1]
-    DCTH = RF_CONST_V2.DCTH[idx1]
-    FRSW = RF_CONST_V2.FRSW[idx1]
-    RADDSW = RF_CONST_V2.RADDSW[idx1]
-    QSW = RF_CONST_V2.QSW[idx1]
-    EXALB = RF_CONST_V2.EXALB[idx1]
-    cDTAUCISW = RF_CONST_V2.cDTAUCISW[idx1]
+    GAMMA = RF_CONST_S2025.GAMMA[idx1]
+    GAMMAS = RF_CONST_S2025.GAMMAS[idx1]
+    TT = RF_CONST_S2025.TT[idx1]
+    GALBS = RF_CONST_S2025.GALBS[idx1]
+    ACTH = RF_CONST_S2025.ACTH[idx1]
+    BCTH = RF_CONST_S2025.BCTH[idx1]
+    CCTH = RF_CONST_S2025.CCTH[idx1]
+    DCTH = RF_CONST_S2025.DCTH[idx1]
+    FRSW = RF_CONST_S2025.FRSW[idx1]
+    RADDSW = RF_CONST_S2025.RADDSW[idx1]
+    QSW = RF_CONST_S2025.QSW[idx1]
+    EXALB = RF_CONST_S2025.EXALB[idx1]
+    cDTAUCISW = RF_CONST_S2025.cDTAUCISW[idx1]
 
     sdr_h = sdr[idx0]
     rsr_h = rsr[idx0]
@@ -1243,6 +1243,7 @@ def contrail_contrail_overlap_radiative_effects(
     max_altitude_m: float = 13000.0,
     dz_overlap_m: float = 500.0,
     spatial_grid_res: float = 0.25,
+    rf_model_s2025: bool = False,
 ) -> GeoVectorDataset:
     r"""
     Calculate radiative properties after accounting for contrail overlapping.
@@ -1280,6 +1281,9 @@ def contrail_contrail_overlap_radiative_effects(
         See :attr:`CocipParams.dz_overlap_m`
     spatial_grid_res : float
         Spatial grid resolution, [:math:`\deg`]
+    rf_model_s2025 : bool
+        Use alternative parametric RF model (Schumann, 2025)
+        See :attr:`CocipParams.parametric_rf_model_s2025`
 
     Returns
     -------
@@ -1503,6 +1507,8 @@ def _local_sw_and_lw_rf_with_contrail_overlap(
     contrails_level: GeoVectorDataset,
     habit_distributions: npt.NDArray[np.floating],
     radius_threshold_um: npt.NDArray[np.floating],
+    *,
+    rf_model_s2025: bool = False
 ) -> GeoVectorDataset:
     """
     Calculate local contrail SW and LW RF after accounting for contrail overlapping.
@@ -1517,6 +1523,9 @@ def _local_sw_and_lw_rf_with_contrail_overlap(
     radius_threshold_um : npt.NDArray[np.floating]
         Radius thresholds for habit distributions.
         See :attr:`CocipParams.radius_threshold_um`
+    rf_model_s2025 : bool
+        Use alternative parametric RF model (Schumann, 2025)
+        See :attr:`CocipParams.parametric_rf_model_s2025`
 
     Returns
     -------
@@ -1534,24 +1543,46 @@ def _local_sw_and_lw_rf_with_contrail_overlap(
     tau_cirrus = contrails_level["tau_cirrus"] + contrails_level["tau_contrails_above"]
 
     # Calculate local SW and LW RF
-    contrails_level["rf_sw_overlap"] = shortwave_radiative_forcing(
-        r_vol_um,
-        contrails_level["sdr"],
-        contrails_level["rsr_overlap"],
-        sd0,
-        tau_contrail,
-        tau_cirrus,
-        habit_w,
-    )
+    if rf_model_s2025:
+        contrails_level["rf_sw_overlap"] = shortwave_radiative_forcing_s2025(
+            r_vol_um,
+            contrails_level["sdr"],
+            contrails_level["rsr_overlap"],
+            sd0,
+            tau_contrail,
+            tau_cirrus,
+            habit_w,
+        )
 
-    contrails_level["rf_lw_overlap"] = longwave_radiative_forcing(
-        r_vol_um,
-        contrails_level["olr_overlap"],
-        contrails_level["air_temperature"],
-        tau_contrail,
-        tau_cirrus,
-        habit_w,
-    )
+        contrails_level["rf_lw_overlap"] = longwave_radiative_forcing_s2025(
+            r_vol_um,
+            contrails_level["olr_overlap"],
+            contrails_level["air_temperature"],
+            tau_contrail,
+            tau_cirrus,
+            habit_w,
+        )
+
+    else:
+        contrails_level["rf_sw_overlap"] = shortwave_radiative_forcing(
+            r_vol_um,
+            contrails_level["sdr"],
+            contrails_level["rsr_overlap"],
+            sd0,
+            tau_contrail,
+            tau_cirrus,
+            habit_w,
+        )
+
+        contrails_level["rf_lw_overlap"] = longwave_radiative_forcing(
+            r_vol_um,
+            contrails_level["olr_overlap"],
+            contrails_level["air_temperature"],
+            tau_contrail,
+            tau_cirrus,
+            habit_w,
+        )
+
     contrails_level["rf_net_overlap"] = (
         contrails_level["rf_lw_overlap"] + contrails_level["rf_sw_overlap"]
     )

--- a/pycontrails/models/cocip/radiative_forcing.py
+++ b/pycontrails/models/cocip/radiative_forcing.py
@@ -147,117 +147,8 @@ class RFConstants:
     )
 
 
-@dataclasses.dataclass(frozen=True)
-class RFConstantsV2:
-    # TODO: Update docstring
-    """
-    Constants that are used to calculate the local contrail radiative forcing.
-
-    See Table 1 of :cite:`schumannParametricRadiativeForcing2012`.
-
-    Each coefficient has 8 elements, one corresponding to each contrail ice particle habit (shape)::
-
-        [
-            Sphere,
-            Solid column,
-            Hollow column,
-            Rough aggregate,
-            Rosette-6,
-            Plate,
-            Droxtal,
-            Myhre,
-        ]
-
-    For each waypoint, the distinct mix of ice particle habits are approximated using the mean
-    contrail ice particle radius (``r_vol_um``) relative to ``radius_threshold_um``.
-
-    For example:
-
-    - if ``r_vol_um`` for a waypoint < 5 um, the mix of ice particle habits will be 100% droxtals.
-    - if ``r_vol_um`` for a waypoint between 5 and 9.5 um, the mix of ice particle habits will
-      be 30% solid columns, 70% droxtals.
-
-    See Table 2 from :cite:`schumannEffectiveRadiusIce2011`.
-
-
-    References
-    ----------
-    - :cite:`schumannEffectiveRadiusIce2011`
-    - :cite:`schumannParametricRadiativeForcing2012`
-    """
-
-    # -----
-    # Variables/coefficients used to calculate the local contrail longwave radiative forcing.
-    # -----
-    AK = np.array([3.23595, 3.25723, 3.23853, 3.20214, 3.22151, 3.20444, 4.00515, 3.24338])
-
-    SIGMA = np.array(
-        [3.35993e-06, 3.00607e-06, 3.33420e-06, 4.09619e-06,
-         3.67116e-06, 4.02626e-06, 4.94882e-08,3.21650e-06]
-    )
-
-    DELTA = np.array(
-        [0.874430, 0.776886, 0.713890, 0.657861, 0.716007, 0.687059, 0.842696, 0.769347])
-
-    QLW = np.array([0.312496, 0.386529, 0.370883, 0.297256, 0.218414, 1.97702, 0.252445, 0.248097])
-
-    cDTAUCI = np.array(
-        [0.200662, 0.174288, 0.148988, 0.0944375, 0.197152, 0.146475, 0.235398, 0.135923]
-    )
-
-    tauexpLW = np.array(
-        [0.941626, 0.921358, 0.924119, 0.929786, 0.931181, 0.927095, 0.856405, 0.924699]
-    )
-
-    # -----
-    # Variables/coefficients used to calculate the local contrail shortwave radiative forcing.
-    # -----
-    # NOTE: `GAMMA` in Fortran -> `gamma_upper` in Python v1
-    GAMMA = np.array([9.06419, 5.45276, 6.61548, 5.49484, 6.66096, 7.96645, 6.15650, 6.69045])
-
-    # NOTE: `GAMMAS` in Fortran -> `gamma_lower` in Python v1
-    GAMMAS = np.array([40.5364, 16.8060, 22.3319, 16.9001, 25.5195, 7.61456, 9.75937, 9.33121])
-
-    # NOTE: `TT` in Fortran -> `t_a` in Python v1
-    TT = np.array([0.879304, 0.901417, 0.881617, 0.898850, 0.879667, 0.883407, 0.898837, 1.00788])
-
-    GALBS = np.array(
-        [0.432165, 0.874683, 0.647569, 0.897522, 0.712315, 0.720927, 0.815349, 0.932811]
-    )
-
-    ACTH = np.array(
-        [0.0129326, 0.0249145, 0.0190486, 0.0245007, 0.0201106, 0.0394534, 0.0325837, 0.0590863]
-    )
-
-    BCTH = np.array([1.41410, 1.37992, 1.56329, 1.40405, 1.38461, 1.58401, 1.34064, 1.45445])
-
-    CCTH = np.array(
-        [0.174603, 0.312233, 0.336866, 0.331776, 0.174517, 0.246677, 0.224502, 0.338728]
-    )
-
-    DCTH = np.array(
-        [0.838433, 0.680409, 0.665093, 0.625401, 0.795688, 0.500001, 0.452205, 0.807171]
-    )
-
-    # NOTE: `FRSW` in Fortran -> `F_r` in Python v1
-    FRSW = np.array([0.930169, 0.918669, 1.00763, 0.742713, 0.945019, 3.40950, 1.37480, 1.39646])
-
-    RADDSW = np.array([5.99100, 37.5521, 39.3959, 121.831, 20.5531, 16.8181, 156.619, 163.951])
-
-    QSW = np.array([1.90758, 3.15424, 3.15424, 1.63419, 2.70324, 1.66234, 1.88483, 1.88483])
-
-    EXALB = np.array(
-        [0.155310, 0.142510, 0.165978, 0.149808, 0.165641, 0.167064, 0.172320, 0.212536]
-    )
-
-    cDTAUCISW = np.array(
-        [0.224998, 0.195919, 0.242060, 0.206488, 0.238648, 0.261965, 0.245360, 0.300703]
-    )
-
-
 # create a new constants class to use within module
 RF_CONST = RFConstants()
-RF_CONST_V2 = RFConstantsV2()
 
 
 # ----------
@@ -553,9 +444,9 @@ def effective_radius_myhre(r_vol_um: npt.NDArray[np.floating]) -> npt.NDArray[np
     return np.minimum(r_vol_um, 45.0)
 
 
-# -----------------
-# Radiative Forcing
-# -----------------
+# ----------------------------------------------------------
+# Parametric radiative forcing model: Schumann et al. (2012)
+# ----------------------------------------------------------
 
 
 def longwave_radiative_forcing(
@@ -989,10 +880,111 @@ def effective_tau_cirrus(
     return np.exp(tau_cirrus * delta_sc_aps - tau_cirrus_eff * delta_sc)
 
 
-# -----------------------------
-# Parametric RF model (V2)
-# -----------------------------
-# TODO: Cite zenodo repository
+# ----------------------------------------------------------
+# Parametric radiative forcing model (V2): Schumann (2025)
+# ----------------------------------------------------------
+
+@dataclasses.dataclass(frozen=True)
+class RFConstantsV2:
+    """
+    Constants that are used to calculate the local contrail radiative forcing (V2).
+
+    Each coefficient has 8 elements, one corresponding to each contrail ice particle habit (shape)::
+
+        [
+            Sphere,
+            Solid column,
+            Hollow column,
+            Rough aggregate,
+            Rosette-6,
+            Plate,
+            Droxtal,
+            Myhre,
+        ]
+
+    For each waypoint, the distinct mix of ice particle habits are approximated using the mean
+    contrail ice particle radius (``r_vol_um``) relative to ``radius_threshold_um``.
+
+    For example:
+
+    - if ``r_vol_um`` for a waypoint < 5 um, the mix of ice particle habits will be 100% droxtals.
+    - if ``r_vol_um`` for a waypoint between 5 and 9.5 um, the mix of ice particle habits will
+      be 30% solid columns, 70% droxtals.
+
+    See Table 2 from :cite:`schumannEffectiveRadiusIce2011`.
+
+    References
+    ----------
+    - `mo_rf.f90` in Schumann (2025), https://doi.org/10.5281/zenodo.17581103
+    """
+
+    # -----
+    # Variables/coefficients used to calculate the local contrail longwave radiative forcing.
+    # -----
+    AK = np.array([3.23595, 3.25723, 3.23853, 3.20214, 3.22151, 3.20444, 4.00515, 3.24338])
+
+    SIGMA = np.array(
+        [3.35993e-06, 3.00607e-06, 3.33420e-06, 4.09619e-06,
+         3.67116e-06, 4.02626e-06, 4.94882e-08,3.21650e-06]
+    )
+
+    DELTA = np.array(
+        [0.874430, 0.776886, 0.713890, 0.657861, 0.716007, 0.687059, 0.842696, 0.769347])
+
+    QLW = np.array([0.312496, 0.386529, 0.370883, 0.297256, 0.218414, 1.97702, 0.252445, 0.248097])
+
+    cDTAUCI = np.array(
+        [0.200662, 0.174288, 0.148988, 0.0944375, 0.197152, 0.146475, 0.235398, 0.135923]
+    )
+
+    tauexpLW = np.array(
+        [0.941626, 0.921358, 0.924119, 0.929786, 0.931181, 0.927095, 0.856405, 0.924699]
+    )
+
+    # -----
+    # Variables/coefficients used to calculate the local contrail shortwave radiative forcing.
+    # -----
+    GAMMA = np.array([9.06419, 5.45276, 6.61548, 5.49484, 6.66096, 7.96645, 6.15650, 6.69045])
+
+    GAMMAS = np.array([40.5364, 16.8060, 22.3319, 16.9001, 25.5195, 7.61456, 9.75937, 9.33121])
+
+    TT = np.array([0.879304, 0.901417, 0.881617, 0.898850, 0.879667, 0.883407, 0.898837, 1.00788])
+
+    GALBS = np.array(
+        [0.432165, 0.874683, 0.647569, 0.897522, 0.712315, 0.720927, 0.815349, 0.932811]
+    )
+
+    ACTH = np.array(
+        [0.0129326, 0.0249145, 0.0190486, 0.0245007, 0.0201106, 0.0394534, 0.0325837, 0.0590863]
+    )
+
+    BCTH = np.array([1.41410, 1.37992, 1.56329, 1.40405, 1.38461, 1.58401, 1.34064, 1.45445])
+
+    CCTH = np.array(
+        [0.174603, 0.312233, 0.336866, 0.331776, 0.174517, 0.246677, 0.224502, 0.338728]
+    )
+
+    DCTH = np.array(
+        [0.838433, 0.680409, 0.665093, 0.625401, 0.795688, 0.500001, 0.452205, 0.807171]
+    )
+
+    FRSW = np.array([0.930169, 0.918669, 1.00763, 0.742713, 0.945019, 3.40950, 1.37480, 1.39646])
+
+    RADDSW = np.array([5.99100, 37.5521, 39.3959, 121.831, 20.5531, 16.8181, 156.619, 163.951])
+
+    QSW = np.array([1.90758, 3.15424, 3.15424, 1.63419, 2.70324, 1.66234, 1.88483, 1.88483])
+
+    EXALB = np.array(
+        [0.155310, 0.142510, 0.165978, 0.149808, 0.165641, 0.167064, 0.172320, 0.212536]
+    )
+
+    cDTAUCISW = np.array(
+        [0.224998, 0.195919, 0.242060, 0.206488, 0.238648, 0.261965, 0.245360, 0.300703]
+    )
+
+
+RF_CONST_V2 = RFConstantsV2()
+
 
 def longwave_radiative_forcing_v2(
     r_vol_um: npt.NDArray[np.floating],
@@ -1041,7 +1033,7 @@ def longwave_radiative_forcing_v2(
 
     References
     ----------
-    - :cite:`schumannParametricRadiativeForcing2012`
+    - `mo_rf.f90` in Schumann (2025), https://doi.org/10.5281/zenodo.17581103
     """
     # get list of habit weight indexs where the weights > 0
     # this is a tuple of (np.array[waypoint index], np.array[habit type index])
@@ -1142,7 +1134,7 @@ def shortwave_radiative_forcing_v2(
 
     References
     ----------
-    - :cite:`schumannParametricRadiativeForcing2012`
+    - `mo_rf.f90` in Schumann (2025), https://doi.org/10.5281/zenodo.17581103
     """
     # create mask for daytime (sdr > 0)
     day = sdr > 0.0

--- a/pycontrails/models/cocip/radiative_forcing.py
+++ b/pycontrails/models/cocip/radiative_forcing.py
@@ -884,6 +884,7 @@ def effective_tau_cirrus(
 # Parametric radiative forcing model: Schumann (2025)
 # ---------------------------------------------------
 
+
 @dataclasses.dataclass(frozen=True)
 class RFConstantsS2025:
     """
@@ -929,12 +930,21 @@ class RFConstantsS2025:
     ak = np.array([3.23595, 3.25723, 3.23853, 3.20214, 3.22151, 3.20444, 4.00515, 3.24338])
 
     sigma = np.array(
-        [3.35993e-06, 3.00607e-06, 3.33420e-06, 4.09619e-06,
-         3.67116e-06, 4.02626e-06, 4.94882e-08,3.21650e-06]
+        [
+            3.35993e-06,
+            3.00607e-06,
+            3.33420e-06,
+            4.09619e-06,
+            3.67116e-06,
+            4.02626e-06,
+            4.94882e-08,
+            3.21650e-06,
+        ]
     )
 
     delta = np.array(
-        [0.874430, 0.776886, 0.713890, 0.657861, 0.716007, 0.687059, 0.842696, 0.769347])
+        [0.874430, 0.776886, 0.713890, 0.657861, 0.716007, 0.687059, 0.842696, 0.769347]
+    )
 
     qlw = np.array([0.312496, 0.386529, 0.370883, 0.297256, 0.218414, 1.97702, 0.252445, 0.248097])
 
@@ -1078,7 +1088,7 @@ def longwave_radiative_forcing_s2025(
 
     # Longwave radiation calculations: Calculate the RF LW per habit type
     rf_lw_per_habit = (
-        (olr_h - sigma * (air_temperature_h ** ak))
+        (olr_h - sigma * (air_temperature_h**ak))
         * (1.0 - np.exp(-delta * np.exp(np.log(tau_contrail_h) * tau_exp_lw)))
         * (1.0 - np.exp(-qlw * r_eff_um_h))
         * np.exp(-c_dtauci * tau_cirrus_h)
@@ -1228,6 +1238,7 @@ def shortwave_radiative_forcing_s2025(
     rf_sw_weighted[idx0, idx1] = rf_sw_per_habit * habit_weights_[habit_weight_mask]
 
     return np.sum(rf_sw_weighted, axis=1)
+
 
 # -----------------------------
 # Contrail-contrail overlapping
@@ -1508,7 +1519,7 @@ def _local_sw_and_lw_rf_with_contrail_overlap(
     habit_distributions: npt.NDArray[np.floating],
     radius_threshold_um: npt.NDArray[np.floating],
     *,
-    rf_model_s2025: bool = False
+    rf_model_s2025: bool = False,
 ) -> GeoVectorDataset:
     """
     Calculate local contrail SW and LW RF after accounting for contrail overlapping.

--- a/pycontrails/models/cocip/radiative_forcing.py
+++ b/pycontrails/models/cocip/radiative_forcing.py
@@ -147,6 +147,114 @@ class RFConstants:
     )
 
 
+@dataclasses.dataclass(frozen=True)
+class RFConstantsV2:
+    # TODO: Update docstring
+    """
+    Constants that are used to calculate the local contrail radiative forcing.
+
+    See Table 1 of :cite:`schumannParametricRadiativeForcing2012`.
+
+    Each coefficient has 8 elements, one corresponding to each contrail ice particle habit (shape)::
+
+        [
+            Sphere,
+            Solid column,
+            Hollow column,
+            Rough aggregate,
+            Rosette-6,
+            Plate,
+            Droxtal,
+            Myhre,
+        ]
+
+    For each waypoint, the distinct mix of ice particle habits are approximated using the mean
+    contrail ice particle radius (``r_vol_um``) relative to ``radius_threshold_um``.
+
+    For example:
+
+    - if ``r_vol_um`` for a waypoint < 5 um, the mix of ice particle habits will be 100% droxtals.
+    - if ``r_vol_um`` for a waypoint between 5 and 9.5 um, the mix of ice particle habits will
+      be 30% solid columns, 70% droxtals.
+
+    See Table 2 from :cite:`schumannEffectiveRadiusIce2011`.
+
+
+    References
+    ----------
+    - :cite:`schumannEffectiveRadiusIce2011`
+    - :cite:`schumannParametricRadiativeForcing2012`
+    """
+
+    # -----
+    # Variables/coefficients used to calculate the local contrail longwave radiative forcing.
+    # -----
+    AK = np.array([3.23595, 3.25723, 3.23853, 3.20214, 3.22151, 3.20444, 4.00515, 3.24338])
+
+    SIGMA = np.array(
+        [3.35993e-06, 3.00607e-06, 3.33420e-06, 4.09619e-06,
+         3.67116e-06, 4.02626e-06, 4.94882e-08,3.21650e-06]
+    )
+
+    DELTA = np.array(
+        [0.874430, 0.776886, 0.713890, 0.657861, 0.716007, 0.687059, 0.842696, 0.769347])
+
+    QLW = np.array([0.312496, 0.386529, 0.370883, 0.297256, 0.218414, 1.97702, 0.252445, 0.248097])
+
+    cDTAUCI = np.array(
+        [0.200662, 0.174288, 0.148988, 0.0944375, 0.197152, 0.146475, 0.235398, 0.135923]
+    )
+
+    tauexpLW = np.array(
+        [0.941626, 0.921358, 0.924119, 0.929786, 0.931181, 0.927095, 0.856405, 0.924699]
+    )
+
+    # -----
+    # Variables/coefficients used to calculate the local contrail shortwave radiative forcing.
+    # -----
+    # NOTE: `GAMMA` in Fortran -> `gamma_upper` in Python v1
+    GAMMA = np.array([9.06419, 5.45276, 6.61548, 5.49484, 6.66096, 7.96645, 6.15650, 6.69045])
+
+    # NOTE: `GAMMAS` in Fortran -> `gamma_lower` in Python v1
+    GAMMAS = np.array([40.5364, 16.8060, 22.3319, 16.9001, 25.5195, 7.61456, 9.75937, 9.33121])
+
+    # NOTE: `TT` in Fortran -> `t_a` in Python v1
+    TT = np.array([0.879304, 0.901417, 0.881617, 0.898850, 0.879667, 0.883407, 0.898837, 1.00788])
+
+    GALBS = np.array(
+        [0.432165, 0.874683, 0.647569, 0.897522, 0.712315, 0.720927, 0.815349, 0.932811]
+    )
+
+    ACTH = np.array(
+        [0.0129326, 0.0249145, 0.0190486, 0.0245007, 0.0201106, 0.0394534, 0.0325837, 0.0590863]
+    )
+
+    BCTH = np.array([1.41410, 1.37992, 1.56329, 1.40405, 1.38461, 1.58401, 1.34064, 1.45445])
+
+    CCTH = np.array(
+        [0.174603, 0.312233, 0.336866, 0.331776, 0.174517, 0.246677, 0.224502, 0.338728]
+    )
+
+    DCTH = np.array(
+        [0.838433, 0.680409, 0.665093, 0.625401, 0.795688, 0.500001, 0.452205, 0.807171]
+    )
+
+    # NOTE: `FRSW` in Fortran -> `F_r` in Python v1
+    FRSW = np.array([0.930169, 0.918669, 1.00763, 0.742713, 0.945019, 3.40950, 1.37480, 1.39646])
+
+    RADDSW = np.array([5.99100, 37.5521, 39.3959, 121.831, 20.5531, 16.8181, 156.619, 163.951])
+
+    QSW = np.array([1.90758, 3.15424, 3.15424, 1.63419, 2.70324, 1.66234, 1.88483, 1.88483])
+
+    EXALB = np.array(
+        [0.155310, 0.142510, 0.165978, 0.149808, 0.165641, 0.167064, 0.172320, 0.212536]
+    )
+
+    cDTAUCISW = np.array(
+        [0.224998, 0.195919, 0.242060, 0.206488, 0.238648, 0.261965, 0.245360, 0.300703]
+    )
+
+
 # create a new constants class to use within module
 RF_CONST = RFConstants()
 

--- a/tests/unit/test_cocip_radiative_forcing.py
+++ b/tests/unit/test_cocip_radiative_forcing.py
@@ -4,14 +4,14 @@ import numpy as np
 import pytest
 
 from pycontrails.models.cocip import CocipParams, radiative_forcing
-from pycontrails.models.cocip.radiative_forcing import RF_CONST, RFConstants
+from pycontrails.models.cocip.radiative_forcing import RF_CONST_S2012, RFConstants
 from pycontrails.physics import geo
 
 
 def test_rf_const() -> None:
     """Test the RFConstant types."""
 
-    assert isinstance(RF_CONST, RFConstants)
+    assert isinstance(RF_CONST_S2012, RFConstants)
 
     # the indexes of the habit_weights should be the (radius_threshold x habits)
     # includes radius < rf_const.radius_threshold_um[0] as the 0th row index
@@ -194,7 +194,7 @@ def test_parametric_rf_model_v2():
         r_vol_um, olr, air_temperature, tau_contrail, tau_cirrus, habit_weights
     )
 
-    rf_lw_v2 = radiative_forcing.longwave_radiative_forcing_v2(
+    rf_lw_v2 = radiative_forcing.longwave_radiative_forcing_s2025(
         r_vol_um, olr, air_temperature, tau_contrail, tau_cirrus, habit_weights
     )
 
@@ -217,7 +217,7 @@ def test_parametric_rf_model_v2():
         r_vol_um, sdr, rsr, sd0, tau_contrail, tau_cirrus, habit_weights
     )
 
-    rf_sw_v2 = radiative_forcing.shortwave_radiative_forcing_v2(
+    rf_sw_v2 = radiative_forcing.shortwave_radiative_forcing_s2025(
         r_vol_um, sdr, rsr, sd0, tau_contrail, tau_cirrus, habit_weights
     )
 

--- a/tests/unit/test_cocip_radiative_forcing.py
+++ b/tests/unit/test_cocip_radiative_forcing.py
@@ -4,14 +4,14 @@ import numpy as np
 import pytest
 
 from pycontrails.models.cocip import CocipParams, radiative_forcing
-from pycontrails.models.cocip.radiative_forcing import RF_CONST_S2012, RFConstants
+from pycontrails.models.cocip.radiative_forcing import RF_CONST_S2012, RFConstantsS2012
 from pycontrails.physics import geo
 
 
 def test_rf_const() -> None:
     """Test the RFConstant types."""
 
-    assert isinstance(RF_CONST_S2012, RFConstants)
+    assert isinstance(RF_CONST_S2012, RFConstantsS2012)
 
     # the indexes of the habit_weights should be the (radius_threshold x habits)
     # includes radius < rf_const.radius_threshold_um[0] as the 0th row index
@@ -19,7 +19,7 @@ def test_rf_const() -> None:
     assert cp.habit_distributions.shape == (cp.radius_threshold_um.size + 1, cp.habits.size)
 
     # make sure habit specific attributes are the same length as the habits
-    for attr, val in RFConstants.__dict__.items():
+    for attr, val in RFConstantsS2012.__dict__.items():
         if not attr.startswith("_"):
             assert isinstance(val, np.ndarray)
             assert val.size == cp.habits.size

--- a/tests/unit/test_cocip_radiative_forcing.py
+++ b/tests/unit/test_cocip_radiative_forcing.py
@@ -168,3 +168,67 @@ def test_override_habit_distributions() -> None:
     habit_distributions[1, 2] = 0.3
     with pytest.raises(ValueError, match="number of rows in"):
         radiative_forcing.habit_weights(r_vol_um, habit_distributions, np.array([5, 10]))
+
+
+def test_parametric_rf_model_v2():
+    """Test behaviour of parametric RF model V1 and V2."""
+    cp = CocipParams()
+    habit_distributions = cp.habit_distributions.astype("float64")
+    radius_threshold_um = cp.radius_threshold_um.astype("float64")
+
+    tau_cirrus = np.linspace(0.0, 5.0, 11)
+    air_temperature = np.full(tau_cirrus.shape, 210.0)
+    r_vol_um = np.full(tau_cirrus.shape, 16.0)
+    tau_contrail = np.full(tau_cirrus.shape, 0.75)
+    sd0 = np.full(tau_cirrus.shape, 1365.0)
+    sdr = np.full(tau_cirrus.shape, 300.0)
+    rsr = np.full(tau_cirrus.shape, 180.0)
+    olr = np.full(tau_cirrus.shape, 130.0)
+
+    habit_weights = radiative_forcing.habit_weights(
+        r_vol_um, habit_distributions, radius_threshold_um
+    )
+
+    # Calculate longwave radiative forcing
+    rf_lw_v1 = radiative_forcing.longwave_radiative_forcing(
+        r_vol_um, olr, air_temperature, tau_contrail, tau_cirrus, habit_weights
+    )
+
+    rf_lw_v2 = radiative_forcing.longwave_radiative_forcing_v2(
+        r_vol_um, olr, air_temperature, tau_contrail, tau_cirrus, habit_weights
+    )
+
+    # Based on Figure 8 of Schumann et al. (2025), https://doi.org/10.5194/acp-25-18571-2025:
+    # (i) `rf_lw_v2` is approximately equal to `rf_lw_v1`, while
+    # (i) `rf_lw_v2` should be larger than `rf_lw_v1` when tau_cirrus is small, and
+    # (ii) `rf_lw_v2` should be smaller than `rf_lw_v1` when tau_cirrus is large
+    rf_lw_v1_actual = np.array(
+        [9.657, 9.260, 8.881, 8.519, 8.173, 7.843, 7.527, 7.225, 6.937, 6.661, 6.397]
+    )
+    rf_lw_v2_actual = np.array(
+        [10.555, 9.491, 8.536, 7.679, 6.909, 6.217, 5.595, 5.037, 4.535, 4.084, 3.678]
+    )
+
+    np.testing.assert_array_almost_equal(rf_lw_v1, rf_lw_v1_actual, decimal=3)
+    np.testing.assert_array_almost_equal(rf_lw_v2, rf_lw_v2_actual, decimal=3)
+
+    # Calculate shortwave radiative forcing
+    rf_sw_v1 = radiative_forcing.shortwave_radiative_forcing(
+        r_vol_um, sdr, rsr, sd0, tau_contrail, tau_cirrus, habit_weights
+    )
+
+    rf_sw_v2 = radiative_forcing.shortwave_radiative_forcing_v2(
+        r_vol_um, sdr, rsr, sd0, tau_contrail, tau_cirrus, habit_weights
+    )
+
+    # Based on Figure 8 of Schumann et al. (2025), https://doi.org/10.5194/acp-25-18571-2025:
+    # The change in `rf_sw` between V1 and V2 is smaller than `rf_lw`
+    rf_sw_v1_actual = np.array(
+        [-12.258, -9.496, -7.359, -5.706, -4.425, -3.434, -2.665, -2.070, -1.608, -1.250, -0.972]
+    )
+    rf_sw_v2_actual = np.array(
+        [-12.778, -9.934, -7.726, -6.011, -4.678, -3.642, -2.836, -2.210, -1.722, -1.343, -1.047]
+    )
+
+    np.testing.assert_array_almost_equal(rf_sw_v1, rf_sw_v1_actual, decimal=3)
+    np.testing.assert_array_almost_equal(rf_sw_v2, rf_sw_v2_actual, decimal=3)


### PR DESCRIPTION
Closes #XX

## Changes

- Experimental: Integrate alternative contrail parametric radiative forcing model (Schumann, 2025) into the CoCiP workflow: The original parametric RF model assumes a near-linear dependence of contrail RF on the contrail and natural cirrus optical depth and provides the best fit to the libRadtran dataset with the minimum number of model coefficients. This alternative model provides a stronger non-linear dependence to the contrail and natural cirrus optical depth, consistent with the ECMWF ecRad model, but yields a slightly weaker fit to the libRadtran dataset. 

The original

#### Breaking changes

#### Features

#### Fixes

#### Internals

## Tests

- [ ] QC test passes locally (`make test`)
- [ ] CI tests pass

## Reviewer

> Select @ reviewer
