### PR TITLE
Extend `parse_ofp_xml` with M633timestamp, category, flightPlanId

### DIFF
--- a/pycontrails/core/flightplan.py
+++ b/pycontrails/core/flightplan.py
@@ -281,6 +281,15 @@ def parse_ofp_xml(raw_xml: AnyStr | IO[AnyStr]) -> flight.Flight:
     if val := root.findtext(".//{*}ArrivalAirport/{*}AirportICAOCode"):
         attrs["arrival_airport"] = val
 
+    if val := root.get("flightPlanId"):
+        attrs["flight_plan_id"] = val
+    if val := root.get("category"):
+        attrs["category"] = val
+
+    m633_header = root.find(".//{*}M633Header")
+    if m633_header is not None and (val := m633_header.get("timestamp")):
+        attrs["m633_timestamp"] = val
+
     aircraft_el = root.find(".//{*}Aircraft")
     if aircraft_el is not None and (val := aircraft_el.get("aircraftRegistration")):
         attrs["tail_number"] = val

--- a/pycontrails/core/flightplan.py
+++ b/pycontrails/core/flightplan.py
@@ -284,11 +284,11 @@ def parse_ofp_xml(raw_xml: AnyStr | IO[AnyStr]) -> flight.Flight:
     if val := root.get("flightPlanId"):
         attrs["flight_plan_id"] = val
     if val := root.get("category"):
-        attrs["category"] = val
+        attrs["flight_plan_category"] = val
 
     m633_header = root.find(".//{*}M633Header")
     if m633_header is not None and (val := m633_header.get("timestamp")):
-        attrs["m633_timestamp"] = pd.to_datetime(val, utc=True)
+        attrs["flight_plan_header_timestamp"] = pd.to_datetime(val, utc=True)
 
     aircraft_el = root.find(".//{*}Aircraft")
     if aircraft_el is not None and (val := aircraft_el.get("aircraftRegistration")):

--- a/pycontrails/core/flightplan.py
+++ b/pycontrails/core/flightplan.py
@@ -288,7 +288,7 @@ def parse_ofp_xml(raw_xml: AnyStr | IO[AnyStr]) -> flight.Flight:
 
     m633_header = root.find(".//{*}M633Header")
     if m633_header is not None and (val := m633_header.get("timestamp")):
-        attrs["flight_plan_header_timestamp"] = pd.to_datetime(val, utc=True)
+        attrs["flight_plan_timestamp"] = pd.to_datetime(val, utc=True)
 
     aircraft_el = root.find(".//{*}Aircraft")
     if aircraft_el is not None and (val := aircraft_el.get("aircraftRegistration")):

--- a/pycontrails/core/flightplan.py
+++ b/pycontrails/core/flightplan.py
@@ -268,7 +268,7 @@ def parse_ofp_xml(raw_xml: AnyStr | IO[AnyStr]) -> flight.Flight:
     if df.empty:
         raise ValueError("No waypoints found in ARINC 633 XML.")
 
-    attrs: dict[str, str] = {}
+    attrs: dict[str, Any] = {}
 
     if val := root.findtext(".//{*}FlightKeyIdentifier"):
         attrs["flight_id"] = val
@@ -288,7 +288,7 @@ def parse_ofp_xml(raw_xml: AnyStr | IO[AnyStr]) -> flight.Flight:
 
     m633_header = root.find(".//{*}M633Header")
     if m633_header is not None and (val := m633_header.get("timestamp")):
-        attrs["m633_timestamp"] = val
+        attrs["m633_timestamp"] = pd.to_datetime(val, utc=True)
 
     aircraft_el = root.find(".//{*}Aircraft")
     if aircraft_el is not None and (val := aircraft_el.get("aircraftRegistration")):

--- a/tests/unit/test_flightplan.py
+++ b/tests/unit/test_flightplan.py
@@ -149,7 +149,7 @@ def test_ofp_xml_parser() -> None:
     assert flight.attrs["flight_number"] == "ZZ1234"
     assert flight.attrs["flight_plan_id"] == "OFP9"
     assert flight.attrs["category"] == "normal"
