### PR TITLE
Feature/pseudo waypoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Extend the OFP XML flight plan parser `flightplan.parse_ofp_xml` by exposing M633 `flight_plan_timestamp`, `flight_plan_category`, and `flight_plan_id` fields.
+- Add new `Flight.add_pseudo_waypoints` method. This can be used to ensure `Flight`s arising from flight plans have realistic segment ROCDs.
 
 ## 0.63.3
 

--- a/pycontrails/core/fleet.py
+++ b/pycontrails/core/fleet.py
@@ -365,9 +365,9 @@ class Fleet(Flight):
     def add_pseudo_waypoints(
         self,
         resolution: str | pd.Timedelta = "1min",
-        minimum_rocd: float = 500,
-        nominal_rocd: float = 2000,
-    ) -> Self:
+        minimum_rocd: float = 500.0,
+        nominal_rocd: float = 2000.0,
+    ) -> NoReturn:
         msg = "Only implemented for Flight instances"
         raise NotImplementedError(msg)
 

--- a/pycontrails/core/fleet.py
+++ b/pycontrails/core/fleet.py
@@ -362,6 +362,16 @@ class Fleet(Flight):
         return type(self).from_seq(flights, broadcast_numeric=False, attrs=self.attrs)
 
     @override
+    def add_pseudo_waypoints(
+        self,
+        resolution: str | pd.Timedelta = "1min",
+        minimum_rocd: float = 500,
+        nominal_rocd: float = 2000,
+    ) -> Self:
+        msg = "Only implemented for Flight instances"
+        raise NotImplementedError(msg)
+
+    @override
     def segment_length(self) -> npt.NDArray[np.floating]:
         return np.where(self.final_waypoints, np.nan, super().segment_length())
 

--- a/pycontrails/core/flight.py
+++ b/pycontrails/core/flight.py
@@ -1029,6 +1029,9 @@ class Flight(GeoVectorDataset):
         filt = (abs_rocd > 0.0) & (abs_rocd < minimum_rocd)  # both climbs and descents
 
         idx = np.flatnonzero(filt)
+        if idx.size == 0:  # early exit (this could be omitted)
+            return self.copy()
+
         d_alt_ft = alt_ft[idx + 1] - alt_ft[idx]
         d_t = np.abs(d_alt_ft) / nominal_rocd * 60.0  # minute -> second
         t_exact = time_s[idx + 1] - d_t
@@ -1044,9 +1047,9 @@ class Flight(GeoVectorDataset):
         lon = (np.interp(t, time_s, lon_unwrapped) + 180.0) % 360.0 - 180.0
         lat = np.interp(t, time_s, self["latitude"])
 
-        data = {}
+        data: dict[str, np.ndarray] = {}
         if "waypoint_name" in self:
-            data["waypoint_name"] = ["PS"] * len(idx)  # name the pseudo waypoints "PS"
+            data["waypoint_name"] = np.array(["PS"] * len(idx))  # name the pseudo waypoints "PS"
 
         for vert_key in self.vertical_keys:
             if vert_key in self:

--- a/pycontrails/core/flight.py
+++ b/pycontrails/core/flight.py
@@ -966,6 +966,102 @@ class Flight(GeoVectorDataset):
         data = {k: v.to_numpy() for k, v in df.items()}
         return type(self)._from_fastpath(data, attrs=self.attrs, fuel=self.fuel)
 
