### PR TITLE
Fix/ap fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,22 +1,28 @@
 # Changelog
 
-## [Unreleased]
+## 0.63.0
 
 ### Features
 
-- Support extrapolation in model-level-to-pressure-level interpolation
-  (ml\_to\_pl)
+- Support extrapolation in model-level-to-pressure-level interpolation (`pycontrails.datalib.ecmwf.ml_to_pl`).
+
 ### Fixes
 
-- Fix `jet.cargo_load_factor` to handle cases where no data is available for the specified origin and destination region pair. In such cases, the function now falls back to using global mean estimates instead raising a meaningless error.
+- Fix `jet.cargo_load_factor` to handle cases where no data is available for the specified origin and destination region pair. In such cases, the function now falls back to using global mean estimates instead of raising a meaningless error.
+- No longer set `Flight.attrs` with NaN or NaT values in `ChAviation` datalib when the metadata is missing.
 
 ### Internals
 
 - Add minor performance improvements to Poll-Schumann internal model functions.
-- Update Spire ValidateTrajectoryHandler `AVG_LOW_GROUND_SPEED_THRESHOLD_MPS` constant to 85 m/s from 100 m/s based on 2024-2025 flights data analysis.
+- Update Spire `ValidateTrajectoryHandler.AVG_LOW_GROUND_SPEED_THRESHOLD_MPS` constant from 100 m/s to 85 m/s based on 2024-2025 flights data analysis.
+- Handle timezone-aware timestamps in met datalibs.
 
 ### Breaking changes
+
 - Remove `ingestion_time` from Spire data schema as it's not required for any contrail predictions.
+- Expose the maximum Mach number buffer applied in `PSFlight` via a new `AircraftPerformanceParams.max_mach_buffer` parameter. Previously this was hard-coded to 0.02. The default value has now changed from 0.02 to 0.0. With this new default, downstream users should expect a small change in `PSFlight` fuel flow estimates (typically a decrease) when working with noisy ADS-B. Set this to 0.02 to retain previous behavior.
+- Change the `fl.attrs["aircraft_performance_model"]` value from `"PSFlight"` to `"PS"` when the `PSFlight` model is used for consistency with `BADAFlight`.
+- Rename the function arguments `max_takeoff_weight` -> `amass_mtow` and `operating_empty_weight` -> `amass_oew` in `jet.update_aircraft_mass` and `jet.initial_aircraft_mass`. This is to standardize the naming convention for aircraft mass parameters across pycontrails. Typically these functions are not called directly so the risk that downstream code is affected by this change is low.
 
 ## 0.62.0
 

--- a/pycontrails/core/aircraft_performance.py
+++ b/pycontrails/core/aircraft_performance.py
@@ -67,6 +67,14 @@ class AircraftPerformanceParams(ModelParams, CommonAircraftPerformanceParams):
     #: filled with zero wind.
     fill_low_altitude_with_zero_wind: bool = False
 
