### PR TITLE
Implement revised ice budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Features
+
+- Experimental: Implement a revised version of the CoCiP contrail ice budget that ensures contrails in air at 100% RHi conserve total ice mass. The revisions can be activated in `Cocip` and `CocipGrid` by setting the `revised_contrail_ice_budget` parameter to `True`. However, they are disabled by default and should be used with caution, as they lead to significant changes in the optical properties of aged contrails. The ice budget revisions and their impact on CoCiP simulations will be described in detail in a future publication.
+
 ### Internals
 
 - Update `CocipParams.particles_{lean,rich}_burn` ambient particle GSD from 2.3 to 2.2 for consistency with Teoh et al. (2026, in preparation).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Experimental: Implement a revised version of the CoCiP contrail ice budget that ensures contrails in air at 100% RHi conserve total ice mass. The revisions can be activated in `Cocip` and `CocipGrid` by setting the `revised_contrail_ice_budget` parameter to `True`. However, they are disabled by default and should be used with caution, as they lead to significant changes in the optical properties of aged contrails. The ice budget revisions and their impact on CoCiP simulations will be described in detail in a future publication.
+- Experimental: Implement a revised version of the CoCiP contrail ice budget, disabled by default and activated in `Cocip` and `CocipGrid` by setting the `revised_contrail_ice_budget` parameter to `True`. The revisions and their impact on CoCiP simulations will be described in detail in a future publication; in brief, the revised ice budget includes tendencies associated with sedimentation across an ambient humidity gradient and ensures that contrails conserve total ice when in air at 100% RHi. This feature should be used with caution, as it changes the optical properties of aged contrails and leads to significant increases in contrail radiative forcing.
 
 ### Internals
 

--- a/docs/_static/pycontrails.bib
+++ b/docs/_static/pycontrails.bib
@@ -295,6 +295,22 @@
   langid = {english}
 }
 