+    def add_pseudo_waypoints(
+        self,
+        resolution: str | pd.Timedelta = "1min",
+        minimum_rocd: float = 500.0,
+        nominal_rocd: float = 2000.0,
+    ) -> Self:
+        """Add pseudo waypoints as necessary at the start of each step climb or descent.
+
+        .. versionadded:: 0.63.4
+
+        Flight plans encode a step climb (or descent) as a pair of cruise waypoints at different
+        altitudes. Linearly interpolating altitude between them implies an unrealistic shallow
+        climb that ATC would not clear. Any segment whose ROCD is nonzero but below the
+        ``minimum_rocd`` is treated as such a step. For these segments, a pseudo waypoint is
+        inserted where the step climb actually begins. In this way, the segment becomes a level
+        flight followed by a step climb at ``nominal_rocd``.
+        ::
+
+            original                        with pseudo waypoint PS
+
+            FL360                  B        FL360                  B
+                               ,-'                                /
+                           ,-'                                   /
+            FL340   A  ,-'                  FL340   A -------- PS
+
+
+        The pseudo waypoint lands on the last multiple of ``resolution`` at or before the
+        exact step start. Rounding down lengthens the step duration, which keeps the resulting ROCD
+        at or below ``nominal_rocd``. For a step shorter than ``resolution``, snapping would
+        push the ROCD back below ``minimum_rocd``, and the exact time is kept instead.
+
+        Parameters
+        ----------
+        resolution : str | pd.Timedelta, optional
+            Frequency onto which pseudo waypoint times are snapped, by default "1min".
+            Use "1s" for the exact time.
+        minimum_rocd : float, optional
+            ROCD below which an altitude change is treated as a step climb, by default 500.0,
+            [:math:`ft min^{-1}`].
+        nominal_rocd : float, optional
+            ROCD at which the step climb or descent is flown, by default 2000.0,
+            [:math:`ft min^{-1}`].
+
+        Returns
+        -------
+        Self
+            Copy of the flight with pseudo waypoints inserted. Pseudo waypoints are named
+            "PS" if the flight has a ``waypoint_name`` key.
+        """
+        if nominal_rocd < minimum_rocd:
+            raise ValueError("The nominal ROCD must exceed the minimum ROCD")
+
+        res_s = pd.Timedelta(resolution) // pd.Timedelta("1s")
+        if res_s <= 0:
+            raise ValueError("The resolution must be at least one second")
+
+        abs_rocd = np.abs(self.segment_rocd())
+        alt_ft = self.altitude_ft
+        time_s = self["time"].astype("datetime64[s]").astype(float)  # truncate to second, floatize
+
+        filt = (abs_rocd > 0.0) & (abs_rocd < minimum_rocd)  # both climbs and descents
+
+        idx = np.flatnonzero(filt)
+        d_alt_ft = alt_ft[idx + 1] - alt_ft[idx]
+        d_t = np.abs(d_alt_ft) / nominal_rocd * 60.0  # minute -> second
+        t_exact = time_s[idx + 1] - d_t
+
+        t_snap = np.floor(t_exact / res_s) * res_s
+
+        # Snapping down can drag the ROCD back below minimum_rocd, keep the exact time in that case
+        t = np.where(t_snap <= time_s[idx + 1] - d_t * nominal_rocd / minimum_rocd, t_exact, t_snap)
+
+        # Could interpolate on the geodesic with pyproj if needed. For now, use a straight
+        # line in the Plate Carree space (same as resample_and_fill for short segments).
+        lon_unwrapped = np.unwrap(self["longitude"], period=360.0)
+        lon = (np.interp(t, time_s, lon_unwrapped) + 180.0) % 360.0 - 180.0
+        lat = np.interp(t, time_s, self["latitude"])
+
+        data = {}
+        if "waypoint_name" in self:
+            data["waypoint_name"] = ["PS"] * len(idx)  # name the pseudo waypoints "PS"
+
+        for vert_key in self.vertical_keys:
+            if vert_key in self:
+                data[vert_key] = self[vert_key][idx]
+
+        ps = Flight(
+            longitude=lon,
+            latitude=lat,
+            time=t.astype("datetime64[s]").astype("datetime64[ns]"),
+            data=data,
+        )
+
+        gvd = GeoVectorDataset.sum([self, ps], infer_attrs=False, fill_value=np.nan).sort("time")
+        return type(self)._from_fastpath(gvd.data, attrs=self.attrs, fuel=self.fuel)
+
     def clean_and_resample(
         self,
         freq: str = "1min",

--- a/tests/unit/test_flight.py
+++ b/tests/unit/test_flight.py
@@ -1554,3 +1554,66 @@ class TestCargoLoadFactorEstimates:
             origin_airport_icao, destination_airport_icao, total_flight_dist, pax_ac
         )
         assert lf == pytest.approx(0.664, abs=1e-3)
