### PR TITLE
Bug/emissions units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.63.2
+
+### Fixes
+
+- Fix unit conversion bug identified in `nvpm_ei_m` estimates when SCOPE11 is used. This does not affect the downstream simulated contrail properties and forcing estimates.
+
+### Internals
+
+- Refactor emissions functions so that SI units are used throughout computations. This ensures consistency and prevents future unit conversion bugs.
+
 ## 0.63.1
 
 ### Breaking changes

--- a/pycontrails/models/emissions/emissions.py
+++ b/pycontrails/models/emissions/emissions.py
@@ -1124,7 +1124,21 @@ def load_edb_nvpm_database() -> dict[str, nvpm.EDBnvpm]:
         "nvPM EInum Max (#/kg)": "nvpm_ei_n_no_sl_max",
     }
 
+    nvpm_mass_cols = [
+        "nvPM EImass_SL Idle (mg/kg)",
+        "nvPM EImass_SL App (mg/kg)",
+        "nvPM EImass_SL C/O (mg/kg)",
+        "nvPM EImass_SL T/O (mg/kg)",
+        "nvPM EImass App (mg/kg)",
+        "nvPM EImass C/O (mg/kg)",
+        "nvPM EImass Max (mg/kg)",
+    ]
+
     df = pd.read_csv(EDB_NVPM_PATH)
+
+    # Convert nvPM mass EI from mg/kg to kg/kg
+    df[nvpm_mass_cols] *= 1e-6
+
     df = df.rename(columns=columns)
     df = df.astype({"nvpm_ei_m_use_max": bool, "nvpm_ei_n_use_max": bool})
     return dict(_row_to_edb_nvpm(tup) for tup in df.itertuples(index=False))

--- a/pycontrails/models/emissions/emissions.py
+++ b/pycontrails/models/emissions/emissions.py
@@ -917,7 +917,7 @@ def nvpm_mass_emissions_index_sac(
         fuel_flow_per_engine, thrust_setting, hydrogen_content
     )
     nvpm_ei_m = 0.5 * (0.8 * nvpm_ei_m_fox + 1.5 * nvpm_ei_m_imfox)
-    return nvpm_ei_m * 1e-6  # mg-nvPM/kg-fuel to kg-nvPM/kg-fuel
+    return nvpm_ei_m
 
 
 def nvpm_geometric_mean_diameter_sac(

--- a/pycontrails/models/emissions/emissions.py
+++ b/pycontrails/models/emissions/emissions.py
@@ -960,7 +960,7 @@ def nvpm_geometric_mean_diameter_sac(
         q_fuel,
         cruise=True,
     )
-    return nvpm_gmd * 1e-9  # nm to m
+    return nvpm_gmd
 
 
 def get_thrust_setting(

--- a/pycontrails/models/emissions/emissions.py
+++ b/pycontrails/models/emissions/emissions.py
@@ -274,7 +274,6 @@ class Emissions(Model):
                 air_temperature,
                 self.source["specific_humidity"],
             )
-            * 1e-3  # g-NOx/kg-fuel to kg-NOx/kg-fuel
         )
 
         self.source["co_ei"] = (
@@ -285,7 +284,6 @@ class Emissions(Model):
                 self.source.air_pressure,
                 air_temperature,
             )
-            * 1e-3  # g-CO/kg-fuel to kg-CO/kg-fuel
         )
 
         self.source["hc_ei"] = (
@@ -296,7 +294,6 @@ class Emissions(Model):
                 self.source.air_pressure,
                 air_temperature,
             )
-            * 1e-3  # g-HC/kg-fuel to kg-HC/kg-fuel
         )
 
     def _gaseous_emissions_constant(self) -> None:
@@ -322,13 +319,14 @@ class Emissions(Model):
         """
         self.source.attrs["gaseous_data_source"] = "Constant"
 
-        nox_ei = np.full(shape=len(self.source), fill_value=15.14, dtype=np.float32)
-        co_ei = np.full(shape=len(self.source), fill_value=3.61, dtype=np.float32)
-        hc_ei = np.full(shape=len(self.source), fill_value=0.520, dtype=np.float32)
+        # Units of NOx, CO, and HC EI: kg/kg fuel
+        nox_ei = np.full(shape=len(self.source), fill_value=(15.14 * 1e-3), dtype=np.float32)
+        co_ei = np.full(shape=len(self.source), fill_value=(3.61 * 1e-3), dtype=np.float32)
+        hc_ei = np.full(shape=len(self.source), fill_value=(0.520 * 1e-3), dtype=np.float32)
 
-        self.source["nox_ei"] = nox_ei * 1e-3  # g-NOx/kg-fuel to kg-NOx/kg-fuel
-        self.source["co_ei"] = co_ei * 1e-3  # g-CO/kg-fuel to kg-CO/kg-fuel
-        self.source["hc_ei"] = hc_ei * 1e-3  # g-HC/kg-fuel to kg-HC/kg-fuel
+        self.source["nox_ei"] = nox_ei
+        self.source["co_ei"] = co_ei
+        self.source["hc_ei"] = hc_ei
 
     def _nvpm_emission_indices_gaia_workflow(self, engine_uid: str | None) -> None:
         """Calculate nvPM mass and number emission indices using the GAIA workflow.