+@article{hallSurvivalIceParticles1976,
+  title = {The {{Survival}} of {{Ice Particles Falling}} from {{Cirrus Clouds}} in {{Subsaturated Air}}},
+  author = {Hall, W. D. and Pruppacher, H. R.},
+  year = 1976,
+  month = oct,
+  journal = {Journal of the Atmospheric Sciences},
+  volume = {33},
+  number = {10},
+  pages = {1995--2006},
+  issn = {0022-4928, 1520-0469},
+  doi = {10.1175/1520-0469(1976)033<1995:TSOIPF>2.0.CO;2},
+  url = {http://journals.ametsoc.org/doi/10.1175/1520-0469(1976)033<1995:TSOIPF>2.0.CO;2},
+  urldate = {2026-04-17},
+  langid = {english}
+}
+
 @article{holzapfelProbabilisticTwoPhaseWake2003,
   title = {Probabilistic {{Two-Phase Wake Vortex Decay}} and {{Transport Model}}},
   author = {Holz{\"a}pfel, Frank},
@@ -615,6 +631,22 @@
   urldate = {2025-05-20},
   abstract = {{$<$}p{$><$}strong class="journal-contentHeaderColor"{$>$}Abstract.{$<$}/strong{$>$} Global simulations suggest the mean annual contrail-cirrus net radiative forcing is comparable to that of aviation\&rsquo;s accumulated CO\textsubscript{2} emissions. However, these simulations assume non-volatile particulate matter (nvPM) and ambient particles are the only source of condensation nuclei, omitting activation of volatile particulate matter (vPM) formed in the nascent plume. Here, we extend a microphysical framework to include vPM and benchmark this against a parcel model (pyrcel) modified to treat contrail formation. We explore how the apparent emission index (EI) of contrail ice crystals (AEI\textsubscript{ice}) scales with EI\textsubscript{nvPM}, vPM properties, ambient temperature and aircraft/fuel characteristics. We find model agreement within 20 \% in the previously defined \&ldquo;soot-poor\&rdquo; regime. However, discrepancies increase non-linearly (up to 60 \%) in the \&ldquo;soot-rich\&rdquo; regime, due to differing treatment of droplet growth. Both models predict that in the \&ldquo;soot-poor\&rdquo; regime, AEI\textsubscript{ice} approaches 10\textsuperscript{16 }kg\textsuperscript{-1} for low ambient temperatures (\&lt; 210 K) and sulphur-rich vPM, which is comparable to estimates in the \&ldquo;soot-rich\&rdquo; regime. Moreover, our sensitivity analyses suggest that the point of transition between the \&ldquo;soot-poor\&rdquo; and \&ldquo;soot-rich\&rdquo; regimes is a dynamic threshold on EI\textsubscript{nvPM} that ranges from 10\textsuperscript{13 }kg\textsuperscript{-1} \&ndash; 10\textsuperscript{16 }kg\textsuperscript{-1} and depends sensitively on ambient temperature and vPM properties, underlining the need for vPM emission characterisation measurements. We suggest that existing contrail simulations omitting vPM activation may underestimate AEI\textsubscript{ice}, especially for flights powered by engines with very low EI\textsubscript{nvPM} (\&lt;10\textsuperscript{13 }kg\textsuperscript{-1}). Under these conditions, AEI\textsubscript{ice} might be reduced by reducing fuel sulphur content, minimising organic emissions and/or avoiding cooler regions of the atmosphere.{$<$}/p{$>$}},
   langid = {english}
+}
+
+@book{pruppacherMicrophysicsCloudsPrecipitation2010,
+  title = {Microphysics of {{Clouds}} and {{Precipitation}}},
+  author = {Pruppacher, H.R. and Klett, J.D.},
+  editor = {Mysak, Lawrence A. and Hamilton, Kevin},
+  year = 2010,
+  series = {Atmospheric and {{Oceanographic Sciences Library}}},
+  volume = {18},
+  publisher = {Springer Netherlands},
+  address = {Dordrecht},
+  doi = {10.1007/978-0-306-48100-0},
+  url = {http://link.springer.com/10.1007/978-0-306-48100-0},
+  urldate = {2026-04-17},
+  copyright = {http://www.springer.com/tdm},
+  isbn = {978-0-7923-4211-3 978-0-306-48100-0}
 }
 
 @article{reutterIceSupersaturatedRegions2020,

--- a/docs/develop.rst
+++ b/docs/develop.rst
@@ -242,8 +242,9 @@ To automatically sync the Zotero library with the
 
 - Install `Zotero <https://www.zotero.org/>`__ and add the `pycontrails library <https://www.zotero.org/groups/4730892/pycontrails/library>`__.
 - Install the `Zotero Better Bibtex extension <https://retorque.re/zotero-better-bibtex/installation/>`__. Leave defaults during setup.
+- In Better Bibtex settings, set "Add URLs to BibTeX export" to "in the 'url' field".
 - Right click on the **pycontrails** library and select *Export Library*
-- Export as *Better Bibtex*. You can optionally check *Keep Updated* if you want
+- Export as *Better BibTeX*. You can optionally check *Keep Updated* if you want
   this file to update every time you make a change to the library.
 - Select the file ``_static/pycontrails.bib`` and press *Save* to overwrite the file.
 - Commit the updated ``_static/pycontrails.bib``

--- a/pycontrails/models/cocip/cocip.py
+++ b/pycontrails/models/cocip/cocip.py
@@ -2536,10 +2536,12 @@ def calc_timestep_contrail_evolution(
     depth_1 = contrail_1["depth"]
 
     # get required met values for evolution calculations
+    q_sat_1 = contrail_1["q_sat"]
     rho_air_1 = contrail_1["rho_air"]
     u_wind_1 = contrail_1["u_wind"]
     v_wind_1 = contrail_1["v_wind"]
 
+    specific_humidity_1 = contrail_1["specific_humidity"]
     vertical_velocity_1 = contrail_1["vertical_velocity"]
     iwc_1 = contrail_1["iwc"]
 
@@ -2674,7 +2676,6 @@ def calc_timestep_contrail_evolution(
 
     # ... using revised ice budget ...
     if params["revised_contrail_ice_budget"]:
-        # compute mass, humidity, and saturation specific humidity after sedimentation
         level_sed = geo.advect_level(level_1, 0.0, rho_air_1, terminal_fall_speed_1, dt)
         contrail_sed = GeoVectorDataset._from_fastpath(
             {
@@ -2700,25 +2701,44 @@ def calc_timestep_contrail_evolution(
         air_pressure_sed = contrail_sed["air_pressure"]
         q_sat_sed = thermo.q_sat_ice(air_temperature_sed, air_pressure_sed)
         rho_air_sed = thermo.rho_d(air_temperature_sed, air_pressure_sed)
+
         area_eff_1 = contrail_1["area_eff"]
         plume_mass_per_m_sed = contrail_properties.plume_mass_per_distance(area_eff_1, rho_air_sed)
+        depth_eff_1 = contrail_properties.plume_effective_depth(width_1, area_eff_1)
+
+        n_ice_per_vol_1 = contrail_properties.ice_particle_number_per_volume_of_plume(
+            n_ice_per_m_1, area_eff_1
+        )
+        n_ice_per_kg_1 = contrail_properties.ice_particle_number_per_mass_of_air(
+            n_ice_per_vol_1, rho_air_1
+        )
+        r_vol_1 = contrail_properties.ice_particle_volume_mean_radius(iwc_1, n_ice_per_kg_1)
+        air_temperature_1 = contrail_1["air_temperature"]
+        air_pressure_1 = contrail_1["air_pressure"]
+        vapor_diffusivity_1 = thermo.diffusivity_water_vapor(air_temperature_1, air_pressure_1)
+        phase_relax_rate_1 = contrail_properties.phase_relaxation_rate(
+            r_vol_1, n_ice_per_vol_1, vapor_diffusivity_1
+        )
 
         iwc_2 = contrail_properties.new_ice_water_content_revised(
             iwc_1,
+            specific_humidity_1,
             specific_humidity_sed,
             specific_humidity_2,
+            q_sat_1,
             q_sat_sed,
             q_sat_2,
             plume_mass_per_m_1,
             plume_mass_per_m_sed,
             plume_mass_per_m_2,
+            depth_eff_1,
+            terminal_fall_speed_1,
+            phase_relax_rate_1,
+            dt,
         )
 
     # ... or original ice budget
     else:
-        q_sat_1 = contrail_1["q_sat"]
-        specific_humidity_1 = contrail_1["specific_humidity"]
-
         iwc_2 = contrail_properties.new_ice_water_content(
             iwc_1,
             specific_humidity_1,

--- a/pycontrails/models/cocip/cocip.py
+++ b/pycontrails/models/cocip/cocip.py
@@ -27,7 +27,6 @@ from pycontrails.core.models import Model, interpolate_met
 from pycontrails.core.vector import GeoVectorDataset, VectorDataDict
 from pycontrails.datalib import ecmwf, gfs
 from pycontrails.models import extended_k15, sac, tau_cirrus
-from pycontrails.models.extended_k15 import Particle, ParticleType
 from pycontrails.models.cocip import (
     contrail_properties,
     radiative_forcing,

--- a/pycontrails/models/cocip/cocip.py
+++ b/pycontrails/models/cocip/cocip.py
@@ -2676,6 +2676,7 @@ def calc_timestep_contrail_evolution(
 
     # ... using revised ice budget ...
     if params["revised_contrail_ice_budget"]:
+        # compute ambient specific humidity and saturation specific humidity after sedimentation
         level_sed = geo.advect_level(level_1, 0.0, rho_air_1, terminal_fall_speed_1, dt)
         contrail_sed = GeoVectorDataset._from_fastpath(
             {
@@ -2685,37 +2686,35 @@ def calc_timestep_contrail_evolution(
                 "level": level_sed,
             }
         )
-        air_temperature_sed = interpolate_met(met, contrail_sed, "air_temperature", **interp_kwargs)
-        specific_humidity_sed = interpolate_met(
-            met, contrail_sed, "specific_humidity", **interp_kwargs
-        )
+        interpolate_met(met, contrail_sed, "air_temperature", **interp_kwargs)
+        interpolate_met(met, contrail_sed, "specific_humidity", **interp_kwargs)
         if humidity_scaling is not None:
             humidity_scaling.eval(contrail_sed, copy_source=False)
         else:
             contrail_sed["air_pressure"] = contrail_sed.air_pressure
-            contrail_sed["rhi"] = thermo.rhi(
-                contrail_sed["specific_humidity"],
-                air_temperature_sed,
-                contrail_sed["air_pressure"],
-            )
-        air_pressure_sed = contrail_sed["air_pressure"]
-        q_sat_sed = thermo.q_sat_ice(air_temperature_sed, air_pressure_sed)
-        rho_air_sed = thermo.rho_d(air_temperature_sed, air_pressure_sed)
 
-        area_eff_1 = contrail_1["area_eff"]
-        plume_mass_per_m_sed = contrail_properties.plume_mass_per_distance(area_eff_1, rho_air_sed)
-        depth_eff_1 = contrail_properties.plume_effective_depth(width_1, area_eff_1)
+        specific_humidity_sed = contrail_sed["specific_humidity"]
+        q_sat_sed = thermo.q_sat_ice(contrail_sed["air_temperature"], contrail_sed["air_pressure"])
 
+        # compute plume mass after sedimentation
+        plume_mass_per_m_sed = contrail_properties.plume_mass_per_distance(
+            contrail_1["area_eff"],
+            thermo.rho_d(contrail_sed["air_temperature"], contrail_sed["air_pressure"]),
+        )
+
+        # compute plume depth and ice crystal phase relaxation rate
+        # used to limit deposition/subplimation in a shallow but rapidly-sedimenting plume
+        depth_eff_1 = contrail_properties.plume_effective_depth(width_1, contrail_1["area_eff"])
         n_ice_per_vol_1 = contrail_properties.ice_particle_number_per_volume_of_plume(
-            n_ice_per_m_1, area_eff_1
+            n_ice_per_m_1, contrail_1["area_eff"]
         )
         n_ice_per_kg_1 = contrail_properties.ice_particle_number_per_mass_of_air(
             n_ice_per_vol_1, rho_air_1
         )
         r_vol_1 = contrail_properties.ice_particle_volume_mean_radius(iwc_1, n_ice_per_kg_1)
-        air_temperature_1 = contrail_1["air_temperature"]
-        air_pressure_1 = contrail_1["air_pressure"]
-        vapor_diffusivity_1 = thermo.diffusivity_water_vapor(air_temperature_1, air_pressure_1)
+        vapor_diffusivity_1 = thermo.diffusivity_water_vapor(
+            contrail_1["air_temperature"], contrail_1["air_pressure"]
+        )
         phase_relax_rate_1 = contrail_properties.phase_relaxation_rate(
             r_vol_1, n_ice_per_vol_1, vapor_diffusivity_1
         )

--- a/pycontrails/models/cocip/cocip.py
+++ b/pycontrails/models/cocip/cocip.py
@@ -2536,16 +2536,15 @@ def calc_timestep_contrail_evolution(
     depth_1 = contrail_1["depth"]
 
     # get required met values for evolution calculations
-    q_sat_1 = contrail_1["q_sat"]
     rho_air_1 = contrail_1["rho_air"]
     u_wind_1 = contrail_1["u_wind"]
     v_wind_1 = contrail_1["v_wind"]
 
-    specific_humidity_1 = contrail_1["specific_humidity"]
     vertical_velocity_1 = contrail_1["vertical_velocity"]
     iwc_1 = contrail_1["iwc"]
 
     # get required contrail_1 properties
+    area_eff_1 = contrail_1["area_eff"]
     sigma_yz_1 = contrail_1["sigma_yz"]
     dsn_dz_1 = contrail_1["dsn_dz"]
     terminal_fall_speed_1 = contrail_1["terminal_fall_speed"]
@@ -2668,39 +2667,32 @@ def calc_timestep_contrail_evolution(
     contrail_2["rho_air"] = rho_air_2
     contrail_2["q_sat"] = q_sat_2
 
-    # compute change in q_sat due to sedimentation
-    level_2_nosed = geo.advect_level(level_1, vertical_velocity_1, rho_air_1, 0.0, dt)
-    contrail_2_nosed = GeoVectorDataset(
+    # compute mass, humidity, and saturation specific humidity after sedimentation
+    level_sed = geo.advect_level(level_1, 0.0, rho_air_1, terminal_fall_speed_1, dt)
+    contrail_sed = GeoVectorDataset(
         {
-            "time": time_2_array,
-            "longitude": longitude_2,
-            "latitude": latitude_2,
-            "level": level_2_nosed,
+            "time": time_1,
+            "longitude": longitude_1,
+            "latitude": latitude_1,
+            "level": level_sed,
         },
         copy=False,
     )
-
-    air_temperature_2_nosed = interpolate_met(
-        met, contrail_2_nosed, "air_temperature", **interp_kwargs
-    )
-    if params["radiative_heating_effects"]:
-        air_temperature_2_nosed += contrail_2["cumul_heat"]
-
-    interpolate_met(met, contrail_2_nosed, "specific_humidity", **interp_kwargs)
-    humidity_scaling = params["humidity_scaling"]
+    air_temperature_sed = interpolate_met(met, contrail_sed, "air_temperature", **interp_kwargs)
+    specific_humidity_sed = interpolate_met(met, contrail_sed, "specific_humidity", **interp_kwargs)
     if humidity_scaling is not None:
-        humidity_scaling.eval(contrail_2_nosed, copy_source=False)
+        humidity_scaling.eval(contrail_sed, copy_source=False)
     else:
-        contrail_2_nosed["air_pressure"] = contrail_2_nosed.air_pressure
-        contrail_2_nosed["rhi"] = thermo.rhi(
-            contrail_2_nosed["specific_humidity"],
-            air_temperature_2_nosed,
-            contrail_2_nosed["air_pressure"],
+        contrail_sed["air_pressure"] = contrail_sed.air_pressure
+        contrail_sed["rhi"] = thermo.rhi(
+            contrail_sed["specific_humidity"],
+            air_temperature_sed,
+            contrail_sed["air_pressure"],
         )
-
-    air_pressure_2_nosed = contrail_2_nosed["air_pressure"]
-    q_sat_2_nosed = thermo.q_sat_ice(air_temperature_2_nosed, air_pressure_2_nosed)
-    q_sat_2_sed = q_sat_1 + q_sat_2 - q_sat_2_nosed
+    air_pressure_sed = contrail_sed["air_pressure"]
+    q_sat_sed = thermo.q_sat_ice(air_temperature_sed, air_pressure_sed)
+    rho_air_sed = thermo.rho_d(air_temperature_sed, air_pressure_sed)
+    plume_mass_per_m_sed = contrail_properties.plume_mass_per_distance(area_eff_1, rho_air_sed)
 
     # New contrail ice particle mass and number
     area_eff_2 = contrail_properties.new_effective_area_from_sigma(
@@ -2709,12 +2701,12 @@ def calc_timestep_contrail_evolution(
     plume_mass_per_m_2 = contrail_properties.plume_mass_per_distance(area_eff_2, rho_air_2)
     iwc_2 = contrail_properties.new_ice_water_content(
         iwc_1,
-        specific_humidity_1,
+        specific_humidity_sed,
         specific_humidity_2,
-        q_sat_1,
+        q_sat_sed,
         q_sat_2,
-        q_sat_2_sed,
         plume_mass_per_m_1,
+        plume_mass_per_m_sed,
         plume_mass_per_m_2,
     )
     n_ice_per_m_2 = contrail_properties.new_ice_particle_number(

--- a/pycontrails/models/cocip/cocip.py
+++ b/pycontrails/models/cocip/cocip.py
@@ -978,7 +978,7 @@ class Cocip(Model):
         if self.params["vpm_activation"]:
             is_lean_burn = nvpm_ei_n < 1.0e12
 
-            aei = np.empty_like(nvpm_ei_n)
+            aei = np.full_like(nvpm_ei_n, np.nan, dtype=float)
 
             # Rich-burn engines
             aei[~is_lean_burn] = extended_k15.droplet_apparent_emission_index(

--- a/pycontrails/models/cocip/cocip.py
+++ b/pycontrails/models/cocip/cocip.py
@@ -2544,7 +2544,6 @@ def calc_timestep_contrail_evolution(
     iwc_1 = contrail_1["iwc"]
 
     # get required contrail_1 properties
-    area_eff_1 = contrail_1["area_eff"]
     sigma_yz_1 = contrail_1["sigma_yz"]
     dsn_dz_1 = contrail_1["dsn_dz"]
     terminal_fall_speed_1 = contrail_1["terminal_fall_speed"]
@@ -2667,48 +2666,70 @@ def calc_timestep_contrail_evolution(
     contrail_2["rho_air"] = rho_air_2
     contrail_2["q_sat"] = q_sat_2
 
-    # compute mass, humidity, and saturation specific humidity after sedimentation
-    level_sed = geo.advect_level(level_1, 0.0, rho_air_1, terminal_fall_speed_1, dt)
-    contrail_sed = GeoVectorDataset(
-        {
-            "time": time_1,
-            "longitude": longitude_1,
-            "latitude": latitude_1,
-            "level": level_sed,
-        },
-        copy=False,
-    )
-    air_temperature_sed = interpolate_met(met, contrail_sed, "air_temperature", **interp_kwargs)
-    specific_humidity_sed = interpolate_met(met, contrail_sed, "specific_humidity", **interp_kwargs)
-    if humidity_scaling is not None:
-        humidity_scaling.eval(contrail_sed, copy_source=False)
-    else:
-        contrail_sed["air_pressure"] = contrail_sed.air_pressure
-        contrail_sed["rhi"] = thermo.rhi(
-            contrail_sed["specific_humidity"],
-            air_temperature_sed,
-            contrail_sed["air_pressure"],
-        )
-    air_pressure_sed = contrail_sed["air_pressure"]
-    q_sat_sed = thermo.q_sat_ice(air_temperature_sed, air_pressure_sed)
-    rho_air_sed = thermo.rho_d(air_temperature_sed, air_pressure_sed)
-    plume_mass_per_m_sed = contrail_properties.plume_mass_per_distance(area_eff_1, rho_air_sed)
-
-    # New contrail ice particle mass and number
+    # calculate new contrail ice particle mass ...
     area_eff_2 = contrail_properties.new_effective_area_from_sigma(
         sigma_yy_2, sigma_zz_2, sigma_yz_2
     )
     plume_mass_per_m_2 = contrail_properties.plume_mass_per_distance(area_eff_2, rho_air_2)
-    iwc_2 = contrail_properties.new_ice_water_content(
-        iwc_1,
-        specific_humidity_sed,
-        specific_humidity_2,
-        q_sat_sed,
-        q_sat_2,
-        plume_mass_per_m_1,
-        plume_mass_per_m_sed,
-        plume_mass_per_m_2,
-    )
+
+    # ... using revised ice budget ...
+    if params["revised_contrail_ice_budget"]:
+        # compute mass, humidity, and saturation specific humidity after sedimentation
+        level_sed = geo.advect_level(level_1, 0.0, rho_air_1, terminal_fall_speed_1, dt)
+        contrail_sed = GeoVectorDataset._from_fastpath(
+            {
+                "time": time_1,
+                "longitude": longitude_1,
+                "latitude": latitude_1,
+                "level": level_sed,
+            }
+        )
+        air_temperature_sed = interpolate_met(met, contrail_sed, "air_temperature", **interp_kwargs)
+        specific_humidity_sed = interpolate_met(
+            met, contrail_sed, "specific_humidity", **interp_kwargs
+        )
+        if humidity_scaling is not None:
+            humidity_scaling.eval(contrail_sed, copy_source=False)
+        else:
+            contrail_sed["air_pressure"] = contrail_sed.air_pressure
+            contrail_sed["rhi"] = thermo.rhi(
+                contrail_sed["specific_humidity"],
+                air_temperature_sed,
+                contrail_sed["air_pressure"],
+            )
+        air_pressure_sed = contrail_sed["air_pressure"]
+        q_sat_sed = thermo.q_sat_ice(air_temperature_sed, air_pressure_sed)
+        rho_air_sed = thermo.rho_d(air_temperature_sed, air_pressure_sed)
+        area_eff_1 = contrail_1["area_eff"]
+        plume_mass_per_m_sed = contrail_properties.plume_mass_per_distance(area_eff_1, rho_air_sed)
+
+        iwc_2 = contrail_properties.new_ice_water_content_revised(
+            iwc_1,
+            specific_humidity_sed,
+            specific_humidity_2,
+            q_sat_sed,
+            q_sat_2,
+            plume_mass_per_m_1,
+            plume_mass_per_m_sed,
+            plume_mass_per_m_2,
+        )
+
+    # ... or original ice budget
+    else:
+        q_sat_1 = contrail_1["q_sat"]
+        specific_humidity_1 = contrail_1["specific_humidity"]
+
+        iwc_2 = contrail_properties.new_ice_water_content(
+            iwc_1,
+            specific_humidity_1,
+            specific_humidity_2,
+            q_sat_1,
+            q_sat_2,
+            plume_mass_per_m_1,
+            plume_mass_per_m_2,
+        )
+
+    # calculate new contrail ice particle number
     n_ice_per_m_2 = contrail_properties.new_ice_particle_number(
         n_ice_per_m_1, dn_dt_agg_1, dn_dt_turb_1, seg_ratio_2, dt
     )

--- a/pycontrails/models/cocip/cocip.py
+++ b/pycontrails/models/cocip/cocip.py
@@ -2668,6 +2668,40 @@ def calc_timestep_contrail_evolution(
     contrail_2["rho_air"] = rho_air_2
     contrail_2["q_sat"] = q_sat_2
 
+    # compute change in q_sat due to sedimentation
+    level_2_nosed = geo.advect_level(level_1, vertical_velocity_1, rho_air_1, 0.0, dt)
+    contrail_2_nosed = GeoVectorDataset(
+        {
+            "time": time_2_array,
+            "longitude": longitude_2,
+            "latitude": latitude_2,
+            "level": level_2_nosed,
+        },
+        copy=False,
+    )
+
+    air_temperature_2_nosed = interpolate_met(
+        met, contrail_2_nosed, "air_temperature", **interp_kwargs
+    )
+    if params["radiative_heating_effects"]:
+        air_temperature_2_nosed += contrail_2["cumul_heat"]
+
+    interpolate_met(met, contrail_2_nosed, "specific_humidity", **interp_kwargs)
+    humidity_scaling = params["humidity_scaling"]
+    if humidity_scaling is not None:
+        humidity_scaling.eval(contrail_2_nosed, copy_source=False)
+    else:
+        contrail_2_nosed["air_pressure"] = contrail_2_nosed.air_pressure
+        contrail_2_nosed["rhi"] = thermo.rhi(
+            contrail_2_nosed["specific_humidity"],
+            air_temperature_2_nosed,
+            contrail_2_nosed["air_pressure"],
+        )
+
+    air_pressure_2_nosed = contrail_2_nosed["air_pressure"]
+    q_sat_2_nosed = thermo.q_sat_ice(air_temperature_2_nosed, air_pressure_2_nosed)
+    q_sat_2_sed = q_sat_1 + q_sat_2 - q_sat_2_nosed
+
     # New contrail ice particle mass and number
     area_eff_2 = contrail_properties.new_effective_area_from_sigma(
         sigma_yy_2, sigma_zz_2, sigma_yz_2
@@ -2679,6 +2713,7 @@ def calc_timestep_contrail_evolution(
         specific_humidity_2,
         q_sat_1,
         q_sat_2,
+        q_sat_2_sed,
         plume_mass_per_m_1,
         plume_mass_per_m_2,
     )

--- a/pycontrails/models/cocip/cocip.py
+++ b/pycontrails/models/cocip/cocip.py
@@ -978,7 +978,7 @@ class Cocip(Model):
         if self.params["vpm_activation"]:
             is_lean_burn = nvpm_ei_n < 1.0e12
 
-            aei = np.full_like(nvpm_ei_n, np.nan, dtype=float)
+            aei = np.empty_like(nvpm_ei_n)
 
             # Rich-burn engines
             aei[~is_lean_burn] = extended_k15.droplet_apparent_emission_index(

--- a/pycontrails/models/cocip/cocip.py
+++ b/pycontrails/models/cocip/cocip.py
@@ -27,6 +27,7 @@ from pycontrails.core.models import Model, interpolate_met
 from pycontrails.core.vector import GeoVectorDataset, VectorDataDict
 from pycontrails.datalib import ecmwf, gfs
 from pycontrails.models import extended_k15, sac, tau_cirrus
+from pycontrails.models.extended_k15 import Particle, ParticleType
 from pycontrails.models.cocip import (
     contrail_properties,
     radiative_forcing,

--- a/pycontrails/models/cocip/cocip_params.py
+++ b/pycontrails/models/cocip/cocip_params.py
@@ -16,6 +16,7 @@ from pycontrails.models.emissions import Emissions
 from pycontrails.models.emissions.emissions import EmissionsParams
 from pycontrails.models.extended_k15 import Particle, ParticleType
 from pycontrails.models.humidity_scaling import HumidityScaling
+from pycontrails.models.extended_k15 import Particle, ParticleType
 
 
 def _radius_threshold_um() -> npt.NDArray[np.float32]:

--- a/pycontrails/models/cocip/cocip_params.py
+++ b/pycontrails/models/cocip/cocip_params.py
@@ -16,7 +16,6 @@ from pycontrails.models.emissions import Emissions
 from pycontrails.models.emissions.emissions import EmissionsParams
 from pycontrails.models.extended_k15 import Particle, ParticleType
 from pycontrails.models.humidity_scaling import HumidityScaling
-from pycontrails.models.extended_k15 import Particle, ParticleType
 
 
 def _radius_threshold_um() -> npt.NDArray[np.float32]:

--- a/pycontrails/models/cocip/cocip_params.py
+++ b/pycontrails/models/cocip/cocip_params.py
@@ -338,6 +338,8 @@ class CocipParams(AdvectionBuffers):
     #: ambient humidity gradient and ensures that contrails conserve total ice when in air at 100%
     #: RHi. This feature should be activated with caution, as it changes the optical properties of
     #: aged contrails and lead to significant increases in contrail radiative forcing.
+    #:
+    #:  .. versionadded:: 0.62.0
     revised_contrail_ice_budget: bool = False
 
     # ---------------------------------------

--- a/pycontrails/models/cocip/cocip_params.py
+++ b/pycontrails/models/cocip/cocip_params.py
@@ -334,8 +334,10 @@ class CocipParams(AdvectionBuffers):
     rf_lw_enhancement_factor: float = 1.0
 
     #: Experimental: use revised contrail ice budget (to be described in a forthcoming paper).
-    #: The revised ice budget includes tendencies associated with sedimentation across an
-    #: ambient humidity gradient.
+    #: In brief, the revised ice budget includes tendencies associated with sedimentation across an
+    #: ambient humidity gradient and ensures that contrails conserve total ice when in air at 100%
+    #: RHi. This feature should be activated with caution, as it changes the optical properties of
+    #: aged contrails and lead to significant increases in contrail radiative forcing.
     revised_contrail_ice_budget: bool = False
 
     # ---------------------------------------

--- a/pycontrails/models/cocip/cocip_params.py
+++ b/pycontrails/models/cocip/cocip_params.py
@@ -333,6 +333,11 @@ class CocipParams(AdvectionBuffers):
     #: Primarily used to support uncertainty estimation.
     rf_lw_enhancement_factor: float = 1.0
 
+    #: Experimental: use revised contrail ice budget (to be described in a forthcoming paper).
+    #: The revised ice budget includes tendencies associated with sedimentation across an
+    #: ambient humidity gradient.
+    revised_contrail_ice_budget: bool = False
+
     # ---------------------------------------
     # Conditions for end of contrail lifetime
     # ---------------------------------------

--- a/pycontrails/models/cocip/contrail_properties.py
+++ b/pycontrails/models/cocip/contrail_properties.py
@@ -1542,7 +1542,8 @@ def new_ice_water_content_revised(
     )
 
     # change from mixing
-    delta_mass_h2o_mix = mass_plume_t2 * q_t2 - mass_plume_sed * q_sed
+    qa = 0.5 * (q_sed + q_t2)
+    delta_mass_h2o_mix = (mass_plume_t2 - mass_plume_sed) * qa
 
     # updated ice water content
     mass_h2o_t2 = (

--- a/pycontrails/models/cocip/contrail_properties.py
+++ b/pycontrails/models/cocip/contrail_properties.py
@@ -1515,17 +1515,12 @@ def new_ice_water_content_revised(
     npt.NDArray[np.floating]
         Contrail ice water content at the end of the time step, [:math:`kg_{ice} kg_{air}^{-1}`]
 
-    Notes (TODO: update)
+    Notes
     -----
-    (1) The ice water content is fully conservative.
-    (2) ``mass_h2o_t2``: the total H2O mass (ice + vapour) per unit of
-        contrail plume [Units of kg-H2O/m]
-    (3) ``q_sat`` is used to calculate mass_h2o because air inside the
-        contrail is assumed to be ice saturated.
-    (4) ``(mass_plume_t2 - mass_plume) * q_mean``: contrail absorbs
-        (releases) H2O from (to) surrounding air.
-    (5) ``iwc_t2 = mass_h2o_t2 / mass_plume_t2 - q_sat_t2``: H2O in the
-        gas phase is removed (``- q_sat_t2``).
+    (1) Differences between this function and :func:`new_ice_water_content` will be described
+    in a future publication. The documentation for this function will be updated when the
+    publication is available.
+
     """
     # change from falling through sub/supersaturated air
     dt_s = units.dt_to_seconds(dt, iwc_t1.dtype)

--- a/pycontrails/models/cocip/contrail_properties.py
+++ b/pycontrails/models/cocip/contrail_properties.py
@@ -1351,6 +1351,7 @@ def new_ice_water_content(
     q_t2: npt.NDArray[np.floating],
     q_sat_t1: npt.NDArray[np.floating],
     q_sat_t2: npt.NDArray[np.floating],
+    q_sat_t2_sed: npt.NDArray[np.floating],
     mass_plume_t1: npt.NDArray[np.floating],
     mass_plume_t2: npt.NDArray[np.floating],
 ) -> npt.NDArray[np.floating]:
@@ -1398,9 +1399,13 @@ def new_ice_water_content(
     (5) ``iwc_t2 = mass_h2o_t2 / mass_plume_t2 - q_sat_t2``: H2O in the
         gas phase is removed (``- q_sat_t2``).
     """
-    q_mean = 0.5 * (q_t1 + q_t2)
+    q_mean = 0.5 * (q_t1 + q_t2 - (q_sat_t1 + q_sat_t2_sed))
     mass_h2o_t1 = mass_plume_t1 * (iwc_t1 + q_sat_t1)
-    mass_h2o_t2 = mass_h2o_t1 + (mass_plume_t2 - mass_plume_t1) * q_mean
+    mass_h2o_t2 = (
+        mass_h2o_t1
+        + (mass_plume_t2 - mass_plume_t1) * q_mean
+        + (mass_plume_t2 * q_sat_t2_sed - mass_plume_t1 * q_sat_t1)
+    )
     iwc_t2 = (mass_h2o_t2 / mass_plume_t2) - q_sat_t2
     iwc_t2.clip(min=0.0, out=iwc_t2)
     return iwc_t2

--- a/pycontrails/models/cocip/contrail_properties.py
+++ b/pycontrails/models/cocip/contrail_properties.py
@@ -1347,6 +1347,67 @@ def new_effective_area_from_sigma(
 
 def new_ice_water_content(
     iwc_t1: npt.NDArray[np.floating],
+    q_t1: npt.NDArray[np.floating],
+    q_t2: npt.NDArray[np.floating],
+    q_sat_t1: npt.NDArray[np.floating],
+    q_sat_t2: npt.NDArray[np.floating],
+    mass_plume_t1: npt.NDArray[np.floating],
+    mass_plume_t2: npt.NDArray[np.floating],
+) -> npt.NDArray[np.floating]:
+    """
+    Calculate the new contrail ice water content after the time integration step (``iwc_t2``).
+
+    Parameters
+    ----------
+    iwc_t1 : npt.NDArray[np.floating]
+        contrail ice water content, i.e., contrail ice mass per kg of air,
+        at the start of the time step, [:math:`kg_{H_{2}O}/kg_{air}`]
+    q_t1 : npt.NDArray[np.floating]
+        specific humidity for each waypoint at the start of the
+        time step, [:math:`kg_{H_{2}O}/kg_{air}`]
+    q_t2 : npt.NDArray[np.floating]
+        specific humidity for each waypoint at the end of the
+        time step, [:math:`kg_{H_{2}O}/kg_{air}`]
+    q_sat_t1 : npt.NDArray[np.floating]
+        saturation humidity for each waypoint at the start of the
+        time step, [:math:`kg_{H_{2}O}/kg_{air}`]
+    q_sat_t2 : npt.NDArray[np.floating]
+        saturation humidity for each waypoint at the end of the
+        time step, [:math:`kg_{H_{2}O}/kg_{air}`]
+    mass_plume_t1 : npt.NDArray[np.floating]
+        contrail plume mass per unit length at the start of the
+        time step, [:math:`kg_{air} m^{-1}`]
+    mass_plume_t2 : npt.NDArray[np.floating]
+        contrail plume mass per unit length at the end of the
+        time step, [:math:`kg_{air} m^{-1}`]
+
+    Returns
+    -------
+    npt.NDArray[np.floating]
+        Contrail ice water content at the end of the time step, [:math:`kg_{ice} kg_{air}^{-1}`]
+
+    Notes
+    -----
+    (1) The ice water content is fully conservative.
+    (2) ``mass_h2o_t2``: the total H2O mass (ice + vapour) per unit of
+        contrail plume [Units of kg-H2O/m]
+    (3) ``q_sat`` is used to calculate mass_h2o because air inside the
+        contrail is assumed to be ice saturated.
+    (4) ``(mass_plume_t2 - mass_plume) * q_mean``: contrail absorbs
+        (releases) H2O from (to) surrounding air.
+    (5) ``iwc_t2 = mass_h2o_t2 / mass_plume_t2 - q_sat_t2``: H2O in the
+        gas phase is removed (``- q_sat_t2``).
+    """
+    q_mean = 0.5 * (q_t1 + q_t2)
+    mass_h2o_t1 = mass_plume_t1 * (iwc_t1 + q_sat_t1)
+    mass_h2o_t2 = mass_h2o_t1 + (mass_plume_t2 - mass_plume_t1) * q_mean
+    iwc_t2 = (mass_h2o_t2 / mass_plume_t2) - q_sat_t2
+    iwc_t2.clip(min=0.0, out=iwc_t2)
+    return iwc_t2
+
+
+def new_ice_water_content_revised(
+    iwc_t1: npt.NDArray[np.floating],
     q_sed: npt.NDArray[np.floating],
     q_t2: npt.NDArray[np.floating],
     q_sat_sed: npt.NDArray[np.floating],

--- a/pycontrails/models/cocip/contrail_properties.py
+++ b/pycontrails/models/cocip/contrail_properties.py
@@ -835,6 +835,50 @@ def ice_particle_mass(r_ice_vol: npt.NDArray[np.floating]) -> npt.NDArray[np.flo
     return ((4 / 3) * np.pi * r_ice_vol**3) * constants.rho_ice
 
 
+def phase_relaxation_rate(
+    r_ice_vol: npt.NDArray[np.floating],
+    n_ice_per_vol: npt.NDArray[np.floating],
+    diffusivity_water_vapor: npt.NDArray[np.floating],
+) -> npt.NDArray[np.floating]:
+    """
+    Calculate the contrail phase relaxation rate.
+
+    The phase relaxation rate is the inverse of the time scale over which specific humidity inside
+    a contrail relaxes toward saturation due to sublimation or deposition.
+
+    Parameters
+    ----------
+    r_ice_vol : npt.NDArray[np.floating]
+        Ice particle volume mean radius, [:math:`m`]
+
+    n_ice_per_vol: npt.NDArray[np.floating]
+        Number of ice particles per contrail plume volume, [:math:`m^3`]
+
+    diffusivity_water_vapor: npt.NDArray[np.floating]
+        Molecular diffusivity of water vapor, [:math:`m^2 s^{-1}`]
+
+    Returns
+    -------
+    npt.NDArray[np.floating]
+        Phase relaxation rate, [:math:`s^{-1}`]
+
+    References
+    ----------
+    - :cite:`hallPrupaccherSurvivalIceParticles1976`
+    - :cite:`prupaccherKlettMicrophysicsCloudsPrecipitation2010`
+
+    Notes
+    -----
+    The phase relaxation time scale provided by this function is based on a model
+    for diffusional growth of spherical ice crystals.
+
+    See Also
+    --------
+    :func:`thermo.diffusivity_water_vapor`
+    """
+    return 4.0 * np.pi * r_ice_vol * n_ice_per_vol * diffusivity_water_vapor
+
+
 def horizontal_diffusivity(
     ds_dz: npt.NDArray[np.floating],
     depth: npt.NDArray[np.floating],
@@ -1408,13 +1452,19 @@ def new_ice_water_content(
 
 def new_ice_water_content_revised(
     iwc_t1: npt.NDArray[np.floating],
+    q_t1: npt.NDArray[np.floating],
     q_sed: npt.NDArray[np.floating],
     q_t2: npt.NDArray[np.floating],
+    q_sat_t1: npt.NDArray[np.floating],
     q_sat_sed: npt.NDArray[np.floating],
     q_sat_t2: npt.NDArray[np.floating],
     mass_plume_t1: npt.NDArray[np.floating],
     mass_plume_sed: npt.NDArray[np.floating],
     mass_plume_t2: npt.NDArray[np.floating],
+    depth_eff: npt.NDArray[np.floating],
+    terminal_fall_speed: npt.NDArray[np.floating],
+    phase_relax_rate: npt.NDArray[np.floating],
+    dt: npt.NDArray[np.timedelta64],
 ) -> npt.NDArray[np.floating]:
     """
     Calculate the new contrail ice water content after the time integration step (``iwc_t2``).
@@ -1451,6 +1501,14 @@ def new_ice_water_content_revised(
     mass_plume_t2 : npt.NDArray[np.floating]
         contrail plume mass per unit length at the end of the
         time step, [:math:`kg_{air} m^{-1}`]
+    depth_eff : npt.NDArray[np.floating]
+        effective depth of contrail plume, [:math:`m`]
+    terminal_fall_speed : npt.NDArray[np.floating]
+        terminal fall speed of contrail plume, [:math:m `s^{-1}`]
+    phase_relax_rate : npt.NDArray[np.floating]
+        phase relaxation rate in the contrail, [:math:`s^{-1}`]
+    dt : npt.NDArray[np.timedelta64]
+        length of time integration step, [:math:`s`]
 
     Returns
     -------
@@ -1468,10 +1526,31 @@ def new_ice_water_content_revised(
         (releases) H2O from (to) surrounding air.
     (5) ``iwc_t2 = mass_h2o_t2 / mass_plume_t2 - q_sat_t2``: H2O in the
         gas phase is removed (``- q_sat_t2``).
-    (X) TODO: add term missing sedimentation term
     """
+    # change from falling through sub/supersaturated air
+    dt_s = units.dt_to_seconds(dt, iwc_t1.dtype)
+    qa = 0.5 * (q_t1 + q_sed)
+    qs = 0.5 * (q_sat_t1 + q_sat_sed)
+    m = 0.5 * (mass_plume_t1 + mass_plume_sed)
+    delta_mass_h2o_sed = (
+        m
+        * (qs - qa)
+        * np.expm1(-depth_eff * phase_relax_rate / terminal_fall_speed)
+        * terminal_fall_speed
+        * dt_s
+        / depth_eff
+    )
+
+    # change from mixing
     delta_mass_h2o_mix = mass_plume_t2 * q_t2 - mass_plume_sed * q_sed
-    mass_h2o_t2 = mass_plume_sed * q_sat_sed + mass_plume_t1 * iwc_t1 + delta_mass_h2o_mix
+
+    # updated ice water content
+    mass_h2o_t2 = (
+        mass_plume_sed * q_sat_sed
+        + mass_plume_t1 * iwc_t1
+        + delta_mass_h2o_mix
+        + delta_mass_h2o_sed
+    )
     iwc_t2 = (mass_h2o_t2 / mass_plume_t2) - q_sat_t2
     iwc_t2.clip(min=0.0, out=iwc_t2)
     return iwc_t2

--- a/pycontrails/models/cocip/contrail_properties.py
+++ b/pycontrails/models/cocip/contrail_properties.py
@@ -864,8 +864,8 @@ def phase_relaxation_rate(
 
     References
     ----------
-    - :cite:`hallPrupaccherSurvivalIceParticles1976`
-    - :cite:`prupaccherKlettMicrophysicsCloudsPrecipitation2010`
+    - :cite:`hallSurvivalIceParticles1976`
+    - :cite:`pruppacherMicrophysicsCloudsPrecipitation2010`
 
     Notes
     -----

--- a/pycontrails/models/cocip/contrail_properties.py
+++ b/pycontrails/models/cocip/contrail_properties.py
@@ -1347,12 +1347,12 @@ def new_effective_area_from_sigma(
 
 def new_ice_water_content(
     iwc_t1: npt.NDArray[np.floating],
-    q_t1: npt.NDArray[np.floating],
+    q_sed: npt.NDArray[np.floating],
     q_t2: npt.NDArray[np.floating],
-    q_sat_t1: npt.NDArray[np.floating],
+    q_sat_sed: npt.NDArray[np.floating],
     q_sat_t2: npt.NDArray[np.floating],
-    q_sat_t2_sed: npt.NDArray[np.floating],
     mass_plume_t1: npt.NDArray[np.floating],
+    mass_plume_sed: npt.NDArray[np.floating],
     mass_plume_t2: npt.NDArray[np.floating],
 ) -> npt.NDArray[np.floating]:
     """
@@ -1366,18 +1366,27 @@ def new_ice_water_content(
     q_t1 : npt.NDArray[np.floating]
         specific humidity for each waypoint at the start of the
         time step, [:math:`kg_{H_{2}O}/kg_{air}`]
+    q_sed : npt.NDArray[np.floating]
+        specific humidity for each waypoint
+        after sedimentation, [:math:`kg_{H_{2}O}/kg_{air}`]
     q_t2 : npt.NDArray[np.floating]
         specific humidity for each waypoint at the end of the
         time step, [:math:`kg_{H_{2}O}/kg_{air}`]
     q_sat_t1 : npt.NDArray[np.floating]
         saturation humidity for each waypoint at the start of the
         time step, [:math:`kg_{H_{2}O}/kg_{air}`]
+    q_sat_sed : npt.NDArray[np.floating]
+        saturation humidity for each waypoint
+        after sedimentation, [:math:`kg_{H_{2}O}/kg_{air}`]
     q_sat_t2 : npt.NDArray[np.floating]
         saturation humidity for each waypoint at the end of the
         time step, [:math:`kg_{H_{2}O}/kg_{air}`]
     mass_plume_t1 : npt.NDArray[np.floating]
         contrail plume mass per unit length at the start of the
         time step, [:math:`kg_{air} m^{-1}`]
+    mass_plume_sed : npt.NDArray[np.floating]
+        contrail plume mass per unit length
+        after sedimentation, [:math:`kg_{air} m^{-1}`]
     mass_plume_t2 : npt.NDArray[np.floating]
         contrail plume mass per unit length at the end of the
         time step, [:math:`kg_{air} m^{-1}`]
@@ -1387,7 +1396,7 @@ def new_ice_water_content(
     npt.NDArray[np.floating]
         Contrail ice water content at the end of the time step, [:math:`kg_{ice} kg_{air}^{-1}`]
 
-    Notes
+    Notes (TODO: update)
     -----
     (1) The ice water content is fully conservative.
     (2) ``mass_h2o_t2``: the total H2O mass (ice + vapour) per unit of
@@ -1398,14 +1407,10 @@ def new_ice_water_content(
         (releases) H2O from (to) surrounding air.
     (5) ``iwc_t2 = mass_h2o_t2 / mass_plume_t2 - q_sat_t2``: H2O in the
         gas phase is removed (``- q_sat_t2``).
+    (X) TODO: add term missing sedimentation term
     """
-    q_mean = 0.5 * (q_t1 + q_t2 - (q_sat_t1 + q_sat_t2_sed))
-    mass_h2o_t1 = mass_plume_t1 * (iwc_t1 + q_sat_t1)
-    mass_h2o_t2 = (
-        mass_h2o_t1
-        + (mass_plume_t2 - mass_plume_t1) * q_mean
-        + (mass_plume_t2 * q_sat_t2_sed - mass_plume_t1 * q_sat_t1)
-    )
+    delta_mass_h2o_mix = mass_plume_t2 * q_t2 - mass_plume_sed * q_sed
+    mass_h2o_t2 = mass_plume_sed * q_sat_sed + mass_plume_t1 * iwc_t1 + delta_mass_h2o_mix
     iwc_t2 = (mass_h2o_t2 / mass_plume_t2) - q_sat_t2
     iwc_t2.clip(min=0.0, out=iwc_t2)
     return iwc_t2

--- a/pycontrails/models/cocipgrid/cocip_grid.py
+++ b/pycontrails/models/cocipgrid/cocip_grid.py
@@ -1634,7 +1634,7 @@ def calc_evolve_one_step(
     .. versionchanged:: 0.60.3
 
         A required ``sed_contrail`` parameter was added to support integration using
-        a revised contrail ice budget. This parameter is unused and can be set to ``None``
+        the revised contrail ice budget. This parameter is unused and can be set to ``None``
         when using the original contrail ice budget.
 
     Parameters

--- a/pycontrails/models/cocipgrid/cocip_grid.py
+++ b/pycontrails/models/cocipgrid/cocip_grid.py
@@ -1104,7 +1104,6 @@ def _evolve_vector(
 
     # After advection, out has time t
     out = advect(vector, dt, dt_head, dt_tail)  # type: ignore[arg-type]
-
     out = run_interpolators(
         out,
         met,
@@ -1113,7 +1112,23 @@ def _evolve_vector(
         humidity_scaling=params["humidity_scaling"],
         **params["_interp_kwargs"],
     )
-    out = calc_evolve_one_step(vector, out, params)
+
+    # required by process-split implementation of revised ice budget
+    if params["revised_contrail_ice_budget"]:
+        sed = sediment(vector, dt)  # type: ignore[arg-type]
+        sed = run_interpolators(
+            sed,
+            met,
+            rad=None,
+            dz_m=None,
+            humidity_scaling=params["humidity_scaling"],
+            keys=("air_temperature", "specific_humidity"),
+            **params["_interp_kwargs"],
+        )
+    else:
+        sed = None
+
+    out = calc_evolve_one_step(vector, sed, out, params)
     ef_summary = out.select(("index", "age", "ef"), copy=False)
 
     return out, ef_summary
@@ -1607,6 +1622,7 @@ def find_initial_persistent_contrails(
 
 def calc_evolve_one_step(
     curr_contrail: GeoVectorDataset,
+    sed_contrail: GeoVectorDataset | None,
     next_contrail: GeoVectorDataset,
     params: dict[str, Any],
 ) -> GeoVectorDataset:
@@ -1615,10 +1631,19 @@ def calc_evolve_one_step(
     This function attaches additional variables to ``next_contrail``, then
     filters by :func:`contrail_properties.contrail_persistent`.
 
+    .. versionchanged:: 0.60.3
+
+        A required ``sed_contrail`` parameter was added to support integration using
+        a revised contrail ice budget. This parameter is unused and can be set to ``None``
+        when using the original contrail ice budget.
+
     Parameters
     ----------
     curr_contrail : GeoVectorDataset
         Existing contrail
+    sed_contrail : GeoVectorDataset
+        Result of sedimentation of existing contrail already interpolated against CoCiP met data.
+        Only required when ``params["revised_contrail_ice_budget"]`` is ``True``.
     next_contrail : GeoVectorDataset
         Result of advecting existing contrail already interpolated against CoCiP met data
     params : dict[str, Any]
@@ -1690,17 +1715,74 @@ def calc_evolve_one_step(
 
     rho_air_t2 = next_contrail["rho_air"]
     plume_mass_per_m_t2 = contrail_properties.plume_mass_per_distance(area_eff_t2, rho_air_t2)
-    iwc_t2 = contrail_properties.new_ice_water_content(
-        iwc_t1=iwc_t1,
-        q_t1=specific_humidity_t1,
-        q_t2=specific_humidity_t2,
-        q_sat_t1=q_sat_t1,
-        q_sat_t2=q_sat_t2,
-        # FIXME
-        q_sat_t2_sed=q_sat_t1,
-        mass_plume_t1=plume_mass_per_m_t1,
-        mass_plume_t2=plume_mass_per_m_t2,
-    )
+
+    if params["revised_contrail_ice_budget"]:
+        if sed_contrail is None:
+            msg = (
+                "Contrail properties after sedimentation must be provided when using "
+                "revised contrail ice budget."
+            )
+            raise ValueError(msg)
+
+        # get ambient specific humidity and saturation specific humidity after sedimentation
+        specific_humidity_sed = sed_contrail["specific_humidity"]
+        q_sat_sed = thermo.q_sat_ice(sed_contrail["air_temperature"], sed_contrail["air_pressure"])
+
+        # compute plume mass after sedimentation
+        plume_mass_per_m_sed = contrail_properties.plume_mass_per_distance(
+            curr_contrail["area_eff"],
+            thermo.rho_d(sed_contrail["air_temperature"], sed_contrail["air_pressure"]),
+        )
+
+        # get plume depth, terminal fall speed, and phase relaxation rate
+        # used to limit deposition/sedimentation in a shallow but rapidly-sedimenting plume
+        terminal_fall_speed_t1 = curr_contrail["terminal_fall_speed"]
+        depth_eff_t1 = contrail_properties.plume_effective_depth(
+            width_t1, curr_contrail["area_eff"]
+        )
+        n_ice_per_vol_t1 = contrail_properties.ice_particle_number_per_volume_of_plume(
+            curr_contrail["n_ice_per_m"], curr_contrail["area_eff"]
+        )
+        n_ice_per_kg_t1 = contrail_properties.ice_particle_number_per_mass_of_air(
+            n_ice_per_vol_t1,
+            thermo.rho_d(curr_contrail["air_temperature"], curr_contrail["air_pressure"]),
+        )
+        r_vol_t1 = contrail_properties.ice_particle_volume_mean_radius(iwc_t1, n_ice_per_kg_t1)
+        vapor_diffusivity_t1 = thermo.diffusivity_water_vapor(
+            curr_contrail["air_temperature"], curr_contrail["air_pressure"]
+        )
+        phase_relax_rate_t1 = contrail_properties.phase_relaxation_rate(
+            r_vol_t1, n_ice_per_vol_t1, vapor_diffusivity_t1
+        )
+
+        iwc_t2 = contrail_properties.new_ice_water_content_revised(
+            iwc_t1=iwc_t1,
+            q_t1=specific_humidity_t1,
+            q_sed=specific_humidity_sed,
+            q_t2=specific_humidity_t2,
+            q_sat_t1=q_sat_t1,
+            q_sat_sed=q_sat_sed,
+            q_sat_t2=q_sat_t2,
+            mass_plume_t1=plume_mass_per_m_t1,
+            mass_plume_sed=plume_mass_per_m_sed,
+            mass_plume_t2=plume_mass_per_m_t2,
+            depth_eff=depth_eff_t1,
+            terminal_fall_speed=terminal_fall_speed_t1,
+            phase_relax_rate=phase_relax_rate_t1,
+            dt=dt,
+        )
+
+    else:
+        iwc_t2 = contrail_properties.new_ice_water_content(
+            iwc_t1=iwc_t1,
+            q_t1=specific_humidity_t1,
+            q_t2=specific_humidity_t2,
+            q_sat_t1=q_sat_t1,
+            q_sat_t2=q_sat_t2,
+            mass_plume_t1=plume_mass_per_m_t1,
+            mass_plume_t2=plume_mass_per_m_t2,
+        )
+
     next_contrail["iwc"] = iwc_t2
 
     n_ice_per_m_t1 = curr_contrail["n_ice_per_m"]
@@ -2119,6 +2201,64 @@ def advect(
     data["latitude_tail"] = latitude_tail_t2
     data["segment_length"] = segment_length_t2
     data["head_tail_dt"] = head_tail_dt_t2
+
+    return GeoVectorDataset._from_fastpath(data, attrs=contrail.attrs).copy()
+
+
+def sediment(
+    contrail: GeoVectorDataset,
+    dt: np.timedelta64 | npt.NDArray[np.timedelta64],
+) -> GeoVectorDataset:
+    """Compute location of new contrail after sedimentation only.
+
+    Parameter ``contrail`` is not modified.
+
+    Required when using revised contrail ice budget.
+
+    Parameters
+    ----------
+    contrail : GeoVectorDataset
+        Original contrail grid points already interpolated against wind data
+    dt : np.timedelta64 | npt.NDArray[np.timedelta64]
+        Time step for sedimentation
+
+    Returns
+    -------
+    GeoVectorDataset
+        New contrail instance with keys:
+            - "index"
+            - "longitude"
+            - "latitude"
+            - "level"
+            - "air_pressure"
+            - "altitude",
+            - "time"
+    """
+    longitude = contrail["longitude"]
+    latitude = contrail["latitude"]
+    level = contrail["level"]
+    time = contrail["time"]
+    rho_air = contrail["rho_air"]
+    terminal_fall_speed = contrail["terminal_fall_speed"]
+
+    # Using the _t2 convention for post-advection data
+    index_t2 = contrail["index"]
+    time_t2 = time + dt
+    longitude_t2 = longitude
+    latitude_t2 = latitude
+
+    level_t2 = geo.advect_level(level, 0.0, rho_air, terminal_fall_speed, dt)
+    altitude_t2 = units.pl_to_m(level_t2)
+
+    data = {
+        "index": index_t2,
+        "longitude": longitude_t2,
+        "latitude": latitude_t2,
+        "level": level_t2,
+        "air_pressure": 100.0 * level_t2,
+        "altitude": altitude_t2,
+        "time": time_t2,
+    }
 
     return GeoVectorDataset._from_fastpath(data, attrs=contrail.attrs).copy()
 

--- a/pycontrails/models/cocipgrid/cocip_grid.py
+++ b/pycontrails/models/cocipgrid/cocip_grid.py
@@ -1696,6 +1696,8 @@ def calc_evolve_one_step(
         q_t2=specific_humidity_t2,
         q_sat_t1=q_sat_t1,
         q_sat_t2=q_sat_t2,
+        # FIXME
+        q_sat_t2_sed=q_sat_t1,
         mass_plume_t1=plume_mass_per_m_t1,
         mass_plume_t2=plume_mass_per_m_t2,
     )

--- a/pycontrails/models/cocipgrid/cocip_grid.py
+++ b/pycontrails/models/cocipgrid/cocip_grid.py
@@ -1631,7 +1631,7 @@ def calc_evolve_one_step(
     This function attaches additional variables to ``next_contrail``, then
     filters by :func:`contrail_properties.contrail_persistent`.
 
-    .. versionchanged:: 0.60.3
+    .. versionchanged:: 0.62.0
 
         A required ``sed_contrail`` parameter was added to support integration using
         the revised contrail ice budget. This parameter is unused and can be set to ``None``

--- a/pycontrails/models/extended_k15.py
+++ b/pycontrails/models/extended_k15.py
@@ -23,7 +23,7 @@ from pycontrails.physics import constants, thermo
 # See upcoming Teoh et. al paper "Impact of Volatile Particulate Matter on Global Contrail
 # Radiative Forcing and Mitigation Assessment" for details on these default parameters.
 DEFAULT_EXHAUST_T = 600.0  # Exhaust temperature, [K]
-EXPERIMENTAL_WARNING = not os.getenv("PYCONTRAILS_SILENCE_VPM_WARNING")
+EXPERIMENTAL_WARNING = False
 
 
 class ParticleType(enum.StrEnum):

--- a/pycontrails/models/extended_k15.py
+++ b/pycontrails/models/extended_k15.py
@@ -23,7 +23,7 @@ from pycontrails.physics import constants, thermo
 # See upcoming Teoh et. al paper "Impact of Volatile Particulate Matter on Global Contrail
 # Radiative Forcing and Mitigation Assessment" for details on these default parameters.
 DEFAULT_EXHAUST_T = 600.0  # Exhaust temperature, [K]
-EXPERIMENTAL_WARNING = False
+EXPERIMENTAL_WARNING = not os.getenv("PYCONTRAILS_SILENCE_VPM_WARNING")
 
 
 class ParticleType(enum.StrEnum):

--- a/pycontrails/physics/geo.py
+++ b/pycontrails/physics/geo.py
@@ -821,7 +821,7 @@ def advect_latitude(
 
 def advect_level(
     level: ArrayLike,
-    vertical_velocity: ArrayLike,
+    vertical_velocity: ArrayLike | float,
     rho_air: ArrayLike | float,
     terminal_fall_speed: ArrayLike | float,
     dt: npt.NDArray[np.timedelta64] | np.timedelta64,

--- a/pycontrails/physics/thermo.py
+++ b/pycontrails/physics/thermo.py
@@ -123,6 +123,47 @@ def water_vapor_partial_pressure_along_mixing_line(
     return p_wa + G * (T_plume - T_ambient)
 
 
+def diffusivity_water_vapor(T: ArrayScalarLike, p: ArrayScalarLike) -> ArrayScalarLike:
+    """
+    Calculate molecular diffusivity of water vapor.
+
+    Parameters
+    ----------
+    T: ArrayScalarLike
+        Air temperature, [:math:`K`]
+
+    p: ArrayScalarLike
+        Air pressure, [:math:`Pa`]
+
+    Returns
+    -------
+    ArrayScalarLike
+        Molecular diffusivity of water vapor, [:math:`m^2 s^{-1}`]
+
+    References
+    ----------
+    - :cite:`hallPrupaccherSurvivalIceParticles1976`
+    - :cite:`prupaccherKlettMicrophysicsCloudsPrecipitation2010`
+
+    Notes
+    -----
+    The parameterization used by this function is valid for temperatures between -40 and 40 C,
+    and input temperatures are clipped to this range.
+    """
+    # FIXME: Presently, mypy is not aware that numpy ufuncs will return `xr.DataArray``
+    # when xr.DataArray is passed in. This will get fixed at some point in the future
+    # as `numpy` their typing patterns, after which the "type: ignore" comment can
+    # get ripped out.
+    # We could explicitly check for `xr.DataArray` then use `xr.apply_ufunc`, but
+    # this only renders our code more boilerplate and less performant.
+    # This comment is pasted several places in `pycontrails` -- they should all be
+    # addressed at the same time.
+    T = np.clip(T, -40.0 - constants.absolute_zero, 40.0 - constants.absolute_zero)  # type: ignore[return-value]
+    T0 = 273.15
+    p0 = 101325.0
+    return 0.0000211 * (T / T0) ** 1.94 * (p0 / p)
+
+
 # -------------------
 # Saturation Pressure
 # -------------------

--- a/pycontrails/physics/thermo.py
+++ b/pycontrails/physics/thermo.py
@@ -158,7 +158,7 @@ def diffusivity_water_vapor(T: ArrayScalarLike, p: ArrayScalarLike) -> ArrayScal
     # this only renders our code more boilerplate and less performant.
     # This comment is pasted several places in `pycontrails` -- they should all be
     # addressed at the same time.
-    T = np.clip(T, -40.0 - constants.absolute_zero, 40.0 - constants.absolute_zero)  # type: ignore[return-value]
+    T = np.clip(T, -40.0 - constants.absolute_zero, 40.0 - constants.absolute_zero)  # type: ignore[assignment]
     T0 = 273.15
     p0 = 101325.0
     return 0.0000211 * (T / T0) ** 1.94 * (p0 / p)

--- a/pycontrails/physics/thermo.py
+++ b/pycontrails/physics/thermo.py
@@ -142,8 +142,8 @@ def diffusivity_water_vapor(T: ArrayScalarLike, p: ArrayScalarLike) -> ArrayScal
 
     References
     ----------
-    - :cite:`hallPrupaccherSurvivalIceParticles1976`
-    - :cite:`prupaccherKlettMicrophysicsCloudsPrecipitation2010`
+    - :cite:`hallSurvivalIceParticles1976`
+    - :cite:`pruppacherMicrophysicsCloudsPrecipitation2010`
 
     Notes
     -----

--- a/tests/unit/test_cocip.py
+++ b/tests/unit/test_cocip.py
@@ -2047,3 +2047,46 @@ def test_cocip_output_columns(
         return
 
     pytest.fail(f"Test case not implemented for T_add={T_add}, q_scale={q_scale}")
+
+
+def test_revised_contrail_ice_budget_param(fl: Flight, met: MetDataset, rad: MetDataset):
+    """Run Cocip with the revised_contrail_ice_budget parameter.
+
+    The purpose of this test is to show that this parameter changes simulation output.
+    """
+
+    fl.update(longitude=np.linspace(-29.0, -32.0, 20))
+    fl.update(latitude=np.linspace(56.0, 57.0, 20))
+    fl.update(altitude=np.full(20, 10900.0))
+
+    params = {
+        "max_age": np.timedelta64(90, "m"),  # keep short to avoid blowing out of bounds
+        "dt_integration": np.timedelta64(10, "m"),
+        "process_emissions": False,
+        "humidity_scaling": ExponentialBoostLatitudeCorrectionHumidityScaling(),
+    }
+
+    # Artificially shift time to get some SDR
+    met.data = met.data.assign_coords(time=met.data["time"] + np.timedelta64(12, "h"))
+    rad.data = rad.data.assign_coords(time=rad.data["time"] + np.timedelta64(12, "h"))
+    fl.update(time=fl["time"] + np.timedelta64(12, "h"))
+
+    cocip = Cocip(met, rad=rad, params=params)
+    fl1 = cocip.eval(source=fl)
+    contrail1 = cocip.contrail
+    assert contrail1 is not None
+    assert not cocip.params["revised_contrail_ice_budget"]
+
+    fl2 = cocip.eval(source=fl, revised_contrail_ice_budget=True)
+    assert cocip.params["revised_contrail_ice_budget"]
+    contrail2 = cocip.contrail
+    assert contrail2 is not None
+
+    # Compare output between two model runs
+    assert set(contrail1.columns) == set(contrail2.columns)
+
+    # Revisions generally increase EF, though only slightly when
+    # contrails are relatively young
+    assert fl1["ef"].sum() == pytest.approx(7.3e12, rel=0.1)
+    assert fl2["ef"].sum() == pytest.approx(7.3e12, rel=0.1)
+    assert fl2["ef"].sum() - fl1["ef"].sum() == pytest.approx(0.06e12, rel=0.1)

--- a/tests/unit/test_cocip_grid.py
+++ b/tests/unit/test_cocip_grid.py
@@ -1053,3 +1053,31 @@ def test_cocip_grid_met_rad_variables_helper(
 ) -> None:
     """Test met and rad variable helper properties."""
     assert grid_mvs == traj_mvs
+
+
+def test_cocip_grid_revised_contrail_ice_budget_param(
+    source: MetDataset, instance_params: dict[str, Any]
+) -> None:
+    """Test that ice budget revisions change gridded output."""
+    gc1 = CocipGrid(**instance_params, aircraft_performance=PSGrid())
+    gc2 = CocipGrid(
+        **instance_params, aircraft_performance=PSGrid(), revised_contrail_ice_budget=True
+    )
+
+    source = CocipGrid.create_source(
+        level=[230, 240, 250, 260],
+        time=np.datetime64("2019-01-01"),
+        longitude=np.linspace(-35, -25, 40),
+        latitude=np.linspace(51, 57, 20),
+    )
+
+    out1 = gc1.eval(source)
+    out2 = gc2.eval(source)
+
+    # Revisions generally increase EF, though only slightly when
+    # contrails are relatively young
+    efpm1 = out1["ef_per_m"].data.mean().item()
+    efpm2 = out2["ef_per_m"].data.mean().item()
+    assert efpm1 == pytest.approx(5.6e6, rel=0.1)
+    assert efpm2 == pytest.approx(5.7e6, rel=0.1)
+    assert efpm2 - efpm1 == pytest.approx(0.2e6, rel=0.1)


### PR DESCRIPTION
Closes https://github.com/contrailcirrus/pycontrails/issues/241

## Changes

#### Features

- Experimental: Implement a revised version of the CoCiP contrail ice budget that ensures contrails in air at 100% RHi conserve total ice mass. The revisions can be activated in `Cocip` and `CocipGrid` by setting the `revised_contrail_ice_budget` parameter to `True`. However, they are disabled by default and should be used with caution, as they lead to significant changes in the optical properties of aged contrails. The ice budget revisions and their impact on CoCiP simulations will be described in detail in a future publication.

## Tests

- [x] QC test passes locally (`make test`)
- [ ] CI tests pass

## Reviewer

> @zebengberg 