-    assert flight.attrs["m633_timestamp"] == "2026-03-23T12:01:00Z"
+    assert flight.attrs["m633_timestamp"] == pd.Timestamp("2026-03-23T12:01:00Z")
     assert flight["waypoint_name"].tolist() == ["AAAA", "BBBB"]
     assert flight["latitude"].tolist() == [0.0, 90.0]
     assert flight["longitude"].tolist() == [1.0, -180.0]

--- a/tests/unit/test_flightplan.py
+++ b/tests/unit/test_flightplan.py
@@ -148,8 +148,8 @@ def test_ofp_xml_parser() -> None:
 
     assert flight.attrs["flight_number"] == "ZZ1234"
     assert flight.attrs["flight_plan_id"] == "OFP9"
-    assert flight.attrs["category"] == "normal"
-    assert flight.attrs["m633_timestamp"] == pd.Timestamp("2026-03-23T12:01:00Z")
+    assert flight.attrs["flight_plan_category"] == "normal"
+    assert flight.attrs["flight_plan_header_timestamp"] == pd.Timestamp("2026-03-23T12:01:00Z")
     assert flight["waypoint_name"].tolist() == ["AAAA", "BBBB"]
     assert flight["latitude"].tolist() == [0.0, 90.0]
     assert flight["longitude"].tolist() == [1.0, -180.0]

--- a/tests/unit/test_flightplan.py
+++ b/tests/unit/test_flightplan.py
@@ -149,7 +149,7 @@ def test_ofp_xml_parser() -> None:
     assert flight.attrs["flight_number"] == "ZZ1234"
     assert flight.attrs["flight_plan_id"] == "OFP9"
     assert flight.attrs["flight_plan_category"] == "normal"
-    assert flight.attrs["flight_plan_header_timestamp"] == pd.Timestamp("2026-03-23T12:01:00Z")
+    assert flight.attrs["flight_plan_timestamp"] == pd.Timestamp("2026-03-23T12:01:00Z")
     assert flight["waypoint_name"].tolist() == ["AAAA", "BBBB"]
     assert flight["latitude"].tolist() == [0.0, 90.0]
     assert flight["longitude"].tolist() == [1.0, -180.0]

--- a/tests/unit/test_flightplan.py
+++ b/tests/unit/test_flightplan.py
@@ -98,10 +98,11 @@ def test_flightplan_two() -> None:
 
 def test_ofp_xml_parser() -> None:
     xml = """<?xml version="1.0" encoding="UTF-8"?>
-        <FlightPlan computedTime="2026-03-23T12:00:00Z"
+        <FlightPlan flightPlanId="OFP9" category="normal" computedTime="2026-03-23T12:00:00Z"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://aeec.aviation-ia.net/633 FlightPlan.xsd"
             xmlns="http://aeec.aviation-ia.net/633">
+        <M633Header timestamp="2026-03-23T12:01:00Z" versionNumber="3"/>
         <M633SupplementaryHeader>
             <Flight scheduledTimeOfDeparture="2026-03-23T14:00:00Z">
                 <FlightIdentification>
@@ -146,6 +147,9 @@ def test_ofp_xml_parser() -> None:
     assert len(flight) == 2
 
     assert flight.attrs["flight_number"] == "ZZ1234"
+    assert flight.attrs["flight_plan_id"] == "OFP9"
+    assert flight.attrs["category"] == "normal"
+    assert flight.attrs["m633_timestamp"] == "2026-03-23T12:01:00Z"
     assert flight["waypoint_name"].tolist() == ["AAAA", "BBBB"]
     assert flight["latitude"].tolist() == [0.0, 90.0]
     assert flight["longitude"].tolist() == [1.0, -180.0]


### PR DESCRIPTION
## Changes

#### Breaking changes

#### Features

> Extend OFP XML flight plan parser by exposing `M633timestamp`, `category` and `flightPlanId` 

#### Fixes

#### Internals

## Tests

- [X] QC test passes locally (`make test`)
- [ ] CI tests pass

## Reviewer

> @zebengberg 