+    #: Add or reduce the maximum permitted Mach number guardrail. This
+    #: parameter buffers the aircraft max Mach number by an additional amount.
+    #:
+    #: .. versionadded:: 0.63.0
+    #:
+    #:    Previously this parameter was hard-coded. Default now changed from 0.02 to 0.0
+    max_mach_buffer: float = 0.0
+
 
 class AircraftPerformance(Model):
     """

--- a/pycontrails/core/aircraft_performance.py
+++ b/pycontrails/core/aircraft_performance.py
@@ -493,8 +493,8 @@ class AircraftPerformance(Model):
             )
 
             aircraft_mass = jet.update_aircraft_mass(
-                operating_empty_weight=amass_oew,
-                max_takeoff_weight=amass_mtow,
+                amass_oew=amass_oew,
+                amass_mtow=amass_mtow,
                 payload=payload,
                 fuel_burn=aircraft_performance.fuel_burn,
                 total_reserve_fuel=tot_reserve_fuel,

--- a/pycontrails/core/aircraft_performance.py
+++ b/pycontrails/core/aircraft_performance.py
@@ -216,14 +216,14 @@ class AircraftPerformance(Model):
             return out
 
         aircraft_role = fl.attrs.get("aircraft_role")
-        if pd.isna(aircraft_role):  # check for None or np.nan (ch-aviation adds nan)
+        if aircraft_role is None:
             aircraft_role = "Passenger"
-            fl.attrs.update(aircraft_role=aircraft_role)
+            fl.attrs["aircraft_role"] = aircraft_role
 
         n_seats = fl.attrs.get("n_seats")
-        if pd.isna(n_seats):  # check for None or np.nan (ch-aviation adds nan)
+        if n_seats is None:
             n_seats = jet.number_of_seats(aircraft_type)
-            fl.attrs.update(n_seats=n_seats)
+            fl.attrs["n_seats"] = n_seats
 
         pax_lf = fl.attrs.get("passenger_load_factor")
         if pax_lf is None:
@@ -250,8 +250,8 @@ class AircraftPerformance(Model):
 
         out = jet.aircraft_payload(
             max_payload=max_payload,
-            aircraft_role=aircraft_role,  # type: ignore[arg-type]
-            n_seats=n_seats,  # type: ignore[arg-type]
+            aircraft_role=aircraft_role,
+            n_seats=n_seats,
             pax_lf=pax_lf,
             cargo_lf=cargo_lf,
         )

--- a/pycontrails/datalib/_met_utils/metsource.py
+++ b/pycontrails/datalib/_met_utils/metsource.py
@@ -13,7 +13,6 @@ from typing import Any, TypeAlias
 import numpy as np
 import pandas as pd
 import xarray as xr
-
 from pycontrails.core import cache
 from pycontrails.core.met import MetDataset, MetVariable
 
@@ -121,6 +120,12 @@ def parse_timesteps(
             "Time input must be compatible with 'pd.to_datetime()'"
         )
         raise ValueError(msg) from e
+
+    # ensure timezone naive
+    if t0.tzinfo:
+        t0 = t0.tz_convert("UTC").tz_localize(None)
+    if t1.tzinfo:
+        t1 = t1.tz_convert("UTC").tz_localize(None)
 
     if freq is None:
         daterange = pd.DatetimeIndex([t0, t1])

--- a/pycontrails/datalib/_met_utils/metsource.py
+++ b/pycontrails/datalib/_met_utils/metsource.py
@@ -13,6 +13,7 @@ from typing import Any, TypeAlias
 import numpy as np
 import pandas as pd
 import xarray as xr
+
 from pycontrails.core import cache
 from pycontrails.core.met import MetDataset, MetVariable
 

--- a/pycontrails/datalib/ch_aviation.py
+++ b/pycontrails/datalib/ch_aviation.py
@@ -174,6 +174,15 @@ def _ch_aviation_root_path() -> pathlib.Path:
     return pathlib.Path(*pycontrails.__path__).parents[1] / "ch-aviation"
 
 
+def _set_value_skip_nan(attrs: dict[str, Any], key: str, value: Any) -> None:
+    """Set value in attrs dict if key is not already defined and value is not NaN / NaT / None."""
+    if key in attrs:
+        return
+    if pd.isna(value):
+        return
+    attrs[key] = value
+
+
 class ChAviation(Model):
     """Support for querying the ch-aviation fleet database.
 
@@ -326,75 +335,77 @@ class ChAviation(Model):
                 return self.source
 
             # Set attributes, if they aren't already defined
-            self.source.attrs.setdefault("engine_name", engine_props.engine_subtype)
-            self.source.attrs.setdefault("engine_uid", engine_props.engine_uid)
-            self.source.attrs.setdefault("operator_name", engine_props.operator_name)
-            self.source.attrs.setdefault("operator_iata", engine_props.operator_iata)
+            attrs = self.source.attrs
+            _set_value_skip_nan(attrs, "engine_name", engine_props.engine_subtype)
+            _set_value_skip_nan(attrs, "engine_uid", engine_props.engine_uid)
+            _set_value_skip_nan(attrs, "operator_name", engine_props.operator_name)
+            _set_value_skip_nan(attrs, "operator_iata", engine_props.operator_iata)
             return self.source
 
         # Happy path: aircraft properties are available in ch-aviation