@@ -498,7 +496,7 @@ class Emissions(Model):
             combustor=edb_nvpm.combustor,
             temp_min=edb_nvpm.temp_min,
             temp_max=edb_nvpm.temp_max,
-            q_fuel=edb_nvpm.fuel_heat * 1e6,
+            q_fuel=edb_nvpm.fuel_heat,
             ff_7=edb_nvpm.ff_7,
             ff_30=edb_nvpm.ff_30,
             ff_85=edb_nvpm.ff_85,
@@ -824,7 +822,9 @@ class Emissions(Model):
         - :cite:`schumannDehydrationEffectsContrails2015`
         """
         nvpm_data_source = "Constant"
-        nvpm_ei_m = np.full(len(self.source), 0.088 * 1e-3, dtype=np.float32)  # g to kg
+
+        # Units of nvPM mass EI: kg/kg fuel
+        nvpm_ei_m = np.full(len(self.source), fill_value=(0.088 * 1e-3), dtype=np.float32)
         nvpm_ei_n = np.full(len(self.source), self.params["default_nvpm_ei_n"], dtype=np.float32)
 
         # Adjust for fuel hydrogen content
@@ -1067,9 +1067,25 @@ def load_edb_gaseous_database() -> dict[str, gaseous.EDBGaseous]:
     df["pressure_min"] = df["pressure_min"].fillna(fill_pressure)
     df["pressure_max"] = df["pressure_max"].fillna(fill_pressure)
 
-    # Convert ambient pressure from kPa to Pa
-    df["pressure_min"] = df["pressure_min"] * 1000.0
-    df["pressure_max"] = df["pressure_max"] * 1000.0
+    # Convert units in ICAO EDB to standardised SI units
+    gaseous_ei_cols = [
+        "ei_nox_7",
+        "ei_nox_30",
+        "ei_nox_85",
+        "ei_nox_100",
+        "ei_co_7",
+        "ei_co_30",
+        "ei_co_85",
+        "ei_co_100",
+        "ei_hc_7",
+        "ei_hc_30",
+        "ei_hc_85",
+        "ei_hc_100",
+    ]
+    df[gaseous_ei_cols] *= 1e-3     # g/kg to kg/kg
+
+    df["pressure_min"] = df["pressure_min"] * 1000.0    # kPa to Pa
+    df["pressure_max"] = df["pressure_max"] * 1000.0    # kPa to Pa
 
     return dict(_row_to_edb_gaseous(tup) for tup in df.itertuples(index=False))
 
@@ -1124,23 +1140,23 @@ def load_edb_nvpm_database() -> dict[str, nvpm.EDBnvpm]:
         "nvPM EInum Max (#/kg)": "nvpm_ei_n_no_sl_max",
     }
 
-    nvpm_mass_cols = [
-        "nvPM EImass_SL Idle (mg/kg)",
-        "nvPM EImass_SL App (mg/kg)",
-        "nvPM EImass_SL C/O (mg/kg)",
-        "nvPM EImass_SL T/O (mg/kg)",
-        "nvPM EImass App (mg/kg)",
-        "nvPM EImass C/O (mg/kg)",
-        "nvPM EImass Max (mg/kg)",
+    df = pd.read_csv(EDB_NVPM_PATH).rename(columns=columns)
+    df = df.astype({"nvpm_ei_m_use_max": bool, "nvpm_ei_n_use_max": bool})
+
+    # Convert units in ICAO EDB to standardised SI units
+    df["fuel_heat"] *= 1e6    # MJ/kg to J/kg
+
+    nvpm_mass_ei_cols = [
+        "nvpm_ei_m_7",
+        "nvpm_ei_m_30",
+        "nvpm_ei_m_85",
+        "nvpm_ei_m_100",
+        "nvpm_ei_m_no_sl_30",
+        "nvpm_ei_m_no_sl_85",
+        "nvpm_ei_m_no_sl_max",
     ]
 
-    df = pd.read_csv(EDB_NVPM_PATH)
-
-    # Convert nvPM mass EI from mg/kg to kg/kg
-    df[nvpm_mass_cols] *= 1e-6
-
-    df = df.rename(columns=columns)
-    df = df.astype({"nvpm_ei_m_use_max": bool, "nvpm_ei_n_use_max": bool})
+    df[nvpm_mass_ei_cols] *= 1e-6  # mg/kg to kg/kg
     return dict(_row_to_edb_nvpm(tup) for tup in df.itertuples(index=False))
 
 

--- a/pycontrails/models/emissions/emissions.py
+++ b/pycontrails/models/emissions/emissions.py
@@ -204,7 +204,7 @@ class Emissions(Model):
             try:
                 edb_gaseous = self.edb_engine_gaseous[engine_uid]  # type: ignore[index]
             except KeyError:
-                self.source["thrust_setting"] = np.full(len(self.source), np.nan, dtype=np.float32)
+                self.source["thrust_setting"] = np.full(self.source.size, np.nan, dtype=np.float32)
             else:
                 self.source["thrust_setting"] = get_thrust_setting(
                     edb_gaseous,
@@ -265,35 +265,29 @@ class Emissions(Model):
         air_temperature = self.source["air_temperature"]
 
         # Emissions indices
-        self.source["nox_ei"] = (
-            gaseous.estimate_nox_ffm2(
-                edb_gaseous.log_ei_nox_profile,
-                fuel_flow_per_engine,
-                true_airspeed,
-                self.source.air_pressure,
-                air_temperature,
-                self.source["specific_humidity"],
-            )
+        self.source["nox_ei"] = gaseous.estimate_nox_ffm2(
+            edb_gaseous.log_ei_nox_profile,
+            fuel_flow_per_engine,
+            true_airspeed,
+            self.source.air_pressure,
+            air_temperature,
+            self.source["specific_humidity"],
         )
 
-        self.source["co_ei"] = (
-            gaseous.estimate_ei_co_hc_ffm2(
-                edb_gaseous.log_ei_co_profile,
-                fuel_flow_per_engine,
-                true_airspeed,
-                self.source.air_pressure,
-                air_temperature,
-            )
+        self.source["co_ei"] = gaseous.estimate_ei_co_hc_ffm2(
+            edb_gaseous.log_ei_co_profile,
+            fuel_flow_per_engine,
+            true_airspeed,
+            self.source.air_pressure,
+            air_temperature,
         )
 
-        self.source["hc_ei"] = (
-            gaseous.estimate_ei_co_hc_ffm2(
-                edb_gaseous.log_ei_hc_profile,
-                fuel_flow_per_engine,
-                true_airspeed,
-                self.source.air_pressure,
-                air_temperature,
-            )
+        self.source["hc_ei"] = gaseous.estimate_ei_co_hc_ffm2(
+            edb_gaseous.log_ei_hc_profile,
+            fuel_flow_per_engine,
+            true_airspeed,
+            self.source.air_pressure,
+            air_temperature,
         )
 
     def _gaseous_emissions_constant(self) -> None:
@@ -320,9 +314,9 @@ class Emissions(Model):
         self.source.attrs["gaseous_data_source"] = "Constant"
 
         # Units of NOx, CO, and HC EI: kg/kg fuel
-        nox_ei = np.full(shape=len(self.source), fill_value=(15.14 * 1e-3), dtype=np.float32)
-        co_ei = np.full(shape=len(self.source), fill_value=(3.61 * 1e-3), dtype=np.float32)
-        hc_ei = np.full(shape=len(self.source), fill_value=(0.520 * 1e-3), dtype=np.float32)
+        nox_ei = np.full(shape=self.source.size, fill_value=15.14 * 1e-3, dtype=np.float32)
+        co_ei = np.full(shape=self.source.size, fill_value=3.61 * 1e-3, dtype=np.float32)
+        hc_ei = np.full(shape=self.source.size, fill_value=0.520 * 1e-3, dtype=np.float32)
 
         self.source["nox_ei"] = nox_ei
         self.source["co_ei"] = co_ei
@@ -824,8 +818,8 @@ class Emissions(Model):
         nvpm_data_source = "Constant"
 
         # Units of nvPM mass EI: kg/kg fuel
-        nvpm_ei_m = np.full(len(self.source), fill_value=(0.088 * 1e-3), dtype=np.float32)
-        nvpm_ei_n = np.full(len(self.source), self.params["default_nvpm_ei_n"], dtype=np.float32)
+        nvpm_ei_m = np.full(self.source.size, fill_value=0.088 * 1e-3, dtype=np.float32)
+        nvpm_ei_n = np.full(self.source.size, self.params["default_nvpm_ei_n"], dtype=np.float32)
 
         # Adjust for fuel hydrogen content
         thrust_setting = self.source["thrust_setting"]
@@ -916,51 +910,7 @@ def nvpm_mass_emissions_index_sac(
     nvpm_ei_m_imfox = nvpm.mass_emissions_index_imfox(
         fuel_flow_per_engine, thrust_setting, hydrogen_content
     )
-    nvpm_ei_m = 0.5 * (0.8 * nvpm_ei_m_fox + 1.5 * nvpm_ei_m_imfox)
-    return nvpm_ei_m
-
-
-def nvpm_geometric_mean_diameter_sac(
-    edb_gaseous: gaseous.EDBGaseous,
-    air_pressure: npt.NDArray[np.floating],
-    true_airspeed: npt.NDArray[np.floating],
-    air_temperature: npt.NDArray[np.floating],
-    thrust_setting: npt.NDArray[np.floating],
-    q_fuel: float,
-) -> npt.NDArray[np.floating]:
-    r"""
-    Estimate nvPM geometric mean diameter for singular annular combustor (SAC) engines.
-
-    Parameters
-    ----------
-    edb_gaseous : EDBGaseous
-        EDB gaseous data
-    air_pressure: npt.NDArray[np.floating]
-        pressure altitude at each waypoint, [:math:`Pa`]
-    true_airspeed: npt.NDArray[np.floating]
-        true airspeed for each waypoint, [:math:`m s^{-1}`]
-    air_temperature: npt.NDArray[np.floating]
-        ambient temperature for each waypoint, [:math:`K`]
-    thrust_setting : npt.NDArray[np.floating]
-        thrust setting
-    q_fuel : float
-        Lower calorific value (LCV) of fuel, [:math:`J \ kg_{fuel}^{-1}`].
-
-    Returns
-    -------
-    npt.NDArray[np.floating]
-        nvPM geometric mean diameter, [:math:`m`]
-    """
-    nvpm_gmd = nvpm.geometric_mean_diameter_sac(
-        air_pressure,
-        air_temperature,
-        true_airspeed,
-        thrust_setting,
-        edb_gaseous.pressure_ratio,
-        q_fuel,
-        cruise=True,
-    )
-    return nvpm_gmd
+    return 0.5 * (0.8 * nvpm_ei_m_fox + 1.5 * nvpm_ei_m_imfox)
 
 
 def get_thrust_setting(
@@ -1082,10 +1032,10 @@ def load_edb_gaseous_database() -> dict[str, gaseous.EDBGaseous]:
         "ei_hc_85",
         "ei_hc_100",
     ]
-    df[gaseous_ei_cols] *= 1e-3     # g/kg to kg/kg
+    df[gaseous_ei_cols] *= 1e-3  # g/kg to kg/kg
 
-    df["pressure_min"] = df["pressure_min"] * 1000.0    # kPa to Pa
-    df["pressure_max"] = df["pressure_max"] * 1000.0    # kPa to Pa
+    pressure_cols = ["pressure_min", "pressure_max"]
+    df[pressure_cols] *= 1e3  # kPa to Pa
 
     return dict(_row_to_edb_gaseous(tup) for tup in df.itertuples(index=False))
 
@@ -1144,7 +1094,7 @@ def load_edb_nvpm_database() -> dict[str, nvpm.EDBnvpm]:
     df = df.astype({"nvpm_ei_m_use_max": bool, "nvpm_ei_n_use_max": bool})
 
     # Convert units in ICAO EDB to standardised SI units
-    df["fuel_heat"] *= 1e6    # MJ/kg to J/kg
+    df["fuel_heat"] *= 1e6  # MJ/kg to J/kg
 
     nvpm_mass_ei_cols = [
         "nvpm_ei_m_7",

--- a/pycontrails/models/emissions/emissions.py
+++ b/pycontrails/models/emissions/emissions.py
@@ -892,7 +892,7 @@ def nvpm_mass_emissions_index_sac(
     fuel_flow_per_engine: npt.NDArray[np.floating]
         fuel mass flow rate per engine, [:math:`kg s^{-1}`]
     hydrogen_content : float
-        Engine unique identification number from the ICAO EDB
+        The percentage of hydrogen mass content in the fuel.
 
     Returns
     -------

--- a/pycontrails/models/emissions/gaseous.py
+++ b/pycontrails/models/emissions/gaseous.py
@@ -64,31 +64,31 @@ class EDBGaseous:
     EMISSIONS:
     -------------------------------------
     ei_nox_7: float
-        NOx emissions index at 7% thrust setting, [:math:`g_{NO_{X}}/kg_{fuel}`]
+        NOx emissions index at 7% thrust setting, [:math:`kg_{NO_{X}}/kg_{fuel}`]
     ei_nox_30: float
-        NOx emissions index at 30% thrust setting, [:math:`g_{NO_{X}}/kg_{fuel}`]
+        NOx emissions index at 30% thrust setting, [:math:`kg_{NO_{X}}/kg_{fuel}`]
     ei_nox_85: float
-        NOx emissions index at 85% thrust setting, [:math:`g_{NO_{X}}/kg_{fuel}`]
+        NOx emissions index at 85% thrust setting, [:math:`kg_{NO_{X}}/kg_{fuel}`]
     ei_nox_100: float
-        NOx emissions index at 100% thrust setting, [:math:`g_{NO_{X}}/kg_{fuel}`]
+        NOx emissions index at 100% thrust setting, [:math:`kg_{NO_{X}}/kg_{fuel}`]
 
     ei_co_7: float
-        CO emissions index at 7% thrust setting, [:math:`g_{CO}/kg_{fuel}`]
+        CO emissions index at 7% thrust setting, [:math:`kg_{CO}/kg_{fuel}`]
     ei_co_30: float
-        CO emissions index at 30% thrust setting, [:math:`g_{CO}/kg_{fuel}`]
+        CO emissions index at 30% thrust setting, [:math:`kg_{CO}/kg_{fuel}`]
     ei_co_85: float
-        CO emissions index at 85% thrust setting, [:math:`g_{CO}/kg_{fuel}`]
+        CO emissions index at 85% thrust setting, [:math:`kg_{CO}/kg_{fuel}`]
     ei_co_100: float
-        CO emissions index at 100% thrust setting, [:math:`g_{CO}/kg_{fuel}`]
+        CO emissions index at 100% thrust setting, [:math:`kg_{CO}/kg_{fuel}`]
 
     ei_hc_7: float
-        HC emissions index at 7% thrust setting, [:math:`g_{HC}/kg_{fuel}`]
+        HC emissions index at 7% thrust setting, [:math:`kg_{HC}/kg_{fuel}`]
     ei_hc_30: float
-        HC emissions index at 30% thrust setting, [:math:`g_{HC}/kg_{fuel}`]
+        HC emissions index at 30% thrust setting, [:math:`kg_{HC}/kg_{fuel}`]
     ei_hc_85: float
-        HC emissions index at 85% thrust setting, [:math:`g_{HC}/kg_{fuel}`]
+        HC emissions index at 85% thrust setting, [:math:`kg_{HC}/kg_{fuel}`]
     ei_hc_100: float
-        HC emissions index at 100% thrust setting, [:math:`g_{HC}/kg_{fuel}`]
+        HC emissions index at 100% thrust setting, [:math:`kg_{HC}/kg_{fuel}`]
 
     sn_7: float
         smoke number at 7% thrust setting
@@ -217,13 +217,13 @@ def nitrogen_oxide_emissions_index_profile_ffm2(
     ff_take_off: float
         ICAO EDB fuel mass flow rate at take-off (100% power), [:math:`kg s^{-1}`]
     ei_nox_idle: float
-        ICAO EDB NOx emissions index at idle conditions (7% power), [:math:`g_{NO_{X}}/kg_{fuel}`]
+        ICAO EDB NOx emissions index at idle conditions (7% power), [:math:`kg_{NO_{X}}/kg_{fuel}`]
     ei_nox_approach: float
-        ICAO EDB NOx emissions index at approach (30% power), [:math:`g_{NO_{X}}/kg_{fuel}`]
+        ICAO EDB NOx emissions index at approach (30% power), [:math:`kg_{NO_{X}}/kg_{fuel}`]
     ei_nox_climb: float
-        ICAO EDB NOx emissions index at climb out (85% power), [:math:`g_{NO_{X}}/kg_{fuel}`]
+        ICAO EDB NOx emissions index at climb out (85% power), [:math:`kg_{NO_{X}}/kg_{fuel}`]
     ei_nox_take_off: float
-        ICAO EDB NOx emissions index at take-off (100% power), [:math:`g_{NO_{X}}/kg_{fuel}`]
+        ICAO EDB NOx emissions index at take-off (100% power), [:math:`kg_{NO_{X}}/kg_{fuel}`]
 
     Returns
     -------
@@ -276,16 +276,16 @@ def co_hc_emissions_index_profile_ffm2(
         (100% power), [:math:`kg s^{-1}`]
     ei_idle: float
         ICAO EDB CO or HC emissions index at idle conditions
-        (7% power), [:math:`g_{pollutant}/kg_{fuel}`]
+        (7% power), [:math:`kg_{pollutant}/kg_{fuel}`]
     ei_approach: float
         ICAO EDB CO or HC emissions index at approach
-        (30% power), [:math:`g_{pollutant}/kg_{fuel}`]
+        (30% power), [:math:`kg_{pollutant}/kg_{fuel}`]
     ei_climb: float
         ICAO EDB CO or HC emissions index at climb out
-        (85% power), [:math:`g_{pollutant}/kg_{fuel}`]
+        (85% power), [:math:`kg_{pollutant}/kg_{fuel}`]
     ei_take_off: float
         ICAO EDB CO or HC emissions index at take-off
-        (100% power), [:math:`g_{pollutant}/kg_{fuel}`]
+        (100% power), [:math:`kg_{pollutant}/kg_{fuel}`]
 
     Returns
     -------
@@ -298,8 +298,8 @@ def co_hc_emissions_index_profile_ffm2(
     fuel_flow_edb *= installation_correction_factor
 
     ei_edb = np.array([ei_idle, ei_approach, ei_climb, ei_take_off], dtype=float)
-    min_vals_ = np.array([1e-3, 1e-3, 1e-4, 1e-4])
-    ei_edb = np.maximum(ei_edb, min_vals_)
+    min_vals = np.array([1e-6, 1e-6, 1e-7, 1e-7])
+    ei_edb = np.maximum(ei_edb, min_vals)
 
     # Get straight-line equation between idle and approach
     m, c = np.polyfit(fuel_flow_edb[:2], ei_edb[:2], deg=1)
@@ -308,9 +308,7 @@ def co_hc_emissions_index_profile_ffm2(
 
     ff_low_power = fuel_flow_edb[3] * 0.03
     ei_co_low_power = min((m * ff_low_power + c), (2 * ei_edb[0]))
-    ei_co_low_power = max(
-        ei_co_low_power, 1e-3
-    )  # Prevent zero/negative values, similar to line 115
+    ei_co_low_power = max(ei_co_low_power, 1e-6)  # Prevent zero/negative values
 
     # Permutation 1: Emissions profile when the bi-linear fit does not work
     # (Figure 14 of DuBois & Paynter, 2006)
@@ -367,6 +365,11 @@ def estimate_nox_ffm2(
         ambient temperature for each waypoint, [:math:`K`]
     specific_humidity: npt.NDArray[np.floating] | None
         specific humidity for each waypoint, [:math:`kg_{H_{2}O}/kg_{air}`]
+
+    Returns
+    -------
+    npt.NDArray[np.floating]
+        NOx emissions index, [:math:`kg_{NO_X}/kg_{fuel}`]
     """
 
     if specific_humidity is None:
