### PR TITLE
Bug/radiative heating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.63.1 [Unreleased]
+
+### Fixes
+
+- Fix a `Cocip` radiative heating bug introduced in v0.61.0 in which the minimum `w_prime` value was accidentally squared, before being squared again when calculating `d_v`. While the effect of this bug was significant, it only occurred when the `radiative_heating_effects` parameter was enabled (disabled by default).
+
 ## 0.63.0
 
 ### Features

--- a/pycontrails/models/cocip/contrail_properties.py
+++ b/pycontrails/models/cocip/contrail_properties.py
@@ -978,10 +978,16 @@ def vertical_diffusivity(
 
     The first term in Eq. (35) of :cite:`schumannContrailCirrusPrediction2012` is
     (c_V * w'_N^2 / N_BV, where c_V = 0.2 and w'_N = 0.1 m s-1) is different
-    than outlined below. Here, a turbulent vertical velocity scale (provided as input) is used
-    directly (without scaling by c_V) when radiative heating effects are not activated
-    We currently recommend setting the turbulent vertical velocity scale to 0.1 m s^{-1} based
-    on guidance from :cite:`schumannAviationinducedCirrusRadiation2013`,
+    than outlined below.
+
+    Previously, the c_V = 0.2 term was included in Eq. (35) of
+    :cite:`schumannContrailCirrusPrediction2012`. However, this was removed in
+    :cite:`schumannAviationinducedCirrusRadiation2013` as described in Paragraph 27, meaning that
+    the vertical diffusivity is enhanced by a factor of 5.
+
+    Here, a turbulent vertical velocity scale (provided as input) is used directly when radiative
+    heating effects are not activated. We recommend setting the turbulent vertical velocity scale
+    to 0.1 m s^{-1} based on Eq. (35) of :cite:`schumannContrailCirrusPrediction2012`,
     which found that the original formulation estimated thinner
     contrails relative to satellite observations. The recommended value produces
     simulated contrails are more consistent with observations.
@@ -992,12 +998,13 @@ def vertical_diffusivity(
     n_bv = thermo.brunt_vaisala_frequency(air_pressure, air_temperature, dT_dz)
     n_bv.clip(min=0.001, out=n_bv)
 
+    # Vertical diffusivity is enhanced further as radiative heating causes convective instability
     w_prime: npt.NDArray[np.floating] | float
     if eff_heat_rate is not None:
         w_prime = radiative_heating.convective_velocity_scale(
             depth_eff, eff_heat_rate, air_temperature
         )
-        w_prime.clip(min=0.01, out=w_prime)
+        w_prime.clip(min=turbulent_vertical_velocity_scale, out=w_prime)
     else:
         w_prime = turbulent_vertical_velocity_scale
 

--- a/tests/unit/test_cocip.py
+++ b/tests/unit/test_cocip.py
@@ -1684,14 +1684,14 @@ def test_radiative_heating_effects_param(fl: Flight, met: MetDataset, rad: MetDa
 
     # Pretty massive difference in EF
     assert fl1["ef"].sum() == pytest.approx(7.3e12, rel=0.1)
-    assert fl2["ef"].sum() == pytest.approx(3.8e12, rel=0.1)
+    assert fl2["ef"].sum() == pytest.approx(4.1e12, rel=0.1)
 
     # Not nonzero in the same places!
     filt1 = fl1["ef"] != 0
     filt2 = fl2["ef"] != 0
     assert np.all(filt1 >= filt2)
     assert filt1.sum() == 10
-    assert filt2.sum() == 9
+    assert filt2.sum() == 8
 
 
 def test_radiative_heating_effects():


### PR DESCRIPTION
Closes #XX

## Changes

Bug fix -> Radiative heating module

#### Breaking changes

#### Features

#### Fixes

- Fix radiative heating bug that was introduced in v0.61.0, where the minimum `w_prime` value was accidentally squared, and then squared again when calculating `d_v`. 

- Updated docstring to improve clarity. 

#### Internals

## Tests

- [ ] QC test passes locally (`make test`)
- [ ] CI tests pass

## Reviewer

> Select @ reviewer