+
+
+@pytest.mark.parametrize("sign", [1.0, -1.0])
+def test_step_is_flown_at_nominal_rocd(sign: float) -> None:
+    """Confirm a shallow 2000 ft step becomes level flight followed by a nominal-rate step."""
+    minimum_rocd = 500.0
+    nominal_rocd = 2000.0
+
+    fl = Flight(
+        {
+            "waypoint_name": ["A", "B", "C"],
+            "longitude": [0.0, 1.0, 2.0],
+            "latitude": [40.0, 40.0, 40.0],
+            "altitude_ft": 37000.0 + sign * np.array([0.0, 2000.0, 2000.0]),
+            "time": np.datetime64("2025-01-01T00:00:00")
+            + np.array([0, 3600, 7200]).astype("timedelta64[s]"),
+        }
+    )
+    assert np.abs(fl.segment_rocd()[0]) < minimum_rocd
+    out = fl.add_pseudo_waypoints(minimum_rocd=minimum_rocd, nominal_rocd=nominal_rocd)
+
+    assert out.size == fl.size + 1  # a single waypoint added
+    assert np.sum(out["waypoint_name"] == "PS") == 1
+
+    # Level flight, then the step at the nominal rate, then level again
+    np.testing.assert_allclose(out.segment_rocd()[:-1], [0.0, sign * nominal_rocd, 0.0])
+    np.testing.assert_allclose(out.altitude_ft[1], fl.altitude_ft[0])
+    assert out["time"][1] == np.datetime64("2025-01-01T00:59:00")
+
+
+@pytest.mark.parametrize("resolution", ["1s", "1min", "2min", "10min"])
+def test_no_segment_left_below_minimum_rocd(resolution: str) -> None:
+    """Confirm every remaining altitude change is flown between the minimum and nominal rates."""
+    minimum_rocd = 500.0
+    nominal_rocd = 2000.0
+
+    # Includes a slow step climb (73 ft/min) and a slow step descent (-100 ft/min)
+    fl = Flight(
+        {
+            "waypoint_name": ["A", "B", "C", "D", "E", "F"],
+            "longitude": np.linspace(-60.0, -10.0, 6),
+            "latitude": np.linspace(41.0, 46.0, 6),
+            "altitude_ft": np.array([37000.0, 37000.0, 41000.0, 41000.0, 37000.0, 37000.0]),
+            "time": np.datetime64("2025-01-01T00:00:00")
+            + np.array([0, 1200, 4500, 7000, 9400, 12000]).astype("timedelta64[s]"),
+        }
+    )
+    rocd_in = np.abs(fl.segment_rocd()[:-1])
+    assert np.sum((rocd_in > 0.0) & (rocd_in < minimum_rocd)) == 2  # 2 waypoints should be added
+
+    out = fl.add_pseudo_waypoints(
+        resolution=resolution,
+        minimum_rocd=minimum_rocd,
+        nominal_rocd=nominal_rocd,
+    )
+    rocd = np.abs(out.segment_rocd())
+
+    assert np.all(rocd[rocd > 0.0] >= minimum_rocd)
+
+    step = np.flatnonzero(out["waypoint_name"] == "PS")
+    assert step.size == 2
+    assert np.all(rocd[step] <= nominal_rocd + 1e-6)
+    assert np.all(np.diff(out["time"]) > np.timedelta64(0, "s"))


### PR DESCRIPTION
## Changes

Add new `Flight.add_pseudo_waypoints` method. This can be used to ensure `Flight`s arising from flight plans have realistic segment ROCDs.

## Tests

- [x] QC test passes locally (`make test`)
- [x] CI tests pass

