### PR TITLE
Use turbulent vertical velocity scale from model params in downwash vortex calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fix a `Cocip` radiative heating bug introduced in v0.61.0 in which the minimum `w_prime` value was accidentally squared, before being squared again when calculating `d_v`. While the effect of this bug was significant, it only occurred when the `radiative_heating_effects` parameter was enabled (disabled by default).
 - Ensure `met_utils.ml_to_pl` handles cases where dataset dimension order is different from variable dimension order.
+- Pass user-provided `turbulent_vertical_velocity_scale` parameter through to vortex downwash calculations in `Cocip` and `CocipGrid`.
 
 ## 0.63.0
 

--- a/pycontrails/models/cocip/cocip.py
+++ b/pycontrails/models/cocip/cocip.py
@@ -875,6 +875,7 @@ class Cocip(Model):
             air_pressure,
             effective_vertical_resolution=self.params["effective_vertical_resolution"],
             wind_shear_enhancement_exponent=self.params["wind_shear_enhancement_exponent"],
+            turbulent_vertical_velocity_scale=self.params["turbulent_vertical_velocity_scale"],
         )
 
         # derive downwash values and save to data model

--- a/pycontrails/models/cocip/wake_vortex.py
+++ b/pycontrails/models/cocip/wake_vortex.py
@@ -40,6 +40,7 @@ def max_downward_displacement(
     air_pressure: npt.NDArray[np.floating],
     effective_vertical_resolution: float,
     wind_shear_enhancement_exponent: npt.NDArray[np.floating] | float,
+    turbulent_vertical_velocity_scale: npt.NDArray[np.floating] | float,
 ) -> npt.NDArray[np.floating]:
     """
     Calculate the maximum contrail downward displacement after the wake vortex phase.
@@ -64,6 +65,8 @@ def max_downward_displacement(
         Passed through to :func:`wind_shear.wind_shear_enhancement_factor`, [:math:`m`]
     wind_shear_enhancement_exponent: npt.NDArray[np.floating] | float
         Passed through to :func:`wind_shear.wind_shear_enhancement_factor`
+    turbulent_vertical_velocity_scale : npt.NDArray[np.floating] | float
+        Passed through to :func:`turbulent_kinetic_energy_dissipation_rate`, [:math:`m s^{-1}`]
 
     Returns
     -------
@@ -100,6 +103,7 @@ def max_downward_displacement(
         t_0=t_0[is_weakly_stratified],
         effective_vertical_resolution=effective_vertical_resolution,
         wind_shear_enhancement_exponent=wind_shear_enhancement_exponent,
+        turbulent_vertical_velocity_scale=turbulent_vertical_velocity_scale,
     )
 
     dz_max_strong[is_weakly_stratified] = dz_max_weak
@@ -194,6 +198,7 @@ def downward_displacement_weakly_stratified(
     t_0: npt.NDArray[np.floating],
     effective_vertical_resolution: float,
     wind_shear_enhancement_exponent: npt.NDArray[np.floating] | float,
+    turbulent_vertical_velocity_scale: npt.NDArray[np.floating] | float,
 ) -> npt.NDArray[np.floating]:
     """
     Calculate the maximum contrail downward displacement under weakly/stably stratified conditions.
