### PR TITLE
Met utils dims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,10 @@
 
 ## 0.63.1 [Unreleased]
 
-### Features
-
-- Support extrapolation in model-level-to-pressure-level interpolation
-  (ml\_to\_pl)
 ### Fixes
 
 - Fix a `Cocip` radiative heating bug introduced in v0.61.0 in which the minimum `w_prime` value was accidentally squared, before being squared again when calculating `d_v`. While the effect of this bug was significant, it only occurred when the `radiative_heating_effects` parameter was enabled (disabled by default).
-- `pycontrailsmdataset.met_utils.ml_to_pl` handles cases where dataset dimension
-  order is different from variable dimension order.
+- Ensure `met_utils.ml_to_pl` handles cases where dataset dimension order is different from variable dimension order.
 
 ## 0.63.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.63.1 [Unreleased]
 
+### Features
+
+- Support extrapolation in model-level-to-pressure-level interpolation
+  (ml\_to\_pl)
 ### Fixes
 
 - Fix a `Cocip` radiative heating bug introduced in v0.61.0 in which the minimum `w_prime` value was accidentally squared, before being squared again when calculating `d_v`. While the effect of this bug was significant, it only occurred when the `radiative_heating_effects` parameter was enabled (disabled by default).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 ### Fixes
 
 - Fix a `Cocip` radiative heating bug introduced in v0.61.0 in which the minimum `w_prime` value was accidentally squared, before being squared again when calculating `d_v`. While the effect of this bug was significant, it only occurred when the `radiative_heating_effects` parameter was enabled (disabled by default).
+- `pycontrailsmdataset.met_utils.ml_to_pl` handles cases where dataset dimension
+  order is different from variable dimension order.
 
 ## 0.63.0
 

--- a/pycontrails/datalib/met_utils.py
+++ b/pycontrails/datalib/met_utils.py
@@ -1,6 +1,7 @@
 """Tooling and support for meteorology data."""
 
 import warnings
+from collections.abc import Hashable
 
 import dask.array
 import numpy as np
@@ -101,7 +102,7 @@ def _interp_on_chunk(
 
 
 def _build_template(
-    ds: xr.Dataset, target_pl: npt.NDArray[np.floating], dimension_order: list[str]
+    ds: xr.Dataset, target_pl: npt.NDArray[np.floating], dimension_order: list[Hashable]
 ) -> xr.Dataset:
     """Build the template dataset for the interpolated data."""
     coords = {k: ds.coords[k] for k in dimension_order if k != "model_level"} | {"level": target_pl}
@@ -178,7 +179,7 @@ def ml_to_pl(ds: xr.Dataset, target_pl: npt.ArrayLike, extrapolate: bool = False
     # IMPORTANT: model_level must be the last dimension for _interp_on_chunk
     ds = ds.transpose(..., "model_level")
 
-    dimension_order = None
+    dimension_order: list[Hashable] = []
     for name, da in ds.items():
         if not dimension_order:
             dimension_order = list(da.dims)

--- a/pycontrails/datalib/met_utils.py
+++ b/pycontrails/datalib/met_utils.py
@@ -185,7 +185,7 @@ def ml_to_pl(ds: xr.Dataset, target_pl: npt.ArrayLike, extrapolate: bool = False
             dimension_order = list(da.dims)
         elif list(da.dims) != dimension_order:
             msg = (
-                f"Variable {name} have inconsistent dimension orders "
+                f"Variable {name} have inconsistent dimension orders: "
                 f"{list(da.dims)} vs {dimension_order}"
             )
             raise ValueError(msg)

--- a/pycontrails/datalib/met_utils.py
+++ b/pycontrails/datalib/met_utils.py
@@ -100,9 +100,11 @@ def _interp_on_chunk(
     return xr.Dataset(interped_dict)
 
 
-def _build_template(ds: xr.Dataset, target_pl: npt.NDArray[np.floating]) -> xr.Dataset:
+def _build_template(
+    ds: xr.Dataset, target_pl: npt.NDArray[np.floating], dimension_order: list[str]
+) -> xr.Dataset:
     """Build the template dataset for the interpolated data."""
-    coords = {k: ds.coords[k] for k in ds.dims if k != "model_level"} | {"level": target_pl}
+    coords = {k: ds.coords[k] for k in dimension_order if k != "model_level"} | {"level": target_pl}
 
     dims = tuple(coords)
     shape = tuple(len(v) for v in coords.values())
@@ -176,6 +178,17 @@ def ml_to_pl(ds: xr.Dataset, target_pl: npt.ArrayLike, extrapolate: bool = False
     # IMPORTANT: model_level must be the last dimension for _interp_on_chunk
     ds = ds.transpose(..., "model_level")
 
+    dimension_order = None
+    for name, da in ds.items():
+        if not dimension_order:
+            dimension_order = list(da.dims)
+        elif list(da.dims) != dimension_order:
+            msg = (
+                f"Variable {name} have inconsistent dimension orders "
+                f"{list(da.dims)} vs {dimension_order}"
+            )
+            raise ValueError(msg)
+
     # Raise if chunks over model level
     if ds.chunks and len(ds.chunks["model_level"]) > 1:
         msg = "The 'model_level' dimension must not be split across chunks"
@@ -183,6 +196,6 @@ def ml_to_pl(ds: xr.Dataset, target_pl: npt.ArrayLike, extrapolate: bool = False
 
     target_pl = np.asarray(target_pl, dtype=ds["pressure_level"].dtype)
     target_pl = np.atleast_1d(target_pl).ravel()
-    template = _build_template(ds, target_pl)
+    template = _build_template(ds, target_pl, dimension_order)
 
     return xr.map_blocks(_interp_on_chunk, ds, (target_pl, extrapolate), template=template)


### PR DESCRIPTION
#### Fixes

- `pycontrailsmdataset.met_utils.ml_to_pl` handles cases where dataset dimension
  order is different from variable dimension order. confusingly xarray does not do a good job keeping these in sync. transpose() for instance changes the variable order but not the dataset order. The ds.assign call in model_levels.ml_to_pl can also do weird things to the dataset dimension order

#### Internals

## Tests

- [X] QC test passes locally (`make test`)
- [X] CI tests pass

## Reviewer

@zebengberg 