-        self.source.attrs.setdefault("msn", aircraft_props.msn)
-        self.source.attrs.setdefault(
-            "country_of_registration", aircraft_props.country_of_registration
+        attrs = self.source.attrs
+        _set_value_skip_nan(attrs, "msn", aircraft_props.msn)
+        _set_value_skip_nan(
+            attrs, "country_of_registration", aircraft_props.country_of_registration
         )
 
         # Aircraft properties
-        self.source.attrs.setdefault("atyp_icao_ch_a", aircraft_props.aircraft_type_icao)
-        self.source.attrs.setdefault("atyp_iata_ch_a", aircraft_props.aircraft_type_iata)
-        self.source.attrs.setdefault("atyp_name_ch_a", aircraft_props.aircraft_subfamily)
-        self.source.attrs.setdefault("atyp_manufacturer", aircraft_props.manufacturer)
+        _set_value_skip_nan(attrs, "atyp_icao_ch_a", aircraft_props.aircraft_type_icao)
+        _set_value_skip_nan(attrs, "atyp_iata_ch_a", aircraft_props.aircraft_type_iata)
+        _set_value_skip_nan(attrs, "atyp_name_ch_a", aircraft_props.aircraft_subfamily)
+        _set_value_skip_nan(attrs, "atyp_manufacturer", aircraft_props.manufacturer)
 
         # Engine properties
-        self.source.attrs.setdefault("engine_name", aircraft_props.engine_subtype)
-        self.source.attrs.setdefault("engine_uid", aircraft_props.engine_uid)
-        self.source.attrs.setdefault("engine_manufacturer", aircraft_props.engine_manufacturer)
-        self.source.attrs.setdefault("n_engines_ch_a", aircraft_props.n_engines)
+        _set_value_skip_nan(attrs, "engine_name", aircraft_props.engine_subtype)
+        _set_value_skip_nan(attrs, "engine_uid", aircraft_props.engine_uid)
+        _set_value_skip_nan(attrs, "engine_manufacturer", aircraft_props.engine_manufacturer)
+        _set_value_skip_nan(attrs, "n_engines_ch_a", aircraft_props.n_engines)
 
         # Performance envelope
-        self.source.attrs.setdefault("amass_mtow", aircraft_props.mtow_kg)
+        _set_value_skip_nan(attrs, "amass_mtow", aircraft_props.mtow_kg)
 
         # Operator properties
-        self.source.attrs.setdefault("operator_name", aircraft_props.operator_name)
-        self.source.attrs.setdefault("operator_icao", aircraft_props.operator_icao)
-        self.source.attrs.setdefault("operator_iata", aircraft_props.operator_iata)
-        self.source.attrs.setdefault("operator_type", aircraft_props.operator_type)
-        self.source.attrs.setdefault("aircraft_role", aircraft_props.aircraft_role)
-        self.source.attrs.setdefault("aircraft_market_group", aircraft_props.aircraft_market_group)
-        self.source.attrs.setdefault("n_seats", aircraft_props.n_seats)
+        _set_value_skip_nan(attrs, "operator_name", aircraft_props.operator_name)
+        _set_value_skip_nan(attrs, "operator_icao", aircraft_props.operator_icao)
+        _set_value_skip_nan(attrs, "operator_iata", aircraft_props.operator_iata)
+        _set_value_skip_nan(attrs, "operator_type", aircraft_props.operator_type)
+        _set_value_skip_nan(attrs, "aircraft_role", aircraft_props.aircraft_role)
+        _set_value_skip_nan(attrs, "aircraft_market_group", aircraft_props.aircraft_market_group)
+        _set_value_skip_nan(attrs, "n_seats", aircraft_props.n_seats)
 
         # Aircraft status
-        self.source.attrs.setdefault("status", aircraft_props.status)
-        self.source.attrs.setdefault("first_flight_date", aircraft_props.first_flight_date)
-        self.source.attrs.setdefault("delivery_date", aircraft_props.delivery_date)
+        _set_value_skip_nan(attrs, "status", aircraft_props.status)
+        _set_value_skip_nan(attrs, "first_flight_date", aircraft_props.first_flight_date)
+        _set_value_skip_nan(attrs, "delivery_date", aircraft_props.delivery_date)
 
         # Aircraft age
         date = pd.Timestamp(self.source["time"][0]) if self.source else pd.Timestamp("NaT")
-        self.source.attrs.setdefault("aircraft_age_yrs", aircraft_props.aircraft_age_yrs(date))
+        _set_value_skip_nan(attrs, "aircraft_age_yrs", aircraft_props.aircraft_age_yrs(date))
 
         # Aircraft utilisation statistics
-        self.source.attrs.setdefault(
-            "cumulative_reported_hours", aircraft_props.cumulative_reported_hours
+        _set_value_skip_nan(
+            attrs, "cumulative_reported_hours", aircraft_props.cumulative_reported_hours
         )
-        self.source.attrs.setdefault(
-            "cumulative_reported_hours_ttm", aircraft_props.cumulative_reported_hours_ttm
+        _set_value_skip_nan(
+            attrs, "cumulative_reported_hours_ttm", aircraft_props.cumulative_reported_hours_ttm
         )
-        self.source.attrs.setdefault(
-            "cumulative_reported_cycles", aircraft_props.cumulative_reported_cycles
+        _set_value_skip_nan(
+            attrs, "cumulative_reported_cycles", aircraft_props.cumulative_reported_cycles
         )
-        self.source.attrs.setdefault(
-            "cumulative_reported_cycles_ttm", aircraft_props.cumulative_reported_cycles_ttm
+        _set_value_skip_nan(
+            attrs, "cumulative_reported_cycles_ttm", aircraft_props.cumulative_reported_cycles_ttm
         )
-        self.source.attrs.setdefault(
-            "cumulative_stats_as_of_date", aircraft_props.cumulative_stats_as_of_date
+        _set_value_skip_nan(
+            attrs, "cumulative_stats_as_of_date", aircraft_props.cumulative_stats_as_of_date
         )
-        self.source.attrs.setdefault("average_annual_hours", aircraft_props.average_annual_hours)
-        self.source.attrs.setdefault("average_daily_hours", aircraft_props.average_daily_hours)
-        self.source.attrs.setdefault(
-            "average_daily_hours_ttm", aircraft_props.average_daily_hours_ttm
+        _set_value_skip_nan(attrs, "average_annual_hours", aircraft_props.average_annual_hours)
+        _set_value_skip_nan(attrs, "average_daily_hours", aircraft_props.average_daily_hours)
+        _set_value_skip_nan(
+            attrs, "average_daily_hours_ttm", aircraft_props.average_daily_hours_ttm
         )
-        self.source.attrs.setdefault("average_annual_cycles", aircraft_props.average_annual_cycles)
-        self.source.attrs.setdefault(
-            "average_stats_as_of_date", aircraft_props.average_stats_as_of_date
+        _set_value_skip_nan(attrs, "average_annual_cycles", aircraft_props.average_annual_cycles)
+        _set_value_skip_nan(
+            attrs, "average_stats_as_of_date", aircraft_props.average_stats_as_of_date
         )
         return self.source
 

--- a/pycontrails/models/ps_model/ps_model.py
+++ b/pycontrails/models/ps_model/ps_model.py
@@ -233,7 +233,7 @@ class PSFlight(AircraftPerformance):
             atyp_param.p_i_max,
             atyp_param.p_inf_co,
             atm_speed_limit=False,
-            buffer=0.02,
+            buffer=self.params["max_mach_buffer"],
         )
         true_airspeed, mach_num = jet.clip_mach_number(true_airspeed, air_temperature, max_mach)
 

--- a/pycontrails/models/ps_model/ps_model.py
+++ b/pycontrails/models/ps_model/ps_model.py
@@ -130,7 +130,7 @@ class PSFlight(AircraftPerformance):
         engine_deterioration_factor = self.get_engine_deterioration_factor(fl, aircraft_type)
 
         # Set flight attributes based on engine, if they aren't already defined
-        fl.attrs.setdefault("aircraft_performance_model", self.name)
+        fl.attrs.setdefault("aircraft_performance_model", "PS")
         fl.attrs.setdefault("aircraft_type_ps", atyp_ps)
         fl.attrs.setdefault("n_engine", aircraft_params.n_engine)
 

--- a/pycontrails/models/ps_model/ps_operational_limits.py
+++ b/pycontrails/models/ps_model/ps_operational_limits.py
@@ -24,10 +24,13 @@ def max_mach_number_by_altitude(
     p_inf_co: float,
     *,
     atm_speed_limit: bool = True,
-    buffer: float = 0.02,
+    buffer: float = 0.0,
 ) -> ArrayOrFloat:
-    """
-    Calculate maximum permitted Mach number at a given altitude.
+    """Calculate maximum permitted Mach number at a given altitude.
+
+    .. versionchanged:: 0.63.0
+
+        Default value of ``buffer`` changed from 0.02 to 0.0.
 
     Parameters
     ----------

--- a/pycontrails/physics/jet.py
+++ b/pycontrails/physics/jet.py
@@ -758,8 +758,8 @@ def aircraft_payload(
 
 def initial_aircraft_mass(
     *,
-    operating_empty_weight: float,
-    max_takeoff_weight: float,
+    amass_oew: float,
+    amass_mtow: float,
     payload: float,
     total_fuel_burn: float,
     total_reserve_fuel: float,
@@ -783,10 +783,10 @@ def initial_aircraft_mass(
 
     Parameters
     ----------
-    operating_empty_weight: float
+    amass_oew: float
         Aircraft operating empty weight, i.e. the basic weight of an aircraft including
         the crew and necessary equipment, but excluding usable fuel and payload, [:math:`kg`]
-    max_takeoff_weight: float
+    amass_mtow: float
         Aircraft maximum take-off weight, [:math:`kg`]
     payload: float
         Aircraft payload, [:math:`kg`]
@@ -812,14 +812,14 @@ def initial_aircraft_mass(
     --------
     :func:`reserve_fuel_requirements`
     """
-    tom = (operating_empty_weight * oew_uplift) + payload + total_fuel_burn + total_reserve_fuel
-    return min(tom, max_takeoff_weight)
+    tom = (amass_oew * oew_uplift) + payload + total_fuel_burn + total_reserve_fuel
+    return min(tom, amass_mtow)
 
 
 def update_aircraft_mass(
     *,
-    operating_empty_weight: float,
-    max_takeoff_weight: float,
+    amass_oew: float,
+    amass_mtow: float,
     payload: float,
     fuel_burn: npt.NDArray[np.floating],
     total_reserve_fuel: float,
@@ -831,12 +831,12 @@ def update_aircraft_mass(
 
     Parameters
     ----------
-    operating_empty_weight: float
+    amass_oew: float
         Aircraft operating empty weight, i.e. the basic weight of an aircraft including
         the crew and necessary equipment, but excluding usable fuel and payload, [:math:`kg`].
     ref_mass: float
         Aircraft reference mass, [:math:`kg`].
-    max_takeoff_weight: float
+    amass_mtow: float
         Aircraft maximum take-off weight, [:math:`kg`].
     payload: float
         Aircraft payload, [:math:`kg`]
@@ -863,8 +863,8 @@ def update_aircraft_mass(
     """
     if takeoff_mass is None:
         takeoff_mass = initial_aircraft_mass(
-            operating_empty_weight=operating_empty_weight,
-            max_takeoff_weight=max_takeoff_weight,
+            amass_oew=amass_oew,
+            amass_mtow=amass_mtow,
             payload=payload,
             total_fuel_burn=np.nansum(fuel_burn).item(),
             total_reserve_fuel=total_reserve_fuel,

--- a/tests/unit/test_ch_aviation.py
+++ b/tests/unit/test_ch_aviation.py
@@ -86,44 +86,23 @@ def test_eval_function_with_tail_number():
     ch_a = ChAviation()
     fl = ch_a.eval(fl)
 
-    expected_fl_attrs = [
+    expected_fl_attrs = {
         "flight_id",
         "tail_number",
         "msn",
-        "country_of_registration",
-        "atyp_icao_ch_a",
-        "atyp_iata_ch_a",
         "atyp_name_ch_a",
-        "atyp_manufacturer",
         "engine_name",
         "engine_uid",
         "engine_manufacturer",
         "n_engines_ch_a",
-        "amass_mtow",
         "operator_name",
-        "operator_icao",
-        "operator_iata",
-        "operator_type",
-        "aircraft_role",
-        "aircraft_market_group",
-        "n_seats",
         "status",
         "first_flight_date",
         "delivery_date",
         "aircraft_age_yrs",
-        "cumulative_reported_hours",
-        "cumulative_reported_hours_ttm",
-        "cumulative_reported_cycles",
-        "cumulative_reported_cycles_ttm",
-        "cumulative_stats_as_of_date",
-        "average_annual_hours",
-        "average_daily_hours",
-        "average_daily_hours_ttm",
-        "average_annual_cycles",
-        "average_stats_as_of_date",
-    ]
-    for key in expected_fl_attrs:
-        assert key in fl.attrs, f"Missing attribute: {key}"
+    }
+    missing = expected_fl_attrs - set(fl.attrs)
+    assert not missing, f"Missing attributes: {missing}"
 
 
 def test_eval_function_with_uncovered_tail_number():

--- a/tests/unit/test_cocip_grid.py
+++ b/tests/unit/test_cocip_grid.py
@@ -600,7 +600,7 @@ def test_calc_emissions(
     keys = (
         "wingspan",
         "n_engine",
-        "bada_model",
+        "aircraft_performance_model",
         "fuel",
         "max_mach",
         "segment_length",
@@ -611,9 +611,9 @@ def test_calc_emissions(
         assert key in vector.attrs
 
     if bada_priority == 3:
-        assert vector.attrs["bada_model"] == "BADA3"
+        assert vector.attrs["aircraft_performance_model"] == "BADA3"
     else:
-        assert vector.attrs["bada_model"] == "BADA4"
+        assert vector.attrs["aircraft_performance_model"] == "BADA4"
 
     # Ensure not seeing crazy fluctuations in true_airspeed and fuel_flow
     # AND check that values are also non-constant

--- a/tests/unit/test_emissions.py
+++ b/tests/unit/test_emissions.py
@@ -65,7 +65,7 @@ def test_emissions_eval(flight_fake: Flight, bada: str, aircraft_type: str, engi
     flight_fake.attrs["aircraft_type"] = aircraft_type
     flight_fake.attrs["aircraft_type_bada"] = aircraft_type
     flight_fake.attrs["engine_uid"] = engine_uid
-    flight_fake.attrs["bada_model"] = bada
+    flight_fake.attrs["aircraft_performance_model"] = bada
     flight_fake.attrs["n_engine"] = 2
 
     out_fl = emissions.eval(source=flight_fake)
@@ -123,7 +123,7 @@ def test_emissions_eval_no_n_engine(
     flight_fake.attrs["aircraft_type"] = aircraft_type
     flight_fake.attrs["aircraft_type_bada"] = aircraft_type
     flight_fake.attrs["engine_uid"] = engine_uid
-    flight_fake.attrs["bada_model"] = bada
+    flight_fake.attrs["aircraft_performance_model"] = bada
 
     out_fl = emissions.eval(source=flight_fake)
     assert emissions.source is not flight_fake  # since copy is True

--- a/tests/unit/test_ps_model.py
+++ b/tests/unit/test_ps_model.py
@@ -700,8 +700,8 @@ def test_ps_flight_on_fleet() -> None:
     assert out.fl_attrs[2]["aircraft_type"] == "A333"
     assert out.fl_attrs[1]["flight_id"] == 1
     assert out.fl_attrs[2]["flight_id"] == 2
-    assert out.fl_attrs[1]["aircraft_performance_model"] == "PSFlight"
-    assert out.fl_attrs[2]["aircraft_performance_model"] == "PSFlight"
+    assert out.fl_attrs[1]["aircraft_performance_model"] == "PS"
+    assert out.fl_attrs[2]["aircraft_performance_model"] == "PS"
     assert out.fl_attrs[1]["n_engine"] == 2
     assert out.fl_attrs[2]["n_engine"] == 2
     assert out.fl_attrs[1]["wingspan"] == 34.1

--- a/tests/unit/test_ps_model.py
+++ b/tests/unit/test_ps_model.py
@@ -229,7 +229,7 @@ def test_mach_number_limits_scalar() -> None:
     )
 
     np.testing.assert_array_almost_equal(
-        mmax, [0.645, 0.703, 0.770, 0.84, 0.84, 0.84, 0.84], decimal=3
+        mmax, [0.624, 0.683, 0.749, 0.82, 0.82, 0.82, 0.82], decimal=3
     )
 
 
@@ -269,7 +269,7 @@ def test_mach_number_limits_vector() -> None:
     )
 
     np.testing.assert_array_almost_equal(
-        mmax, [0.645, 0.703, 0.770, 0.84, 0.84, 0.84, 0.84], decimal=3
+        mmax, [0.624, 0.683, 0.749, 0.82, 0.82, 0.82, 0.82], decimal=3
     )
 
 
@@ -440,7 +440,7 @@ def test_total_fuel_burn(payload: float) -> None:
     flight["true_airspeed"] = units.knots_to_m_per_s(flight["speed"])
 
     # Aircraft performance model
-    ps_model = ps.PSFlight()
+    ps_model = ps.PSFlight(max_mach_buffer=0.02)  # using old buffer value to match pinned values
     out = ps_model.eval(flight)
 
     if payload == 6000:
@@ -513,7 +513,7 @@ def test_ps_optimal_mach() -> None:
     )
 
     np.testing.assert_array_almost_equal(
-        mach_opt["mach_number"].values, [0.645, 0.703, 0.77, 0.804, 0.81, 0.807, 0.795], decimal=3
+        mach_opt["mach_number"].values, [0.624, 0.683, 0.749, 0.804, 0.81, 0.807, 0.795], decimal=3
     )
 
 


### PR DESCRIPTION
### Fixes

- No longer set `Flight.attrs` with NaN or NaT values in `ChAviation` datalib when the metadata is missing.

### Internals

- Handle timezone-aware timestamps in met datalibs.

### Breaking changes

- Expose the maximum Mach number buffer applied in `PSFlight` via a new `AircraftPerformanceParams.max_mach_buffer` parameter. Previously this was hard-coded to 0.02. The default value has now changed from 0.02 to 0.0. With this new default, downstream users should expect a small change in `PSFlight` fuel flow estimates (typically a decrease) when working with noisy ADS-B. Set this to 0.02 to retain previous behavior.
- Change the `fl.attrs["aircraft_performance_model"]` value from `"PSFlight"` to `"PS"` when the `PSFlight` model is used for consistency with `BADAFlight`.
- Rename the function arguments `max_takeoff_weight` -> `amass_mtow` and `operating_empty_weight` -> `amass_oew` in `jet.update_aircraft_mass` and `jet.initial_aircraft_mass`. This is to standardize the naming convention for aircraft mass parameters across pycontrails. Typically these functions are not called directly so the risk that downstream code is affected by this change is low.


## Tests

- [ ] QC test passes locally (`make test`)
- [ ] CI tests pass

## Reviewer

> Select @ reviewer