@@ -220,6 +225,8 @@ def downward_displacement_weakly_stratified(
         Passed through to :func:`wind_shear.wind_shear_enhancement_factor`, [:math:`m`]
     wind_shear_enhancement_exponent: npt.NDArray[np.floating] | float
         Passed through to :func:`wind_shear.wind_shear_enhancement_factor`
+    turbulent_vertical_velocity_scale : npt.NDArray[np.floating] | float
+        Passed through to :func:`turbulent_kinetic_energy_dissipation_rate`, [:math:`m s^{-1}`]
 
     Returns
     -------
@@ -242,7 +249,9 @@ def downward_displacement_weakly_stratified(
 
     # Calculate epsilon and epsilon star
     # In Schumann's Fortran code, epsn = EDR and epsn_st = EPSN
-    epsn = turbulent_kinetic_energy_dissipation_rate(ds_dz, shear_enhancement_factor)
+    epsn = turbulent_kinetic_energy_dissipation_rate(
+        ds_dz, shear_enhancement_factor, turbulent_vertical_velocity_scale
+    )
     epsn_st = normalized_dissipation_rate(epsn, wingspan, true_airspeed, aircraft_mass, rho_air)
     return b_0 * (7.68 * (1 - 4.07 * epsn_st + 5.67 * epsn_st**2) * (0.79 - n_bv * t_0) + 1.88)
 
@@ -269,6 +278,7 @@ def wake_vortex_separation(
 def turbulent_kinetic_energy_dissipation_rate(
     ds_dz: npt.NDArray[np.floating],
     shear_enhancement_factor: npt.NDArray[np.floating] | float = 1.0,
+    turbulent_vertical_velocity_scale: npt.NDArray[np.floating] | float = 0.1,
 ) -> npt.NDArray[np.floating]:
     """
     Calculate the turbulent kinetic energy dissipation rate (epsilon).
@@ -281,6 +291,8 @@ def turbulent_kinetic_energy_dissipation_rate(
         Difference in wind speed over dz in the atmosphere, [:math:`m s^{-1} / m`]
     shear_enhancement_factor : npt.NDArray[np.floating] | float
         Multiplication factor to enhance the wind shear
+    turbulent_vertical_velocity_scale : npt.NDArray[np.floating] | float
+        Turbulent vertical velocity scale, [:math:`m s^{-1}`]
 
     Returns
     -------
@@ -299,7 +311,7 @@ def turbulent_kinetic_energy_dissipation_rate(
     - :cite:`schumannContrailCirrusPrediction2012`
     - :cite:`schumannTurbulentMixingStably1995`
     """
-    return 0.5 * 0.1**2 * (ds_dz * shear_enhancement_factor**2)
+    return 0.5 * turbulent_vertical_velocity_scale**2 * (ds_dz * shear_enhancement_factor**2)
 
 
 def normalized_dissipation_rate(

--- a/pycontrails/models/cocipgrid/cocip_grid.py
+++ b/pycontrails/models/cocipgrid/cocip_grid.py
@@ -1377,6 +1377,7 @@ def simulate_wake_vortex_downwash(
     T_crit_sac = vector["T_crit_sac"]
 
     wsee = _get_source_param_override("wind_shear_enhancement_exponent", vector, params)
+    wn = _get_source_param_override("turbulent_vertical_velocity_scale", vector, params)
     wingspan = _get_source_param_override("wingspan", vector, params)
     aircraft_mass = _get_source_param_override("aircraft_mass", vector, params)
 
@@ -1390,6 +1391,7 @@ def simulate_wake_vortex_downwash(
         air_pressure=air_pressure,
         effective_vertical_resolution=params["effective_vertical_resolution"],
         wind_shear_enhancement_exponent=wsee,
+        turbulent_vertical_velocity_scale=wn,
     )
 
     width = wake_vortex.initial_contrail_width(wingspan, dz_max)


### PR DESCRIPTION
Under weakly stratified conditions, the vortex downwash calculation used by CoCiP depends on the assumed turbulent vertical velocity scale (see eq. 37 of [Schumann 2012](https://doi.org/10.5194/gmd-5-543-2012)). This PR updates the vortex downwash calculation to use the user-provided vertical velocity scale rather than the default value of 0.1 m/s.

Thanks to Jin Maruhashi for suggesting this change.

## Changes

#### Fixes

- Pass user-provided `turbulent_vertical_velocity_scale` parameter through to vortex downwash calculations in `Cocip` and `CocipGrid`.

## Tests

- [x] QC test passes locally (`make test`)
- [x] CI tests pass

## Reviewer

> @zebengberg 