@@ -407,6 +410,11 @@ def estimate_ei_co_hc_ffm2(
         pressure altitude at each waypoint, [:math:`Pa`]
     air_temperature : npt.NDArray[np.floating]
         ambient temperature for each waypoint, [:math:`K`]
+
+    Returns
+    -------
+    npt.NDArray[np.floating]
+        CO or HC emissions index, [:math:`kg_{pollutant}/kg_{fuel}`]
     """
     mach_num = units.tas_to_mach_number(true_airspeed, air_temperature)
     theta_amb = jet.temperature_ratio(air_temperature)

--- a/pycontrails/models/emissions/nvpm.py
+++ b/pycontrails/models/emissions/nvpm.py
@@ -920,10 +920,9 @@ def mass_emissions_index_fox(
         afr_ref=afr_ref,
     )
     q_exhaust_cru = exhaust_gas_volume_per_kg_fuel(afr_cru)
-    return convert_nvpm_mass_concentration_to_ei(
-        c_bc_cru, q_exhaust_cru
-    ) * 1e-6  # mg-nvPM/kg-fuel to kg-nvPM/kg-fuel
-
+    return (
+        convert_nvpm_mass_concentration_to_ei(c_bc_cru, q_exhaust_cru) * 1e-6
+    )  # mg-nvPM/kg-fuel to kg-nvPM/kg-fuel
 
 
 def flame_temperature(t_3: ArrayScalarLike) -> ArrayScalarLike:
@@ -1096,9 +1095,9 @@ def mass_emissions_index_imfox(
         fuel_flow_per_engine, afr_cru, t_4_cru, fuel_hydrogen=fuel_hydrogen
     )
     q_exhaust_cru = exhaust_gas_volume_per_kg_fuel(afr_cru)
-    return convert_nvpm_mass_concentration_to_ei(
-        c_bc_cru, q_exhaust_cru
-    ) * 1e-6  # mg-nvPM/kg-fuel to kg-nvPM/kg-fuel
+    return (
+        convert_nvpm_mass_concentration_to_ei(c_bc_cru, q_exhaust_cru) * 1e-6
+    )  # mg-nvPM/kg-fuel to kg-nvPM/kg-fuel
 
 
 def air_to_fuel_ratio_imfox(thrust_setting: npt.NDArray[np.floating]) -> npt.NDArray[np.floating]:

--- a/pycontrails/models/emissions/nvpm.py
+++ b/pycontrails/models/emissions/nvpm.py
@@ -272,7 +272,6 @@ def estimate_nvpm_t4_t2(
 
     # Interpolate nvPM EI_m and EI_n
     nvpm_ei_m = nvpm_ei_m_profile.interp(t4_t2)
-    nvpm_ei_m = nvpm_ei_m * 1e-6  # mg-nvPM/kg-fuel to kg-nvPM/kg-fuel
     nvpm_ei_n = nvpm_ei_n_profile.interp(t4_t2)
     return nvpm_ei_m, nvpm_ei_n
 
@@ -561,7 +560,6 @@ def estimate_nvpm_meem(
 
     # Interpolate nvPM EI_m for ground conditions
     nvpm_ei_m_sl = nvpm_ei_m_profile.interp(fuel_flow_per_engine)
-    nvpm_ei_m_sl = nvpm_ei_m_sl * 1e-6  # mg-nvPM/kg-fuel to kg-nvPM/kg-fuel
 
     # Interpolate nvPM EI_n for ground conditions
     nvpm_ei_n_sl = nvpm_ei_n_profile.interp(fuel_flow_per_engine)

--- a/pycontrails/models/emissions/nvpm.py
+++ b/pycontrails/models/emissions/nvpm.py
@@ -1227,7 +1227,7 @@ def geometric_mean_diameter_sac(
     Returns
     -------
     npt.NDArray[np.floating]
-        nvPM geometric mean diameter, [:math:`nm`]
+        nvPM geometric mean diameter, [:math:`m`]
 
     References
     ----------

--- a/pycontrails/models/emissions/nvpm.py
+++ b/pycontrails/models/emissions/nvpm.py
@@ -886,7 +886,7 @@ def mass_emissions_index_fox(
     Returns
     -------
     npt.NDArray[np.floating]
-        nvPM mass emissions index, [:math:`mg \ kg_{fuel}^{-1}`]
+        nvPM mass emissions index, [:math:`kg \ kg_{fuel}^{-1}`]
 
     References
     ----------
@@ -920,7 +920,10 @@ def mass_emissions_index_fox(
         afr_ref=afr_ref,
     )
     q_exhaust_cru = exhaust_gas_volume_per_kg_fuel(afr_cru)
-    return convert_nvpm_mass_concentration_to_ei(c_bc_cru, q_exhaust_cru)
+    return convert_nvpm_mass_concentration_to_ei(
+        c_bc_cru, q_exhaust_cru
+    ) * 1e-6  # mg-nvPM/kg-fuel to kg-nvPM/kg-fuel
+
 
 
 def flame_temperature(t_3: ArrayScalarLike) -> ArrayScalarLike:
@@ -1081,7 +1084,7 @@ def mass_emissions_index_imfox(
     Returns
     -------
     npt.NDArray[np.floating]
-        nvPM mass emissions index, [:math:`mg \ kg_{fuel}^{-1}`]
+        nvPM mass emissions index, [:math:`kg \ kg_{fuel}^{-1}`]
 
     References
     ----------
@@ -1093,7 +1096,9 @@ def mass_emissions_index_imfox(
         fuel_flow_per_engine, afr_cru, t_4_cru, fuel_hydrogen=fuel_hydrogen
     )
     q_exhaust_cru = exhaust_gas_volume_per_kg_fuel(afr_cru)
-    return convert_nvpm_mass_concentration_to_ei(c_bc_cru, q_exhaust_cru)
+    return convert_nvpm_mass_concentration_to_ei(
+        c_bc_cru, q_exhaust_cru
+    ) * 1e-6  # mg-nvPM/kg-fuel to kg-nvPM/kg-fuel
 
 
 def air_to_fuel_ratio_imfox(thrust_setting: npt.NDArray[np.floating]) -> npt.NDArray[np.floating]:

--- a/pycontrails/models/emissions/nvpm.py
+++ b/pycontrails/models/emissions/nvpm.py
@@ -1243,7 +1243,7 @@ def geometric_mean_diameter_sac(
         comp_efficiency=comp_efficiency,
         cruise=cruise,
     )
-    return (2.5883 * t4_t2**2) - (5.3723 * t4_t2) + 16.721 - delta_loss
+    return ((2.5883 * t4_t2**2) - (5.3723 * t4_t2) + 16.721 - delta_loss) * 1e-9  # nm to m
 
 
 def number_emissions_index_fractal_aggregates(

--- a/tests/unit/test_emissions.py
+++ b/tests/unit/test_emissions.py
@@ -239,7 +239,7 @@ def test_fox_fa_model_nvpm_emissions_profile():
         thrust_setting,
         edb_gaseous.pressure_ratio,
     )
-    nvpm_ei_m_fox = np.array([38.03, 128.90, 591.87, 801.00])
+    nvpm_ei_m_fox = np.array([38.03, 128.90, 591.87, 801.00]) * 1e-6  # mg/kg -> kg/kg
     np.testing.assert_allclose(nvpm_ei_m_fox_est, nvpm_ei_m_fox, atol=0.01)
 
     nvpm_gmd_fa_est = nvpm.geometric_mean_diameter_sac(
@@ -250,13 +250,10 @@ def test_fox_fa_model_nvpm_emissions_profile():
         edb_gaseous.pressure_ratio,
         43.13e6,
     )
-    nvpm_gmd_fa = np.array([12.02, 19.34, 39.54, 45.79])  # nm
+    nvpm_gmd_fa = np.array([12.02, 19.34, 39.54, 45.79]) * 1e-9  # nm -> m
     np.testing.assert_allclose(nvpm_gmd_fa_est, nvpm_gmd_fa_est, atol=0.01)
 
-    nvpm_ei_n_fa_est = nvpm.number_emissions_index_fractal_aggregates(
-        nvpm_ei_m_fox * 1e-6,
-        nvpm_gmd_fa * 1e-9,
-    )
+    nvpm_ei_n_fa_est = nvpm.number_emissions_index_fractal_aggregates(nvpm_ei_m_fox, nvpm_gmd_fa)
     nvpm_ei_n_fa = np.array([5.66, 4.94, 2.95, 2.62]) * 1e15
     np.testing.assert_allclose(nvpm_ei_n_fa_est, nvpm_ei_n_fa, atol=0.01e15)
 
@@ -280,41 +277,32 @@ def test_emissions_index_ffm2():
     edb_gaseous = emissions.edb_engine_gaseous[engine_uid]
 
     # Nitrogen oxide
-    nox_ei = (
-        gaseous.estimate_nox_ffm2(
-            edb_gaseous.log_ei_nox_profile,
-            fuel_flow_per_engine_cruise,
-            true_airspeed,
-            air_pressure,
-            air_temperature,
-        )
-        * 1e-3
+    nox_ei = gaseous.estimate_nox_ffm2(
+        edb_gaseous.log_ei_nox_profile,
+        fuel_flow_per_engine_cruise,
+        true_airspeed,
+        air_pressure,
+        air_temperature,
     )
     np.testing.assert_almost_equal(nox_ei, np.array([0.019298]), decimal=6)
 
     # Carbon monoxide (descent conditions with very low power)
-    co_ei = (
-        gaseous.estimate_ei_co_hc_ffm2(
-            edb_gaseous.log_ei_co_profile,
-            fuel_flow_per_engine_descent,
-            true_airspeed,
-            air_pressure,
-            air_temperature,
-        )
-        * 1e-3
+    co_ei = gaseous.estimate_ei_co_hc_ffm2(
+        edb_gaseous.log_ei_co_profile,
+        fuel_flow_per_engine_descent,
+        true_airspeed,
+        air_pressure,
+        air_temperature,
     )
     np.testing.assert_almost_equal(co_ei, np.array([0.028461]), decimal=6)
 
     # Hydrocarbons (descent conditions with very low power)
-    hc_ei = (
-        gaseous.estimate_ei_co_hc_ffm2(
-            edb_gaseous.log_ei_hc_profile,
-            fuel_flow_per_engine_descent,
-            true_airspeed,
-            air_pressure,
-            air_temperature,
-        )
-        * 1e-3
+    hc_ei = gaseous.estimate_ei_co_hc_ffm2(
+        edb_gaseous.log_ei_hc_profile,
+        fuel_flow_per_engine_descent,
+        true_airspeed,
+        air_pressure,
+        air_temperature,
     )
     np.testing.assert_almost_equal(hc_ei, np.array([0.000077817]), decimal=6)
 
@@ -333,15 +321,12 @@ def test_E45x_hydrocarbon_emissions_index() -> None:
     edb_gaseous = emissions.edb_engine_gaseous[engine_uid]
 
     # Hydrocarbons (descent conditions with very low power)
-    hc_ei = (
-        gaseous.estimate_ei_co_hc_ffm2(
-            edb_gaseous.log_ei_hc_profile,
-            fuel_flow_per_engine_descent,
-            true_airspeed,
-            air_pressure,
-            air_temperature,
-        )
-        * 1e-3
+    hc_ei = gaseous.estimate_ei_co_hc_ffm2(
+        edb_gaseous.log_ei_hc_profile,
+        fuel_flow_per_engine_descent,
+        true_airspeed,
+        air_pressure,
+        air_temperature,
     )
     np.testing.assert_almost_equal(hc_ei, np.array([0.0097947]), decimal=6)
 

--- a/tests/unit/test_emissions.py
+++ b/tests/unit/test_emissions.py
@@ -240,7 +240,7 @@ def test_fox_fa_model_nvpm_emissions_profile():
         edb_gaseous.pressure_ratio,
     )
     nvpm_ei_m_fox = np.array([38.03, 128.90, 591.87, 801.00]) * 1e-6  # mg/kg -> kg/kg
-    np.testing.assert_allclose(nvpm_ei_m_fox_est, nvpm_ei_m_fox, atol=0.01)
+    np.testing.assert_allclose(nvpm_ei_m_fox_est, nvpm_ei_m_fox, atol=0.01e-6)
 
     nvpm_gmd_fa_est = nvpm.geometric_mean_diameter_sac(
         average_pressure,
@@ -251,7 +251,7 @@ def test_fox_fa_model_nvpm_emissions_profile():
         43.13e6,
     )
     nvpm_gmd_fa = np.array([12.02, 19.34, 39.54, 45.79]) * 1e-9  # nm -> m
-    np.testing.assert_allclose(nvpm_gmd_fa_est, nvpm_gmd_fa_est, atol=0.01)
+    np.testing.assert_allclose(nvpm_gmd_fa_est, nvpm_gmd_fa, atol=0.01e-9)
 
     nvpm_ei_n_fa_est = nvpm.number_emissions_index_fractal_aggregates(nvpm_ei_m_fox, nvpm_gmd_fa)
     nvpm_ei_n_fa = np.array([5.66, 4.94, 2.95, 2.62]) * 1e15


### PR DESCRIPTION
Closes #XX

## Changes

- Fix unit conversion bug identified in `nvpm_ei_m` estimates when SCOPE11 is used. This does not affect the downstream simulated contrail properties and climate forcing. 
- Refactor functions so that SI units are used for computations. This ensures consistency and prevents future unit conversion bugs. 

#### Breaking changes

#### Features

#### Fixes

#### Internals

## Tests

- [ ] QC test passes locally (`make test`)
- [ ] CI tests pass

## Reviewer

> Select @ reviewer
